### PR TITLE
Prevent concurrent releases to the same environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,10 +65,12 @@ pipeline {
 }
 
 void ci_pipeline(env, version) {
-  build job: "ci-pipeline", parameters: [
-    string(name: "Team", value: "datasci"),
-    string(name: "Project", value: "data-flow"),
-    string(name: "Environment", value: env),
-    string(name: "Version", value: version)
-  ]
+  lock("data-flow-ci-pipeline-${env}") {
+    build job: "ci-pipeline", parameters: [
+        string(name: "Team", value: "datasci"),
+        string(name: "Project", value: "data-flow"),
+        string(name: "Environment", value: env),
+        string(name: "Version", value: version)
+    ]
+  }
 }


### PR DESCRIPTION
Locks ci-pipeline job for each environment so that consecutive
merges wait until the previous release to the given environment
has completed.

ci-pipeline would prevent a concurrent run for the same project,
the difference is this delays the job run instead of failing it.