### PR TITLE
Release a specific commit through all CI stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,17 @@
 pipeline {
   agent none
   parameters {
-      string(name: 'VERSION', defaultValue: 'master', description: 'Branch name or commit SHA to deploy')
+      string(name: 'GIT_COMMIT', defaultValue: 'origin/master', description: 'Commit SHA or origin branch to deploy')
   }
 
   stages {
     stage('prepare') {
       agent any
       steps {
-        checkout scm
+        checkout([
+            $class: 'GitSCM',
+            branches: [[name: params.GIT_COMMIT]],
+        ])
         script {
           pullRequestNumber = sh(
               script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
@@ -22,7 +25,7 @@ pipeline {
 
     stage('release: dev') {
       steps {
-        ci_pipeline("dev", params.VERSION)
+        ci_pipeline("dev", params.GIT_COMMIT)
       }
     }
 
@@ -38,7 +41,7 @@ pipeline {
       }
 
       steps {
-        ci_pipeline("staging", params.VERSION)
+        ci_pipeline("staging", params.GIT_COMMIT)
       }
     }
 
@@ -54,7 +57,7 @@ pipeline {
       }
 
       steps {
-        ci_pipeline("production", params.VERSION)
+        ci_pipeline("production", params.GIT_COMMIT)
       }
     }
 


### PR DESCRIPTION
Promotion pipeline should consistently move the same commit through
dev, staging and prod, even if there were new merges into master
since the job has initially been started.

The easiest way to set a variable that is available in all stages of
the Jenkins Pipeline and doesn't require an agent to access seems to
be to set a parameter when starting the build. This changes the job
to accept GIT_COMMIT parameter, checkout that specific commit to
populate build name with a PR number and then call ci-pipeline with
it.

In order to set the commit parameter automatically on each master merge
this job will be started by another Jenkins job, which watches the Github
repo.