### PR TITLE
Add a full list of ERP fields for 4 user flows

### DIFF
--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -96,10 +96,11 @@ class BaseActivityStreamPipeline:
 class ERPPipeline(BaseActivityStreamPipeline):
     name = "erp"
     index = "objects"
-    table_name = "erp_activity_stream"
+    table_name = "erp_submissions"
 
     field_mapping = [
         ("id", sa.Column("id", sa.String, primary_key=True)),
+        ("url", sa.Column("url", sa.String, primary_key=True)),
         (
             ("dit:directoryFormsApi:Submission:Data", "commodity", "commodity_code"),
             sa.Column("commodity_code", sa.ARRAY(sa.String)),
@@ -111,6 +112,22 @@ class ERPPipeline(BaseActivityStreamPipeline):
         (
             ("dit:directoryFormsApi:Submission:Data", "company_name"),
             sa.Column("company_name", sa.String),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "company_number"),
+            sa.Column("company_number", sa.String),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "company_type"),
+            sa.Column("company_type", sa.String),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "consumer_region"),
+            sa.Column("consumer_region", sa.String),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "consumer_type"),
+            sa.Column("consumer_type", sa.String),
         ),
         (
             ("dit:directoryFormsApi:Submission:Data", "country"),
@@ -125,12 +142,28 @@ class ERPPipeline(BaseActivityStreamPipeline):
             sa.Column("employees", sa.String),
         ),
         (
+            ("dit:directoryFormsApi:Submission:Data", "employment_regions"),
+            sa.Column("employment_regions", sa.ARRAY(sa.String)),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "equivalent_uk_goods"),
+            sa.Column("equivalent_uk_goods", sa.Boolean),
+        ),
+        (
             ("dit:directoryFormsApi:Submission:Data", "family_name"),
             sa.Column("family_name", sa.String),
         ),
         (
             ("dit:directoryFormsApi:Submission:Data", "given_name"),
             sa.Column("given_name", sa.String),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "has_consumer_choice_changed"),
+            sa.Column("has_consumer_choice_changed", sa.Boolean),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "has_consumer_price_changed"),
+            sa.Column("has_consumer_price_changed", sa.Boolean),
         ),
         (
             ("dit:directoryFormsApi:Submission:Data", "has_market_price_changed"),
@@ -153,8 +186,31 @@ class ERPPipeline(BaseActivityStreamPipeline):
             sa.Column("has_volume_changed", sa.Boolean),
         ),
         (
+            ("dit:directoryFormsApi:Submission:Data", "import_countries"),
+            sa.Column("import_countries", sa.ARRAY(sa.String)),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "income_bracket"),
+            sa.Column("income_bracket", sa.ARRAY(sa.String)),
+        ),
+        (
+            (
+                "dit:directoryFormsApi:Submission:Data",
+                "imported_goods_makes_something_else",
+            ),
+            sa.Column("imported_goods_makes_something_else", sa.Boolean),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "market_size_known"),
+            sa.Column("market_size_known", sa.Boolean),
+        ),
+        (
             ("dit:directoryFormsApi:Submission:Data", "other_information"),
             sa.Column("other_information", sa.String),
+        ),
+        (
+            ("dit:directoryFormsApi:Submission:Data", "production_cost_percentage"),
+            sa.Column("production_cost_percentage", sa.Integer),
         ),
         (
             (

--- a/dataflow/operators/activity_stream.py
+++ b/dataflow/operators/activity_stream.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import backoff
 import requests
 from airflow.models import Variable
 from mohawk import Sender
@@ -9,6 +10,7 @@ from dataflow import config
 from .dataset import get_redis_client
 
 
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
 def _activity_stream_request(url: str, query: dict):
     body = json.dumps(query)
     header = Sender(

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
-mohawk
-requests
 apache-airflow[postgres,crypto,celery,s3,sentry]
-requests-oauthlib
+backoff
+mohawk
 redis
+requests
+requests-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ apispec[yaml]==3.1.0      # via flask-appbuilder
 argcomplete==1.10.3       # via apache-airflow
 attrs==19.3.0             # via jsonschema
 babel==2.7.0              # via flask-babel, flower
+backoff==1.9.2
 billiard==3.6.1.0         # via celery
 blinker==1.4              # via apache-airflow
 boto3==1.7.84             # via apache-airflow

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ ignore_missing_imports = True
 
 [flake8]
 exclude = venv
-ignore = E501
+ignore = E501, E203, W503

--- a/tests/operators/test_activity_stream.py
+++ b/tests/operators/test_activity_stream.py
@@ -23,7 +23,8 @@ def test_activity_stream_request_raises_error_without_hits(requests_mock):
         activity_stream._activity_stream_request('http://test', {})
 
 
-def test_activity_stream_request_raises_for_non_2xx_status(requests_mock):
+def test_activity_stream_request_raises_for_non_2xx_status(mocker, requests_mock):
+    mocker.patch("time.sleep")  # skip backoff retry delay
     requests_mock.get('http://test', status_code=404)
 
     with pytest.raises(HTTPError):


### PR DESCRIPTION
### Ignore flake8 warnings that conflict with PEP8/black


### Add a full list of ERP fields for 4 user flows

ERP form has 4 possible user flows, which result in slightly different object schemas. This adds fields from all 4 possible responses and a `url` field that contains the type of the response into the ERP dataset table.

### Pass run_fetch_task_id explicitly to activity stream operators

provide_context no longer seems to pass user_defined_macros as args in Airflow 1.10.6, so we provide `run_fetch_task_id` explicitly to tasks that rely on it

### Add a check step to activity stream dags

Adds 2 simple checks to verify dataset import is operating as intended:

1. Compares the sizes of the new import and existing dataset and aborts the table swap if the new dataset is more than 10% smaller than the existing one. This only runs if the dataset already exists.

2. Checks if any columns only have NULL values (and are therefore either unused or being imported from a wrong field, for example due to a typo).

### Add request retries to activity stream fetcher

For long running imports it's possible to run into one-off failed requests, which would normally lead to entire import being stopped.

This retries any failed individual Activity Stream request up to 5 times with exponential back-off.
