### PR TITLE
Add teams dataset pipeline

### DIFF
--- a/dataflow/meta/dataset_pipelines.py
+++ b/dataflow/meta/dataset_pipelines.py
@@ -1078,3 +1078,46 @@ class AdvisersDatasetPipeline:
             'boolean',
         ),
     ]
+
+
+class TeamsDatasetPipeline:
+    """Pipeline meta object for TeamsDataset."""
+
+    table_name = 'teams'
+    source_url = '{0}/v4/dataset/teams-dataset'.format(constants.DATAHUB_BASE_URL)
+    target_db = 'datasets_db'
+    start_date = datetime.now().replace(day=1)
+    end_date = None
+    schedule_interval = '@daily'
+    field_mapping = [
+        (
+            'id',
+            'id',
+            'uuid',
+
+        ),
+        (
+            'name',
+            'name',
+            'character varying(255)',
+
+        ),
+        (
+            'role__name',
+            'role',
+            'character varying(255)',
+
+        ),
+        (
+            'uk_region__name',
+            'uk_region',
+            'character varying(255)',
+
+        ),
+        (
+            'country__name',
+            'country',
+            'character varying(255)',
+
+        ),
+    ]


### PR DESCRIPTION
Used to import teams data from datahub. One thing to note is that
currently datahub endpoint is only ordered by ID (which is a UUID),
so it's possible that pagination will break (by including an item
more than once) if a new team is created during the import. Teams
don't have a creation date column, so there's no other way to order
them at the moment, but the table shouldn't change too often.