### PR TITLE
Stop Postgres wanting a password in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
 
   data-flow-redis:
     image: redis


### PR DESCRIPTION
### Description of change
On running `docker-compose up`, I got the following error from the Postgres image:
```
Error: Database is uninitialized and superuser password is not specified.
        You must specify POSTGRES_PASSWORD for the superuser. Use
        "-e POSTGRES_PASSWORD=password" to set it in "docker run".

        You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
        without a password. This is *not* recommended. See PostgreSQL
        documentation about "trust":
        https://www.postgresql.org/docs/current/auth-trust.html
```
This error stops the Postgres container from launching, causing data-flow to error out
trying to connect to the db.

Although it says it isn't recommended, I think allowing no password in docker-compose is probably ok.
Test is that `docker-compose up` works. I think this change is not notable enough for CHANGELOG and no change is needed to README.

### Checklist

* [x] Have tests been added to cover any changes?
* [X] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [X] Has the README been updated (if needed)?
