### PR TITLE
Add ordering to cancelled omis order report.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-02-20
+
+### Changed
+
+- Order cancelled omis orders by cancelled date
+
+
 ## 2020-02-13
 
 ### Added

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -83,6 +83,7 @@ class DataHubOMISCancelledOrdersCSVPipeline(BaseMonthlyCSVPipeline):
         LEFT JOIN teams_dataset ON omis.dit_team_id=teams_dataset.id
         WHERE omis.order_status = 'cancelled'
         AND omis.cancelled_date_financial_year = omis.current_financial_year
+        ORDER BY omis_dataset.cancelled_date
     '''
 
 

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -83,7 +83,7 @@ class DataHubOMISCancelledOrdersCSVPipeline(BaseMonthlyCSVPipeline):
         LEFT JOIN teams_dataset ON omis.dit_team_id=teams_dataset.id
         WHERE omis.order_status = 'cancelled'
         AND omis.cancelled_date_financial_year = omis.current_financial_year
-        ORDER BY omis_dataset.cancelled_date
+        ORDER BY omis.cancelled_date
     '''
 
 


### PR DESCRIPTION
This was removed accidentally in the switch to csv outputs

### Description of change

Add ordering back to cancelled omis orders report.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
