### PR TITLE
Add great.gov.uk export opportunities and enquiries

### DIFF
--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -23,9 +23,13 @@ def get_nested_key(data: dict, path: Union[Tuple, str], required: bool = False) 
         path = (path,)
 
     for key in path:
-        data = data[key] if required else data.get(key)
-        if not required and data is None:
-            return data
+        try:
+            data = data[key]
+        except (KeyError, IndexError):
+            if required:
+                raise
+            else:
+                return None
 
     return data
 


### PR DESCRIPTION
Adds pipelines to import great.gov.uk export opportunities and
export opportunity enquiries datasets from the activity stream API.

Two datasets are connected by id - `enquiries.opportunity_id` should
match with `opportunity.id`.

Enquiries contain company and person data as 2 items in the `actor`
array, so for the time being we're extracting them by indexing into
the array (first record is the company, second is the person). This
works because the order seems to always be the same, but will raise
an error if the records are switched since `name` types are different.

This can be generalised by extending `get_nested_key` to match based
on a predicate instead of fixed index in the future.