### PR TITLE
ONS Postcodes from data-store-service added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Two new ONS datasets for UK trade in services.
+- ONS Postcode (data-store-service) pipeline
+
 
 ## 2020-02-04
 

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -28,6 +28,9 @@ REDIS_URL = os.environ.get('AIRFLOW__CELERY__BROKER_URL')
 COUNTRIES_OF_INTEREST_BASE_URL = os.environ.get(
     'COUNTRIES_OF_INTEREST_BASE_URL', 'localhost:5000'
 )
+DATA_STORE_SERVICE_BASE_URL = os.environ.get(
+    'DATA_STORE_SERVICE_BASE_URL', 'localhost:5050'
+)
 
 S3_IMPORT_DATA_BUCKET = os.environ.get("S3_IMPORT_DATA_BUCKET")
 

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -699,5 +699,66 @@ class ExportWinsWinsDatasetPipeline(BaseDatasetPipeline):
     ]
 
 
+class ONSPostcodePipeline(BaseDatasetPipeline):
+    """Pipeline meta object for ONS Postcode data."""
+
+    table_name = 'ons_postcodes'
+    source_url = '{0}/api/v1/get-ons-postcodes/?orientation=records'.format(
+        config.DATA_STORE_SERVICE_BASE_URL
+    )
+    field_mapping = [
+        ('pcd', ' pcd', 'character varying(255)'),
+        ('pcd2', 'pcd2', 'character varying(255)'),
+        ('pcds', 'pcds', 'character varying(255)'),
+        ('dointr', 'dointr', 'date'),
+        ('doterm', 'doterm', 'date'),
+        ('oscty', 'oscty', 'character varying(255)'),
+        ('ced', 'ced', 'character varying(255)'),
+        ('oslaua' 'oslaua', 'character varying(255)'),
+        ('osward', 'osward', 'character varying(255)'),
+        ('parish', 'parish', 'character varying(255)'),
+        ('usertype', 'usertype', 'character varying(255)'),
+        ('oseast1m', 'oseast1m', 'character varying(255)'),
+        ('osnrth1m', 'osnrth1m', 'character varying(255)'),
+        ('osgrdind', 'osgrdind', 'character varying(255)'),
+        ('oshlthau', 'oshlthau', 'character varying(255)'),
+        ('nhser', 'nhser', 'character varying(255)'),
+        ('ctry', 'ctry', 'character varying(255)'),
+        ('rgn', 'rgn', 'character varying(255)'),
+        ('streg', 'streg', 'character varying(255)'),
+        ('pcon', 'pcon', 'character varying(255)'),
+        ('eer', 'eer', 'character varying(255)'),
+        ('teclec', 'teclec', 'character varying(255)'),
+        ('ttwa', 'ttwa', 'character varying(255)'),
+        ('pct', 'pct', 'character varying(255)'),
+        ('nuts', 'nuts', 'character varying(255)'),
+        ('statsward', 'statsward', 'character varying(255)'),
+        ('oa01', 'oa01', 'character varying(255)'),
+        ('casward', 'casward', 'character varying(255)'),
+        ('park', 'park', 'character varying(255)'),
+        ('lsoa01', 'lsoa01', 'character varying(255)'),
+        ('msoa01', 'msoa01', 'character varying(255)'),
+        ('ur01ind', 'ur01ind', 'character varying(255)'),
+        ('oac01', 'oac01', 'character varying(255)'),
+        ('oa11', 'oa11', 'character varying(255)'),
+        ('lsoa11', 'lsoa11', 'character varying(255)'),
+        ('msoa11', 'msoa11', 'character varying(255)'),
+        ('wz11', 'wz11', 'character varying(255)'),
+        ('ccg', 'ccg', 'character varying(255)'),
+        ('bua11', 'bua11', 'character varying(255)'),
+        ('buasd11', 'buasd11', 'character varying(255)'),
+        ('ru11ind', 'ru11ind', 'character varying(255)'),
+        ('oac11', 'oac11', 'character varying(255)'),
+        ('lat', 'lat', 'character varying(255)'),
+        ('long', 'long', 'character varying(255)'),
+        ('lep1', 'lep1', 'character varying(255)'),
+        ('lep2', 'lep2', 'character varying(255)'),
+        ('pfa', 'pfa', 'character varying(255)'),
+        ('imd', 'imd', 'character varying(255)'),
+        ('calncv', 'calncv', 'character varying(255)'),
+        ('stp', 'stp', 'character varying(255)'),
+    ]
+
+
 for pipeline in BaseDatasetPipeline.__subclasses__():
     globals()[pipeline.__name__ + '__dag'] = pipeline.get_dag()

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -714,7 +714,7 @@ class ONSPostcodePipeline(BaseDatasetPipeline):
         ('doterm', 'doterm', 'date'),
         ('oscty', 'oscty', 'character varying(255)'),
         ('ced', 'ced', 'character varying(255)'),
-        ('oslaua' 'oslaua', 'character varying(255)'),
+        ('oslaua', 'oslaua', 'character varying(255)'),
         ('osward', 'osward', 'character varying(255)'),
         ('parish', 'parish', 'character varying(255)'),
         ('usertype', 'usertype', 'character varying(255)'),

--- a/sample.env
+++ b/sample.env
@@ -42,6 +42,7 @@ DATAHUB_BASE_URL=https://datahub-api-demo.london.cloudapps.digital
 FINANCIAL_YEAR_FIRST_DAY_MONTH='4-1'
 INGEST_TASK_CONCURRENCY=4
 COUNTRIES_OF_INTEREST_BASE_URL=https://countries-of-interest-service-dev.london.cloudapps.digital
+DATA_STORE_SERVICE_BASE_URL=https://data-store-service-dev.london.cloudapps.digital
 FINANCIAL_YEAR_FIRST_MONTH_DAY=4-1
 
 AWS_DEFAULT_REGION=eu-west-2


### PR DESCRIPTION
### Description of change
This adds ONS Postcode pipeline that retrieves its data from the data-store-service

`DATA_STORE_SERVICE_BASE_URL` has been added to vault on all platforms

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
