### PR TITLE
Split ONS UK trade data dataset import by the time period

### DIFF
--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -31,4 +31,7 @@ COUNTRIES_OF_INTEREST_BASE_URL = os.environ.get(
 
 S3_IMPORT_DATA_BUCKET = os.environ.get("S3_IMPORT_DATA_BUCKET")
 
-ONS_SPARQL_URL = "http://gss-data.org.uk/sparql"
+ONS_SPARQL_URL = os.environ.get(
+    "ONS_SPARQL_URL",
+    "https://production-drafter-ons-alpha.publishmydata.com/v1/sparql/live",
+)

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Optional
 
 import sqlalchemy as sa
 from airflow import DAG
@@ -19,6 +20,8 @@ class BaseONSPipeline:
     start_date = datetime(2019, 11, 5)
     end_date = None
     schedule_interval = "@daily"
+
+    index_query: Optional[str] = None
 
     @property
     def table(self):
@@ -53,7 +56,7 @@ class BaseONSPipeline:
                 task_id="fetch-from-ons-sparql",
                 python_callable=fetch_from_ons_sparql,
                 provide_context=True,
-                op_args=[self.table_name, self.query],
+                op_args=[self.table_name, self.query, self.index_query],
             )
 
             _create_tables = PythonOperator(

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -142,6 +142,7 @@ class ONSUKSATradeInGoodsPipeline(BaseONSPipeline):
 
 class ONSUKTradeInGoodsPipeline(BaseONSPipeline):
     table_name = "ons_uk_trade_in_goods"
+    schedule_interval = "@weekly"
 
     field_mapping = [
         (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
@@ -153,26 +154,52 @@ class ONSUKTradeInGoodsPipeline(BaseONSPipeline):
         (("unit", "value"), sa.Column("unit", sa.String)),
     ]
 
+    index_query = """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX qb: <http://purl.org/linked-data/cube#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX pmdqb: <http://publishmydata.com/def/qb/>
+
+    SELECT ?compvalue ?label WHERE {
+    BIND(<http://gss-data.org.uk/data/gss_data/trade/ons-trade-in-goods> AS ?dataset)
+    BIND(<http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> AS ?component)
+    ?dataset qb:structure/qb:component ?compspec .
+
+    ?compspec ?comp_type ?component ;
+                pmdqb:codesUsed / skos:member ?compvalue .
+
+    ?compvalue rdfs:label ?label .
+
+    } ORDER BY ?compvalue
+    """
+
     query = """
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?period ?geography_name ?product_label ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    {% raw %}
+
+    SELECT ?period ?geography_name ?product ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {{
+
+        BIND(<{compvalue[value]}> AS ?period_s)
+
         ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-trade-in-goods> ;
+        <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> ?period_s ;
+        <http://gss-data.org.uk/def/dimension/trade-partner-geography> ?geography_s ;
         <http://gss-data.org.uk/def/dimension/product> ?product_s ;
         <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
         <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s ;
-        <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
-        <http://gss-data.org.uk/def/dimension/trade-partner-geography> ?geography_s ;
-        <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> ?period_s .
+        <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total .
 
         ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
         ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
         ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
         ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
         ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
-        ?product_s <http://www.w3.org/2000/01/rdf-schema#label> ?product_label .
-    } ORDER BY ?period_s ?geography_s ?product_s
+        ?product_s <http://www.w3.org/2000/01/rdf-schema#label> ?product .
+    }} ORDER BY ?geography_s ?product_s
+
+    {% endraw %}
     """
 
 

--- a/dataflow/operators/ons.py
+++ b/dataflow/operators/ons.py
@@ -8,13 +8,10 @@ from dataflow.utils import S3Data
 
 
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
-def _ons_sparql_request(url: str, query: str, page: int = 1, per_page: int = 1000):
+def _ons_sparql_request(url: str, query: str, page: int = 1, per_page: int = 10000):
+    query += f" LIMIT {per_page} OFFSET {per_page * (page - 1)}"
     response = requests.request(
-        "POST",
-        url,
-        data={"query": query},
-        params={"page": page, "per_page": per_page},
-        headers={"Accept": "application/json"},
+        "POST", url, data={"query": query}, headers={"Accept": "application/json"}
     )
 
     try:

--- a/tests/operators/test_ons.py
+++ b/tests/operators/test_ons.py
@@ -8,19 +8,19 @@ from dataflow.operators import ons
 
 def test_ons_sparql_request(requests_mock):
     requests_mock.post(
-        'http://test/?page=2&per_page=20',
+        'http://test/',
         request_headers={'Accept': 'application/json'},
         json={'results': []},
     )
 
-    ons._ons_sparql_request('http://test', {}, page=2, per_page=20)
+    ons._ons_sparql_request('http://test', "SELECT *", page=2, per_page=20)
 
 
 def test_activity_stream_request_raises_error_without_hits(requests_mock):
     requests_mock.post('http://test', json={})
 
     with pytest.raises(ValueError):
-        ons._ons_sparql_request('http://test', {})
+        ons._ons_sparql_request('http://test', "SELECT *")
 
 
 def test_activity_stream_request_raises_for_non_2xx_status(mocker, requests_mock):
@@ -28,7 +28,7 @@ def test_activity_stream_request_raises_for_non_2xx_status(mocker, requests_mock
     requests_mock.post('http://test', status_code=404)
 
     with pytest.raises(HTTPError):
-        ons._ons_sparql_request('http://test', {})
+        ons._ons_sparql_request('http://test', "SELECT *")
 
 
 def test_fetch_from_activity_stream(mocker):
@@ -46,7 +46,7 @@ def test_fetch_from_activity_stream(mocker):
     s3_mock = mock.MagicMock()
     mocker.patch.object(ons, "S3Data", return_value=s3_mock, autospec=True)
 
-    ons.fetch_from_ons_sparql('table', "SELECT *", ts_nodash='task-1')
+    ons.fetch_from_ons_sparql('table', "SELECT *", None, ts_nodash='task-1')
     req.assert_has_calls(
         [
             mock.call(ons.config.ONS_SPARQL_URL, "SELECT *", page=1),
@@ -60,4 +60,35 @@ def test_fetch_from_activity_stream(mocker):
             mock.call('0000000001.json', ['data']),
             mock.call('0000000002.json', ['data2']),
         ]
+    )
+
+
+def test_fetch_from_activity_stream_with_index_query(mocker):
+    req = mocker.patch.object(
+        ons,
+        '_ons_sparql_request',
+        side_effect=[
+            {"results": {"bindings": [{"label": {"value": "index_data"}}]}},
+            {"results": {"bindings": ["data"]}},
+            {"results": {"bindings": []}},
+        ],
+        autospec=True,
+    )
+
+    s3_mock = mock.MagicMock()
+    mocker.patch.object(ons, "S3Data", return_value=s3_mock, autospec=True)
+
+    ons.fetch_from_ons_sparql(
+        'table', "SELECT {label[value]}", "SELECT *", ts_nodash='task-1'
+    )
+    req.assert_has_calls(
+        [
+            mock.call(ons.config.ONS_SPARQL_URL, "SELECT *"),
+            mock.call(ons.config.ONS_SPARQL_URL, "SELECT index_data", page=1),
+            mock.call(ons.config.ONS_SPARQL_URL, "SELECT index_data", page=2),
+        ]
+    )
+
+    s3_mock.write_key.assert_has_calls(
+        [mock.call('index_data-0000000001.json', ['data'])]
     )


### PR DESCRIPTION
### Switch to public backend ONS SPARQL endpoint

gss-alpha wraps another ONS SPARQL endpoint that we can use directly.

Since it doesn't support pagination arguments we need to modify the query with LIMIT and OFFSET parameters.

### Split large ONS datasets by indexing over one of the dimensions

This implements the "cursoring" approach proposed by ONS: we split the dataset into smaller ones by first getting a list of all possible values for one or more dimensions (e.g. geography or year/month) and then requesting data for each value (or combination of values) of these dimensions.

In order to achieve this we add an optional `index_query` to the ONS pipeline class. This query returns a list of values used to parameterize the dataset query in order to filter out results. The query should also return a `label` value, which is used to prefix page response file names stored in S3.

Index query is currently not paginated. With a raised default page limit of 10000, a paginated response would require us to make more than 10000 HTTP requests, so we might need a different approach in that case.

### Split ONS UK trade data dataset import by the time period

ONS UK traded data contains 15 million records and is too large to paginate through using LIMIT and OFFSET.

This is using the `index_query` to retrieve a list of time periods used by the dataset (~250 values, one for each month since 1998) and then request data for each of those periods separately. With a page size of 10000 this results in 6 requests per month, for a total of ~1500 requests, which take around 1.5 hours to import and store in S3.

Since we're using `str.format` to inject the filter value into the query, there's a small escape sequence conflict between literal `{` required by SPARQL `WHERE` clause escaped as `{{` for python string formatting and Airflow interpreting parameters as Jinja2 templates by default. To avoid having `{{ ... }}` interpreted as Jinja2 tag we wrap part of the query with Jinja `{% raw %}` tag.
