### PR TITLE
Add pipelines for two more ONS datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-11
+
+### Added
+
+- Two new ONS datasets for UK trade in services.
+
 ## 2020-02-04
 
 ### Changed

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -244,5 +244,72 @@ class ONSUKTradeInGoodsByCommodityPipeline(BaseONSPipeline):
     """
 
 
+class ONSUKTradeInServicesByPartnerCountryPipeline(BaseONSPipeline):
+    table_name = "ons_uk_trade_in_services_by_country"
+
+    field_mapping = [
+        (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
+        (("geography_name", "value"), sa.Column("geography_name", sa.String)),
+        (("product_label", "value"), sa.Column("product", sa.String)),
+        (("period", "value"), sa.Column("period", sa.String)),
+        (("direction", "value"), sa.Column("direction", sa.String)),
+        (("total", "value"), sa.Column("total", sa.Numeric(asdecimal=True))),
+        (("unit", "value"), sa.Column("unit", sa.String)),
+    ]
+
+    query = """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+    SELECT ?geography_name ?product_label ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-services> ;
+        <http://gss-data.org.uk/def/dimension/trade-partner-geography> ?geography_s ;
+        <http://gss-data.org.uk/def/dimension/product> ?product_s ;
+        <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> ?period_s ;
+        <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
+        <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
+        <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s .
+    ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
+    ?product_s <http://www.w3.org/2000/01/rdf-schema#label> ?product_label .
+    ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
+    ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
+    ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
+    } ORDER BY ?geography_name ?product_label ?period
+    """
+
+
+class ONSUKTotalTradeInServicesByPartnerCountryPipeline(BaseONSPipeline):
+    table_name = "ons_uk_total_trade_in_services_by_country"
+
+    field_mapping = [
+        (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
+        (("geography_name", "value"), sa.Column("geography_name", sa.String)),
+        (("period", "value"), sa.Column("period", sa.String)),
+        (("direction", "value"), sa.Column("direction", sa.String)),
+        (("total", "value"), sa.Column("total", sa.Numeric(asdecimal=True))),
+        (("unit", "value"), sa.Column("unit", sa.String)),
+    ]
+
+    query = """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+    SELECT ?geography_name ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-total-trade> ;
+        <http://gss-data.org.uk/def/dimension/trade-partner-geography> ?geography_s ;
+        <http://gss-data.org.uk/def/dimension/product> ?product_s ;
+        <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> ?period_s ;
+        <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
+        <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
+        <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s .
+    ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
+    ?product_s <http://www.w3.org/2000/01/rdf-schema#label> "Services" .
+    ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
+    ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
+    ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
+    } ORDER BY ?geography_name ?period
+    """
+
+
 for pipeline in BaseONSPipeline.__subclasses__():
     globals()[pipeline.__name__ + "__dag"] = pipeline().get_dag()


### PR DESCRIPTION
### Description of change
The two datasets added here are:

* UK trade in services: total by flow and country, non-seasonally adjusted
* UK trade in services: total by service type, flow and country,
  non-seasonally adjusted.

Ticket: https://trello.com/c/T4qi6vPG/836

### Notes

These datasets are intended to be comparable to [UK trade in services: service type by partner country, non-seasonally adjusted](https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted) and [UK trade in services: all countries, non-seasonally adjusted](https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/uktradeinservicesallcountriesnonseasonallyadjusted), however GSS data doesn't seem to have datasets that match these names exactly.

One of them does [UK trade in services: service type by partner country, non-seasonally adjusted](http://gss-data.org.uk/dataset?uri=http%3A%2F%2Fgss-data.org.uk%2Fdata%2Fgss_data%2Ftrade%2Fons-uk-trade-in-services), but the other is using [UK total trade: all countries, non-seasonally adjusted](http://gss-data.org.uk/dataset?uri=http%3A%2F%2Fgss-data.org.uk%2Fdata%2Fgss_data%2Ftrade%2Fons-uk-total-trade) and filtering out only trade in the "Services" category.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [x] Has the README been updated (if needed)?
