### PR TITLE
Add static code analysis checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Install requirements
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements-dev.txt
+      - run:
+          name: Run static checks
+          command: |
+            . venv/bin/activate
+            make check

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: check
 check:
 	flake8 .
-	black --skip-string-normalization --check .
+	black --exclude=venv --skip-string-normalization --check .
 	mypy .
 
 .PHONY: format
 format:
-	black --skip-string-normalization .
+	black --exclude=venv --skip-string-normalization .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: check
+check:
+	flake8 .
+	black --skip-string-normalization --check .
+	mypy .
+
+.PHONY: format
+format:
+	black --skip-string-normalization .

--- a/dataflow/dags/view_pipelines.py
+++ b/dataflow/dags/view_pipelines.py
@@ -7,10 +7,15 @@ from airflow.operators.postgres_operator import PostgresOperator
 
 from dataflow import constants
 from dataflow.meta import view_pipelines
-from dataflow.utils import XCOMIntegratedPostgresOperator, get_defined_pipeline_classes_by_key
+from dataflow.utils import (
+    XCOMIntegratedPostgresOperator,
+    get_defined_pipeline_classes_by_key,
+)
 
 
-view_pipeline_classes = get_defined_pipeline_classes_by_key(view_pipelines, 'ViewPipeline')
+view_pipeline_classes = get_defined_pipeline_classes_by_key(
+    view_pipelines, 'ViewPipeline'
+)
 
 
 default_args = {

--- a/dataflow/meta/dataset_pipelines.py
+++ b/dataflow/meta/dataset_pipelines.py
@@ -15,96 +15,24 @@ class OMISDatasetPipeline:
     end_date = None
     schedule_interval = '@monthly'
     field_mapping = [
-        (
-            'cancellation_reason__name',
-            'cancellation_reason',
-            'text',
-        ),
-        (
-            'cancelled_on',
-            'cancelled_date',
-            'timestamp with time zone',
-        ),
-        (
-            'company_id',
-            'company_id',
-            'uuid'
-        ),
-        (
-            'completed_on',
-            'completion_date',
-            'timestamp with time zone',
-        ),
-        (
-            'contact_id',
-            'contact_id',
-            'uuid'
-        ),
-        (
-            'created_by__dit_team_id',
-            'dit_team_id',
-            'uuid',
-        ),
-        (
-            'created_on',
-            'created_date',
-            'timestamp with time zone',
-        ),
-        (
-            'delivery_date',
-            'delivery_date',
-            'date',
-        ),
-        (
-            'id',
-            'id',
-            'uuid primary key'
-        ),
-        (
-            'invoice__subtotal_cost',
-            'subtotal',
-            'integer',
-        ),
-        (
-            'paid_on',
-            'payment_received_date',
-            'timestamp with time zone',
-        ),
-        (
-            'primary_market__name',
-            'market',
-            'text',
-        ),
-        (
-            'reference',
-            'omis_order_reference',
-            'character varying(100)',
-        ),
-        (
-            'sector_name',
-            'sector',
-            'character varying(255)',
-        ),
-        (
-            'services',
-            'services',
-            'text',
-        ),
-        (
-            'status',
-            'order_status',
-            'character varying(100)',
-        ),
-        (
-            'subtotal_cost',
-            'net_price',
-            'integer',
-        ),
-        (
-            'uk_region__name',
-            'uk_region',
-            'text',
-        ),
+        ('cancellation_reason__name', 'cancellation_reason', 'text'),
+        ('cancelled_on', 'cancelled_date', 'timestamp with time zone'),
+        ('company_id', 'company_id', 'uuid'),
+        ('completed_on', 'completion_date', 'timestamp with time zone'),
+        ('contact_id', 'contact_id', 'uuid'),
+        ('created_by__dit_team_id', 'dit_team_id', 'uuid'),
+        ('created_on', 'created_date', 'timestamp with time zone'),
+        ('delivery_date', 'delivery_date', 'date'),
+        ('id', 'id', 'uuid primary key'),
+        ('invoice__subtotal_cost', 'subtotal', 'integer'),
+        ('paid_on', 'payment_received_date', 'timestamp with time zone'),
+        ('primary_market__name', 'market', 'text'),
+        ('reference', 'omis_order_reference', 'character varying(100)'),
+        ('sector_name', 'sector', 'character varying(255)'),
+        ('services', 'services', 'text'),
+        ('status', 'order_status', 'character varying(100)'),
+        ('subtotal_cost', 'net_price', 'integer'),
+        ('uk_region__name', 'uk_region', 'text'),
     ]
 
 
@@ -112,227 +40,65 @@ class InvestmentProjectsDatasetPipeline:
     """Pipeline meta object for InvestmentProjectsDataset."""
 
     table_name = 'investment_projects_dataset'
-    source_url = '{0}/v4/dataset/investment-projects-dataset'.format(constants.DATAHUB_BASE_URL)
+    source_url = '{0}/v4/dataset/investment-projects-dataset'.format(
+        constants.DATAHUB_BASE_URL
+    )
     target_db = 'datasets_db'
     start_date = datetime.now().replace(day=1)
     end_date = None
     schedule_interval = '@daily'
     field_mapping = [
-        (
-            'actual_land_date',
-            'actual_land_date',
-            'date',
-        ),
-        (
-            'actual_uk_region_names',
-            'actual_uk_regions',
-            'text',
-        ),
-        (
-            'allow_blank_possible_uk_regions',
-            'possible_uk_regions',
-            'boolean',
-        ),
-        (
-            'anonymous_description',
-            'anonymous_description',
-            'text',
-        ),
+        ('actual_land_date', 'actual_land_date', 'date'),
+        ('actual_uk_region_names', 'actual_uk_regions', 'text'),
+        ('allow_blank_possible_uk_regions', 'possible_uk_regions', 'boolean'),
+        ('anonymous_description', 'anonymous_description', 'text'),
         (
             'associated_non_fdi_r_and_d_project__id',
             'associated_non_fdi_r_and_d_project_id',
             'character varying(100)',
         ),
-        (
-            'average_salary__name',
-            'average_salary',
-            'text',
-        ),
-        (
-            'business_activity_names',
-            'business_activities',
-            'text',
-        ),
-        (
-            'client_relationship_manager_id',
-            'client_relationship_manager_id',
-            'uuid',
-        ),
-        (
-            'clint_requirements',
-            'client_requirements',
-            'text',
-        ),
-        (
-            'competing_countries',
-            'competing_countries',
-            'text',
-        ),
-        (
-            'created_by_id',
-            'created_by_id',
-            'uuid',
-        ),
-        (
-            'created_on',
-            'created_on',
-            'timestamp with time zone',
-        ),
-        (
-            'delivery_partner_names',
-            'delivery_partners',
-            'text',
-        ),
-        (
-            'description',
-            'description',
-            'text',
-        ),
-        (
-            'estimated_land_date',
-            'estimated_land_date',
-            'date',
-        ),
-        (
-            'export_revenue',
-            'export_revenue',
-            'boolean',
-        ),
-        (
-            'fdi_type__name',
-            'fdi_type',
-            'text',
-        ),
-        (
-            'fdi_value__name',
-            'fdi_value',
-            'text',
-        ),
-        (
-            'foreign_equity_investment',
-            'foreign_equity_investment',
-            'decimal',
-        ),
-        (
-            'government_assistance',
-            'government_assistance',
-            'boolean',
-        ),
-        (
-            'gross_value_added',
-            'gross_value_added',
-            'decimal',
-        ),
-        (
-            'gva_multiplier__multiplier',
-            'gva_multiplier',
-            'decimal',
-        ),
-        (
-            'id',
-            'id',
-            'uuid primary key',
-        ),
-        (
-            'investment_type__name',
-            'investment_type',
-            'text',
-        ),
-        (
-            'investor_company_id',
-            'investor_company_id',
-            'uuid',
-        ),
+        ('average_salary__name', 'average_salary', 'text'),
+        ('business_activity_names', 'business_activities', 'text'),
+        ('client_relationship_manager_id', 'client_relationship_manager_id', 'uuid'),
+        ('clint_requirements', 'client_requirements', 'text'),
+        ('competing_countries', 'competing_countries', 'text'),
+        ('created_by_id', 'created_by_id', 'uuid'),
+        ('created_on', 'created_on', 'timestamp with time zone'),
+        ('delivery_partner_names', 'delivery_partners', 'text'),
+        ('description', 'description', 'text'),
+        ('estimated_land_date', 'estimated_land_date', 'date'),
+        ('export_revenue', 'export_revenue', 'boolean'),
+        ('fdi_type__name', 'fdi_type', 'text'),
+        ('fdi_value__name', 'fdi_value', 'text'),
+        ('foreign_equity_investment', 'foreign_equity_investment', 'decimal'),
+        ('government_assistance', 'government_assistance', 'boolean'),
+        ('gross_value_added', 'gross_value_added', 'decimal'),
+        ('gva_multiplier__multiplier', 'gva_multiplier', 'decimal'),
+        ('id', 'id', 'uuid primary key'),
+        ('investment_type__name', 'investment_type', 'text'),
+        ('investor_company_id', 'investor_company_id', 'uuid'),
         (
             'investor_company_sector',
             'investor_company_sector',
             'character varying(255)',
         ),
-        (
-            'investor_type__name',
-            'investor_type',
-            'text',
-        ),
-        (
-            'level_of_involvement_name',
-            'level_of_involvement',
-            'text',
-        ),
-        (
-            'likelihood_to_land__name',
-            'likelihood_to_land',
-            'text',
-        ),
-        (
-            'modified_by_id',
-            'modified_by_id',
-            'uuid',
-        ),
-        (
-            'modified_on',
-            'modified_on',
-            'timestamp with time zone',
-        ),
-        (
-            'name',
-            'name',
-            'character varying(255) NOT NULL',
-        ),
-        (
-            'new_tech_to_uk',
-            'new_tech_to_uk',
-            'boolean',
-        ),
-        (
-            'non_fdi_r_and_d_budget',
-            'non_fdi_r_and_d_budget',
-            'boolean',
-        ),
-        (
-            'number_new_jobs',
-            'number_new_jobs',
-            'integer',
-        ),
-        (
-            'number_safeguarded_jobs',
-            'number_safeguarded_jobs',
-            'integer',
-        ),
-        (
-            'project_arrived_in_triage_on',
-            'project_arrived_in_triage_on',
-            'date',
-        ),
-        (
-            'project_assurance_adviser_id',
-            'project_assurance_adviser_id',
-            'uuid',
-        ),
-        (
-            'project_manager_id',
-            'project_manager_id',
-            'uuid',
-        ),
-        (
-            'project_reference',
-            'project_reference',
-            'text',
-        ),
-        (
-            'proposal_deadline',
-            'proposal_deadline',
-            'date',
-        ),
-        (
-            'r_and_d_budget',
-            'r_and_d_budget',
-            'boolean',
-        ),
-        (
-            'referral_source_activity__name',
-            'referral_source_activity',
-            'text',
-        ),
+        ('investor_type__name', 'investor_type', 'text'),
+        ('level_of_involvement_name', 'level_of_involvement', 'text'),
+        ('likelihood_to_land__name', 'likelihood_to_land', 'text'),
+        ('modified_by_id', 'modified_by_id', 'uuid'),
+        ('modified_on', 'modified_on', 'timestamp with time zone'),
+        ('name', 'name', 'character varying(255) NOT NULL'),
+        ('new_tech_to_uk', 'new_tech_to_uk', 'boolean'),
+        ('non_fdi_r_and_d_budget', 'non_fdi_r_and_d_budget', 'boolean'),
+        ('number_new_jobs', 'number_new_jobs', 'integer'),
+        ('number_safeguarded_jobs', 'number_safeguarded_jobs', 'integer'),
+        ('project_arrived_in_triage_on', 'project_arrived_in_triage_on', 'date'),
+        ('project_assurance_adviser_id', 'project_assurance_adviser_id', 'uuid'),
+        ('project_manager_id', 'project_manager_id', 'uuid'),
+        ('project_reference', 'project_reference', 'text'),
+        ('proposal_deadline', 'proposal_deadline', 'date'),
+        ('r_and_d_budget', 'r_and_d_budget', 'boolean'),
+        ('referral_source_activity__name', 'referral_source_activity', 'text'),
         (
             'referral_source_activity_marketing__name',
             'referral_source_activity_marketing',
@@ -343,154 +109,52 @@ class InvestmentProjectsDatasetPipeline:
             'referral_source_activity_website',
             'text',
         ),
-        (
-            'sector_name',
-            'sector',
-            'character varying(255)',
-        ),
-        (
-            'specific_programme__name',
-            'specific_programme',
-            'text',
-        ),
-        (
-            'stage__name',
-            'stage',
-            'text NOT NULL',
-        ),
-        (
-            'status',
-            'status',
-            'character varying(255)',
-        ),
-        (
-            'strategic_driver_names',
-            'strategic_drivers',
-            'text',
-        ),
-        (
-            'team_member_ids',
-            'team_member_ids',
-            'text []',
-        ),
-        (
-            'total_investment',
-            'total_investment',
-            'decimal',
-        ),
-        (
-            'uk_company_id',
-            'uk_company_id',
-            'uuid',
-        ),
-        (
-            'uk_company_sector',
-            'uk_company_sector',
-            'character varying(255)',
-        ),
+        ('sector_name', 'sector', 'character varying(255)'),
+        ('specific_programme__name', 'specific_programme', 'text'),
+        ('stage__name', 'stage', 'text NOT NULL'),
+        ('status', 'status', 'character varying(255)'),
+        ('strategic_driver_names', 'strategic_drivers', 'text'),
+        ('team_member_ids', 'team_member_ids', 'text []'),
+        ('total_investment', 'total_investment', 'decimal'),
+        ('uk_company_id', 'uk_company_id', 'uuid'),
+        ('uk_company_sector', 'uk_company_sector', 'character varying(255)'),
     ]
 
 
 class InteractionsDatasetPipeline:
     table_name = 'interactions_dataset'
-    source_url = '{}/v4/dataset/interactions-dataset'.format(
-        constants.DATAHUB_BASE_URL
-    )
+    source_url = '{}/v4/dataset/interactions-dataset'.format(constants.DATAHUB_BASE_URL)
     target_db = 'datasets_db'
     start_date = datetime.now().replace(day=1)
     end_date = None
     schedule_interval = '@daily'
     field_mapping = [
-        (
-            'adviser_ids',
-            'adviser_ids',
-            'text []'
-        ),
+        ('adviser_ids', 'adviser_ids', 'text []'),
         (
             'communication_channel__name',
             'communication_channel',
-            'character varying(255)'
+            'character varying(255)',
         ),
-        (
-            'company_id',
-            'company_id',
-            'uuid'
-        ),
-        (
-            'contact_ids',
-            'contact_ids',
-            'text []'
-        ),
-        (
-            'created_on',
-            'created_on',
-            'timestamp with time zone'
-        ),
-        (
-            'date',
-            'interaction_date',
-            'date'
-        ),
-        (
-            'event_id',
-            'event_id',
-            'uuid'
-        ),
-        (
-            'grant_amount_offered',
-            'grant_amount_offered',
-            'decimal'
-        ),
-        (
-            'id',
-            'id',
-            'uuid primary key'
-        ),
-        (
-            'interaction_link',
-            'interaction_link',
-            'character varying(255)'
-        ),
-        (
-            'investment_project_id',
-            'investment_project_id',
-            'uuid'
-        ),
-        (
-            'kind',
-            'interaction_kind',
-            'character varying(255)'
-        ),
-        (
-            'net_company_receipt',
-            'net_company_receipt',
-            'decimal'
-        ),
-        (
-            'notes',
-            'interaction_notes',
-            'text'
-        ),
-        (
-            'sector',
-            'sector',
-            'character varying(255)'
-        ),
+        ('company_id', 'company_id', 'uuid'),
+        ('contact_ids', 'contact_ids', 'text []'),
+        ('created_on', 'created_on', 'timestamp with time zone'),
+        ('date', 'interaction_date', 'date'),
+        ('event_id', 'event_id', 'uuid'),
+        ('grant_amount_offered', 'grant_amount_offered', 'decimal'),
+        ('id', 'id', 'uuid primary key'),
+        ('interaction_link', 'interaction_link', 'character varying(255)'),
+        ('investment_project_id', 'investment_project_id', 'uuid'),
+        ('kind', 'interaction_kind', 'character varying(255)'),
+        ('net_company_receipt', 'net_company_receipt', 'decimal'),
+        ('notes', 'interaction_notes', 'text'),
+        ('sector', 'sector', 'character varying(255)'),
         (
             'service_delivery_status__name',
             'service_delivery_status',
-            'character varying(255)'
+            'character varying(255)',
         ),
-        (
-            'service_delivery',
-            'service_delivery',
-            'character varying(255)'
-        ),
-        (
-            'subject',
-            'interaction_subject',
-            'text'
-        ),
+        ('service_delivery', 'service_delivery', 'character varying(255)'),
+        ('subject', 'interaction_subject', 'text'),
     ]
 
 
@@ -504,71 +168,19 @@ class ContactsDatasetPipeline:
     end_date = None
     schedule_interval = '@monthly'
     field_mapping = [
-        (
-            'accepts_dit_email_marketing',
-            'accepts_dit_email_marketing',
-            'boolean',
-        ),
-        (
-            'address_country__name',
-            'address_country',
-            'text',
-        ),
-        (
-            'address_postcode',
-            'address_postcode',
-            'character varying(255)',
-        ),
-        (
-            'company_id',
-            'company_id',
-            'uuid',
-        ),
-        (
-            'created_on',
-            'date_added_to_datahub',
-            'date',
-        ),
-        (
-            'email',
-            'email',
-            'character varying(255)',
-        ),
-        (
-            'email_alternative',
-            'email_alternative',
-            'character varying(255)',
-        ),
-        (
-            'id',
-            'id',
-            'uuid primary key',
-        ),
-        (
-            'job_title',
-            'job_title',
-            'character varying(255)',
-        ),
-        (
-            'name',
-            'contact_name',
-            'text',
-        ),
-        (
-            'notes',
-            'notes',
-            'text',
-        ),
-        (
-            'telephone_alternative',
-            'telephone_alternative',
-            'character varying(255)',
-        ),
-        (
-            'telephone_number',
-            'phone',
-            'character varying(255)',
-        ),
+        ('accepts_dit_email_marketing', 'accepts_dit_email_marketing', 'boolean'),
+        ('address_country__name', 'address_country', 'text'),
+        ('address_postcode', 'address_postcode', 'character varying(255)'),
+        ('company_id', 'company_id', 'uuid'),
+        ('created_on', 'date_added_to_datahub', 'date'),
+        ('email', 'email', 'character varying(255)'),
+        ('email_alternative', 'email_alternative', 'character varying(255)'),
+        ('id', 'id', 'uuid primary key'),
+        ('job_title', 'job_title', 'character varying(255)'),
+        ('name', 'contact_name', 'text'),
+        ('notes', 'notes', 'text'),
+        ('telephone_alternative', 'telephone_alternative', 'character varying(255)'),
+        ('telephone_number', 'phone', 'character varying(255)'),
     ]
 
 
@@ -582,111 +194,35 @@ class CompaniesDatasetPipeline:
     end_date = None
     schedule_interval = '@monthly'
     field_mapping = [
-        (
-            'address_1',
-            'address_1',
-            'character varying(255)',
-        ),
-        (
-            'address_2',
-            'address_2',
-            'character varying(255)',
-        ),
-        (
-            'address_county',
-            'address_county',
-            'character varying(255)',
-        ),
-        (
-            'address_country__name',
-            'address_country',
-            'character varying(255)',
-        ),
-        (
-            'address_postcode',
-            'address_postcode',
-            'character varying(255)',
-        ),
-        (
-            'address_town',
-            'address_town',
-            'character varying(255)',
-        ),
-        (
-            'business_type__name',
-            'business_type',
-            'character varying(255)',
-        ),
-        (
-            'company_number',
-            'company_number',
-            'character varying(255)',
-        ),
-        (
-            'created_on',
-            'created_on',
-            'date',
-        ),
-        (
-            'description',
-            'description',
-            'text',
-        ),
-        (
-            'duns_number',
-            'duns_number',
-            'character varying(9)',
-        ),
+        ('address_1', 'address_1', 'character varying(255)'),
+        ('address_2', 'address_2', 'character varying(255)'),
+        ('address_county', 'address_county', 'character varying(255)'),
+        ('address_country__name', 'address_country', 'character varying(255)'),
+        ('address_postcode', 'address_postcode', 'character varying(255)'),
+        ('address_town', 'address_town', 'character varying(255)'),
+        ('business_type__name', 'business_type', 'character varying(255)'),
+        ('company_number', 'company_number', 'character varying(255)'),
+        ('created_on', 'created_on', 'date'),
+        ('description', 'description', 'text'),
+        ('duns_number', 'duns_number', 'character varying(9)'),
         (
             'export_experience_category__name',
             'export_experience',
             'character varying(255)',
         ),
-        (
-            'id',
-            'id',
-            'uuid primary key',
-        ),
+        ('id', 'id', 'uuid primary key'),
         (
             'is_number_of_employees_estimated',
             'is_number_of_employees_estimated',
             'boolean',
         ),
-        (
-            'is_turnover_estimated',
-            'is_turnover_estimated',
-            'boolean',
-        ),
-        (
-            'name',
-            'name',
-            'character varying(255)',
-        ),
-        (
-            'number_of_employees',
-            'number_of_employees',
-            'integer',
-        ),
-        (
-            'one_list_tier__name',
-            'classification',
-            'character varying(255)',
-        ),
-        (
-            'reference_code',
-            'cdms_reference_code',
-            'character varying(255)',
-        ),
-        (
-            'registered_address_1',
-            'registered_address_1',
-            'character varying(255)',
-        ),
-        (
-            'registered_address_2',
-            'registered_address_2',
-            'character varying(255)',
-        ),
+        ('is_turnover_estimated', 'is_turnover_estimated', 'boolean'),
+        ('name', 'name', 'character varying(255)'),
+        ('number_of_employees', 'number_of_employees', 'integer'),
+        ('one_list_tier__name', 'classification', 'character varying(255)'),
+        ('reference_code', 'cdms_reference_code', 'character varying(255)'),
+        ('registered_address_1', 'registered_address_1', 'character varying(255)'),
+        ('registered_address_2', 'registered_address_2', 'character varying(255)'),
         (
             'registered_address_country__name',
             'registered_address_country',
@@ -707,36 +243,12 @@ class CompaniesDatasetPipeline:
             'registered_address_town',
             'character varying(255)',
         ),
-        (
-            'sector_name',
-            'sector',
-            'character varying(255)',
-        ),
-        (
-            'trading_names',
-            'trading_names',
-            'character varying(255)',
-        ),
-        (
-            'turnover',
-            'turnover',
-            'bigint',
-        ),
-        (
-            'uk_region__name',
-            'uk_region',
-            'character varying(255)',
-        ),
-        (
-            'vat_number',
-            'vat_number',
-            'character varying(255)',
-        ),
-        (
-            'website',
-            'website',
-            'character varying(255)',
-        ),
+        ('sector_name', 'sector', 'character varying(255)'),
+        ('trading_names', 'trading_names', 'character varying(255)'),
+        ('turnover', 'turnover', 'bigint'),
+        ('uk_region__name', 'uk_region', 'character varying(255)'),
+        ('vat_number', 'vat_number', 'character varying(255)'),
+        ('website', 'website', 'character varying(255)'),
     ]
 
 
@@ -750,53 +262,14 @@ class AdvisersDatasetPipeline:
     end_date = None
     schedule_interval = '@daily'
     field_mapping = [
-        (
-            'id',
-            'id',
-            'uuid primary key',
-
-        ),
-        (
-            'date_joined',
-            'date_joined',
-            'date',
-
-        ),
-        (
-            'first_name',
-            'first_name',
-            'character varying(255)',
-
-        ),
-        (
-            'last_name',
-            'last_name',
-            'character varying(255)',
-
-        ),
-        (
-            'telephone_number',
-            'telephone_number',
-            'character varying(255)',
-
-        ),
-        (
-            'contact_email',
-            'contact_email',
-            'character varying(255)',
-
-        ),
-        (
-            'dit_team_id',
-            'team_id',
-            'uuid',
-
-        ),
-        (
-            'is_active',
-            'is_active',
-            'boolean',
-        ),
+        ('id', 'id', 'uuid primary key'),
+        ('date_joined', 'date_joined', 'date'),
+        ('first_name', 'first_name', 'character varying(255)'),
+        ('last_name', 'last_name', 'character varying(255)'),
+        ('telephone_number', 'telephone_number', 'character varying(255)'),
+        ('contact_email', 'contact_email', 'character varying(255)'),
+        ('dit_team_id', 'team_id', 'uuid'),
+        ('is_active', 'is_active', 'boolean'),
     ]
 
 
@@ -810,34 +283,9 @@ class TeamsDatasetPipeline:
     end_date = None
     schedule_interval = '@daily'
     field_mapping = [
-        (
-            'id',
-            'id',
-            'uuid primary key',
-
-        ),
-        (
-            'name',
-            'name',
-            'character varying(255)',
-
-        ),
-        (
-            'role__name',
-            'role',
-            'character varying(255)',
-
-        ),
-        (
-            'uk_region__name',
-            'uk_region',
-            'character varying(255)',
-
-        ),
-        (
-            'country__name',
-            'country',
-            'character varying(255)',
-
-        ),
+        ('id', 'id', 'uuid primary key'),
+        ('name', 'name', 'character varying(255)'),
+        ('role__name', 'role', 'character varying(255)'),
+        ('uk_region__name', 'uk_region', 'character varying(255)'),
+        ('country__name', 'country', 'character varying(255)'),
     ]

--- a/dataflow/meta/view_pipelines.py
+++ b/dataflow/meta/view_pipelines.py
@@ -2,9 +2,7 @@
 from datetime import datetime
 
 from dataflow import constants
-from dataflow.meta.dataset_pipelines import (
-    OMISDatasetPipeline,
-)
+from dataflow.meta.dataset_pipelines import OMISDatasetPipeline
 
 
 class CompletedOMISOrderViewPipeline:
@@ -24,11 +22,26 @@ class CompletedOMISOrderViewPipeline:
         ('omis_dataset.market', 'Market'),
         ('omis_dataset.sector', 'Sector'),
         ('omis_dataset.services', 'Services'),
-        ('to_char(omis_dataset.delivery_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Delivery date'),
-        ('to_char(omis_dataset.payment_received_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Payment received date'),
-        ('to_char(omis_dataset.completion_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Completion Date'),
-        ('to_char(omis_dataset.created_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Created date'),
-        ('to_char(omis_dataset.cancelled_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Cancelled date'),
+        (
+            'to_char(omis_dataset.delivery_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Delivery date',
+        ),
+        (
+            'to_char(omis_dataset.payment_received_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Payment received date',
+        ),
+        (
+            'to_char(omis_dataset.completion_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Completion Date',
+        ),
+        (
+            'to_char(omis_dataset.created_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Created date',
+        ),
+        (
+            'to_char(omis_dataset.cancelled_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Cancelled date',
+        ),
         ('omis_dataset.cancellation_reason', 'Cancellation reason'),
     ]
     join_clause = '''
@@ -57,8 +70,14 @@ class CancelledOMISOrderViewPipeline:
         ('ROUND(omis_dataset.subtotal::numeric/100::numeric,2)', 'Net price'),
         ('teams_dataset.name', 'DIT Team'),
         ('omis_dataset.market', 'Market'),
-        ('to_char(omis_dataset.created_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Created Date'),
-        ('to_char(omis_dataset.cancelled_date, \'YYYY-MM-DD HH24:MI:SS\')', 'Cancelled Date'),
+        (
+            'to_char(omis_dataset.created_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Created Date',
+        ),
+        (
+            'to_char(omis_dataset.cancelled_date, \'YYYY-MM-DD HH24:MI:SS\')',
+            'Cancelled Date',
+        ),
         ('omis_dataset.cancellation_reason', 'Cancellation reason'),
     ]
     join_clause = """
@@ -67,7 +86,7 @@ class CancelledOMISOrderViewPipeline:
     """
     where_clause = """
         omis_dataset.order_status = 'cancelled'
-        AND omis_dataset.cancelled_date >= 
+        AND omis_dataset.cancelled_date >=
         {% if macros.datetime.strptime(ds, '%Y-%m-%d') <= macros.datetime.strptime('{0}-{1}'.format(macros.ds_format(ds, '%Y-%m-%d', '%Y'), month_day_financial_year), '%Y-%m-%d') %}
             to_date('{{ macros.ds_format(macros.ds_add(ds, -365), '%Y-%m-%d', '%Y') }}-{{ month_day_financial_year }}', 'YYYY-MM-DD')
         {% else %}
@@ -75,9 +94,7 @@ class CancelledOMISOrderViewPipeline:
         {% endif %}
         ORDER BY omis_dataset.cancelled_date
     """
-    params = {
-        'month_day_financial_year': constants.FINANCIAL_YEAR_FIRST_MONTH_DAY,
-    }
+    params = {'month_day_financial_year': constants.FINANCIAL_YEAR_FIRST_MONTH_DAY}
     schedule_interval = '@monthly'
 
 
@@ -102,11 +119,22 @@ class OMISClientSurveyViewPipeline:
         ('companies_dataset.address_postcode', 'Company Trading Address Postcode'),
         ('companies_dataset.registered_address_1', 'Company Registered Address Line 1'),
         ('companies_dataset.registered_address_2', 'Company Registered Address Line 2'),
-        ('companies_dataset.registered_address_town', 'Company Registered Address Town'),
-        ('companies_dataset.registered_address_county', 'Company Registered Address County'),
-        ('companies_dataset.registered_address_country', 'Company Registered Address Country'),
-        ('companies_dataset.registered_address_postcode', 'Company Registered Address Postcode'),
-
+        (
+            'companies_dataset.registered_address_town',
+            'Company Registered Address Town',
+        ),
+        (
+            'companies_dataset.registered_address_county',
+            'Company Registered Address County',
+        ),
+        (
+            'companies_dataset.registered_address_country',
+            'Company Registered Address Country',
+        ),
+        (
+            'companies_dataset.registered_address_postcode',
+            'Company Registered Address Postcode',
+        ),
     ]
     join_clause = """
         JOIN companies_dataset ON omis_dataset.company_id=companies_dataset.id
@@ -118,5 +146,3 @@ class OMISClientSurveyViewPipeline:
         ORDER BY omis_dataset.completion_date
     """
     schedule_interval = '@monthly'
-
-

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -7,7 +7,8 @@ from airflow.operators.postgres_operator import PostgresOperator
 def get_defined_pipeline_classes_by_key(module, key):
     """Return all class objects in given module which contains given key in its name."""
     return [
-        cls for name, cls in module.__dict__.items()
+        cls
+        for name, cls in module.__dict__.items()
         if isinstance(cls, type) and key in name
     ]
 
@@ -18,6 +19,7 @@ class XCOMIntegratedPostgresOperator(PostgresOperator):
     def execute(self, context):
         """Return execution result."""
         self.log.info('Executing: %s', self.sql)
-        self.hook = PostgresHook(postgres_conn_id=self.postgres_conn_id,
-                                 schema=self.database)
+        self.hook = PostgresHook(
+            postgres_conn_id=self.postgres_conn_id, schema=self.database
+        )
         return self.hook.get_records(self.sql, parameters=self.parameters)

--- a/dataflow_worker_dummy_app.py
+++ b/dataflow_worker_dummy_app.py
@@ -1,5 +1,7 @@
 from flask import Flask
+
 app = Flask(__name__)
+
 
 @app.route('/')
 def hello_world():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+
+black==19.3b0
+flake8==3.7.8
+flake8-bugbear==19.8.0
+mypy==0.740

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ ignore_missing_imports = True
 
 [flake8]
 exclude = venv
-max-line-length = 88
+ignore = E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [mypy]
 ignore_missing_imports = True
+
+[flake8]
+exclude = venv
+max-line-length = 88


### PR DESCRIPTION
### Add teams dataset pipeline

Used to import teams data from datahub. One thing to note is that currently datahub endpoint is only ordered by ID (which is a UUID), so it's possible that pagination will break (by including an item more than once) if a new team is created during the import. Teams don't have a creation date column, so there's no other way to order them at the moment, but the table shouldn't change too often.

### Add a requirements-dev file with some static analysis tools

Adds a separate requirements file that can be used in CI or dev docker images to run static analysis tools and tests in the future.

Installs flake8 for code style checks, black for autoformatting and mypy for type hints validation.

### Disable missing import errors in mypy

Some of the libraries we're using don't have type hints, so we can disable missing import errors for the time being.

### Add a makefile to run static checks and fix file formatting


### Add a CircleCI config to run `make check` for every PR


### Apply autoformatting changes

This is the result of running `make format` for the first time. No other changes have been made, so the code should stay functionally the same.

black seems to join a lot of lines in dataset_pipelines, which makes it slightly harder to to scan through. I'm on the fence about this, but still think the benefits of standardised auto-formatting outweigh the individual style points. Happy to drop this for now if people disagree though.
