### PR TITLE
Fix empty response task failure

### DIFF
--- a/dataflow/operators/dataset.py
+++ b/dataflow/operators/dataset.py
@@ -278,6 +278,9 @@ def execute_insert_into(
                     logging.info(f'Page {var_name} does not exist. Moving on.')
                     continue
 
+                if not record_subset:
+                    continue
+
                 escaped_record_subset = []
                 for record in record_subset:
                     escaped_record = {}


### PR DESCRIPTION
This fixes the issue where an empty response from datahub was causing the insert task to fail as there was no data in the insert statement.