### PR TITLE
Rollback airflow to investigate daily job failures

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-apache-airflow[postgres,crypto,celery,s3,sentry]
+apache-airflow[postgres,crypto,celery,s3]==1.10.5
 backoff
 mohawk
 redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,19 +6,17 @@
 #
 alembic==1.3.1            # via apache-airflow
 amqp==2.5.2               # via kombu
-apache-airflow[celery,crypto,postgres,s3,sentry]==1.10.6
+apache-airflow[celery,crypto,postgres,s3]==1.10.5
 apispec[yaml]==3.1.0      # via flask-appbuilder
-argcomplete==1.10.3       # via apache-airflow
 attrs==19.3.0             # via jsonschema
 babel==2.7.0              # via flask-babel, flower
 backoff==1.9.2
 billiard==3.6.1.0         # via celery
-blinker==1.4              # via apache-airflow
 boto3==1.7.84             # via apache-airflow
 botocore==1.10.84         # via boto3, s3transfer
 cached-property==1.5.1    # via apache-airflow
 celery==4.3.0             # via apache-airflow, flower
-certifi==2019.11.28       # via requests, sentry-sdk
+certifi==2019.11.28       # via requests
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask, flask-appbuilder
@@ -28,8 +26,9 @@ configparser==3.5.3       # via apache-airflow
 croniter==0.3.30          # via apache-airflow
 cryptography==2.8         # via apache-airflow
 defusedxml==0.6.0         # via python3-openid
-dill==0.3.1.1             # via apache-airflow
+dill==0.2.9               # via apache-airflow
 docutils==0.15.2          # via botocore, python-daemon
+dumb-init==1.2.2          # via apache-airflow
 flask-admin==1.5.3        # via apache-airflow
 flask-appbuilder==1.13.1  # via apache-airflow
 flask-babel==0.12.2       # via flask-appbuilder
@@ -44,7 +43,6 @@ flask==1.1.1              # via apache-airflow, flask-admin, flask-appbuilder, f
 flower==0.9.3             # via apache-airflow
 funcsigs==1.0.0           # via apache-airflow
 future==0.16.0            # via apache-airflow
-graphviz==0.13.2          # via apache-airflow
 gunicorn==19.10.0         # via apache-airflow
 idna==2.8                 # via requests
 importlib-metadata==0.23  # via jsonschema
@@ -61,7 +59,7 @@ mako==1.1.0               # via alembic
 markdown==2.6.11          # via apache-airflow
 markupsafe==1.1.1         # via jinja2, mako
 marshmallow-enum==1.5.1   # via flask-appbuilder
-marshmallow-sqlalchemy==0.18.0  # via apache-airflow, flask-appbuilder
+marshmallow-sqlalchemy==0.18.0  # via flask-appbuilder
 marshmallow==2.19.5       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
 mohawk==1.1.0
 more-itertools==7.2.0     # via zipp
@@ -88,7 +86,6 @@ redis==3.3.11
 requests-oauthlib==1.3.0
 requests==2.22.0
 s3transfer==0.1.13        # via boto3
-sentry-sdk==0.13.4        # via apache-airflow
 setproctitle==1.1.10      # via apache-airflow
 six==1.13.0               # via cryptography, flask-jwt-extended, jsonschema, mohawk, prison, pyrsistent, python-dateutil, tenacity, thrift
 sqlalchemy==1.3.11        # via alembic, apache-airflow, flask-sqlalchemy, marshmallow-sqlalchemy
@@ -100,7 +97,7 @@ thrift==0.13.0            # via apache-airflow
 tornado==5.1.1            # via apache-airflow, flower
 tzlocal==1.5.1            # via apache-airflow, pendulum
 unicodecsv==0.14.1        # via apache-airflow
-urllib3==1.25.7           # via requests, sentry-sdk
+urllib3==1.25.7           # via requests
 vine==1.3.0               # via amqp, celery
 werkzeug==0.16.0          # via flask, flask-caching, flask-jwt-extended
 wtforms==2.2.1            # via flask-admin, flask-wtf
@@ -108,4 +105,4 @@ zipp==0.6.0               # via importlib-metadata
 zope.deprecation==4.4.0   # via apache-airflow
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.1        # via jsonschema, python-daemon, zope.deprecation
+# setuptools==42.0.2        # via jsonschema, python-daemon, zope.deprecation


### PR DESCRIPTION
We've had daily jobs failures with tasks failing to be scheduled
that started happening after the Airflow upgrade, so we're rolling
it back for the time being to investigate if it's related to any
of the 1.10.6 changes.

This will rollback the Sentry integration but shouldn't affect
anything else.