### PR TITLE
Use /v3/ activity-stream API and search_after pagination

### DIFF
--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -220,23 +220,20 @@ class ERPPipeline(BaseActivityStreamPipeline):
     ]
 
     query = {
-        "size": 10,
-        "query": {
-            "bool": {
-                "filter": [
-                    {
-                        "term": {
-                            "attributedTo.id": "dit:directoryFormsApi:SubmissionType:ExceptionalReviewProcedure"
-                        }
-                    },
-                    {
-                        "term": {
-                            "attributedTo.type": "dit:directoryFormsApi:SubmissionAction:zendesk"
-                        }
-                    },
-                ]
-            }
-        },
+        "bool": {
+            "filter": [
+                {
+                    "term": {
+                        "attributedTo.id": "dit:directoryFormsApi:SubmissionType:ExceptionalReviewProcedure"
+                    }
+                },
+                {
+                    "term": {
+                        "attributedTo.type": "dit:directoryFormsApi:SubmissionAction:zendesk"
+                    }
+                },
+            ]
+        }
     }
 
 

--- a/dataflow/operators/activity_stream.py
+++ b/dataflow/operators/activity_stream.py
@@ -13,13 +13,13 @@ def _activity_stream_request(url: str, query: dict):
     body = json.dumps(query)
     header = Sender(
         {
-            'id': config.ACTIVITY_STREAM_ID,
-            'key': config.ACTIVITY_STREAM_SECRET,
-            'algorithm': config.HAWK_ALGORITHM,
+            "id": config.ACTIVITY_STREAM_ID,
+            "key": config.ACTIVITY_STREAM_SECRET,
+            "algorithm": config.HAWK_ALGORITHM,
         },
         url,
         "get",
-        content_type='application/json',
+        content_type="application/json",
         content=body,
     ).request_header
 
@@ -27,13 +27,18 @@ def _activity_stream_request(url: str, query: dict):
         "GET",
         url,
         data=body,
-        headers={'Authorization': header, 'Content-Type': 'application/json'},
+        headers={"Authorization": header, "Content-Type": "application/json"},
     )
-    response.raise_for_status()
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logging.error(f"Request failed: {response.text}")
+        raise
 
     response_json = response.json()
-    if 'hits' not in response_json:
-        raise ValueError('Unexpected response structure')
+    if "hits" not in response_json:
+        raise ValueError("Unexpected response structure")
 
     return response_json
 
@@ -45,25 +50,42 @@ def fetch_from_activity_stream(
     # Clear any leftover requests from previous task runs
     redis_client.delete(run_fetch_task_id)
 
-    query = {**query, "size": config.ACTIVITY_STREAM_RESULTS_PER_PAGE, "from": 0}
-    next_page = True
+    query = {
+        "query": query,
+        "size": config.ACTIVITY_STREAM_RESULTS_PER_PAGE,
+        "sort": [{"id": "asc"}],
+    }
+    next_page = 1
 
-    source_url = f"{config.ACTIVITY_STREAM_BASE_URL}{index_name}"
+    source_url = f"{config.ACTIVITY_STREAM_BASE_URL}/v3/{index_name}/_search"
 
     while next_page:
-        logging.info(f'Fetching page {source_url}, offset {query["from"]}')
+        logging.info(f"Fetching page {next_page} of {source_url}")
         data = _activity_stream_request(source_url, query)
+        if "failures" in data["_shards"]:
+            logging.warning(
+                "Request failed on {} shards: {}".format(
+                    data['_shards']['failed'], data['_shards']['failures']
+                )
+            )
+        key = f"{run_fetch_task_id}_{next_page}"
 
-        key = f'{run_fetch_task_id}{query["from"]}'
+        if not data["hits"]["hits"]:
+            next_page = 0
+            continue
+
+        logging.info(
+            f"Fetched {len(data['hits']['hits'])} of {data['hits']['total']} records"
+        )
+
         Variable.set(
-            key, [item['_source'] for item in data['hits']['hits']], serialize_json=True
+            key, [item["_source"] for item in data["hits"]["hits"]], serialize_json=True
         )
         redis_client.rpush(run_fetch_task_id, key)
 
-        if data['hits']['hits']:
-            query = query.copy()
-            query["from"] += query["size"]
-        else:
-            next_page = False
+        query = query.copy()
+        query["search_after"] = data["hits"]["hits"][-1]["sort"]
 
-    logging.info(f'Fetching from source completed, total {data["hits"]["total"]}')
+        next_page += 1
+
+    logging.info(f"Fetching from source completed, total {data['hits']['total']}")

--- a/tests/operators/test_activity_stream.py
+++ b/tests/operators/test_activity_stream.py
@@ -32,14 +32,21 @@ def test_activity_stream_request_raises_for_non_2xx_status(requests_mock):
 
 def test_fetch_from_activity_stream(mocker):
     mocker.patch.object(
-        activity_stream.config, "ACTIVITY_STREAM_BASE_URL", "http://test/"
+        activity_stream.config, "ACTIVITY_STREAM_BASE_URL", "http://test"
     )
     req = mocker.patch.object(
         activity_stream,
         '_activity_stream_request',
         side_effect=[
-            {'hits': {'hits': [{"_source": "data"}]}},
-            {'hits': {'hits': [], 'total': 100}},
+            {
+                "_shards": {"failures": [], "failed": 1},
+                "hits": {"hits": [{"_source": "data", "sort": [120]}], "total": 100},
+            },
+            {
+                "_shards": {},
+                "hits": {"hits": [{"_source": "data", "sort": [240]}], "total": 100},
+            },
+            {"_shards": {}, "hits": {"hits": [], "total": 100}},
         ],
         autospec=True,
     )
@@ -54,18 +61,38 @@ def test_fetch_from_activity_stream(mocker):
     activity_stream.fetch_from_activity_stream('index', {}, 'task-1')
     req.assert_has_calls(
         [
-            mock.call('http://test/index', {'size': 100, 'from': 0}),
-            mock.call('http://test/index', {'size': 100, 'from': 100}),
+            mock.call(
+                'http://test/v3/index/_search',
+                {'query': {}, 'size': 100, 'sort': [{'id': 'asc'}]},
+            ),
+            mock.call(
+                'http://test/v3/index/_search',
+                {
+                    'query': {},
+                    'size': 100,
+                    'sort': [{'id': 'asc'}],
+                    'search_after': [120],
+                },
+            ),
+            mock.call(
+                'http://test/v3/index/_search',
+                {
+                    'query': {},
+                    'size': 100,
+                    'sort': [{'id': 'asc'}],
+                    'search_after': [240],
+                },
+            ),
         ]
     )
 
     redis.rpush.assert_has_calls(
-        [mock.call('task-1', 'task-10'), mock.call('task-1', 'task-1100')]
+        [mock.call('task-1', 'task-1_1'), mock.call('task-1', 'task-1_2')]
     )
 
     var_set.assert_has_calls(
         [
-            mock.call('task-10', ['data'], serialize_json=True),
-            mock.call('task-1100', [], serialize_json=True),
+            mock.call('task-1_1', ['data'], serialize_json=True),
+            mock.call('task-1_2', ['data'], serialize_json=True),
         ]
     )


### PR DESCRIPTION
This updates activity stream operators to use /v3/ API and paginate
based on `search_after` instead of `from`. Search after doesn't have
offset restrictions, so can be used to download large datasets.

This also moves size/sort parts of the query to the fetch operator
itself, so the DAG query should only contain the `"query"` part
itself (for example filters).