### PR TITLE
Bugfix/fdi report end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## 2020-02-25
+
+### Changed
+
+- Set monthly static fdi report window to end of the current month
+
+
 ## 2020-02-24
 
 ### Changed

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -503,7 +503,7 @@ class DataHubFDIMonthlyStaticCSVPipeline(BaseMonthlyCSVPipeline):
                 AND LOWER(fdi.status) IN ('ongoing', 'won')
             )
             OR (
-                (fdi.modified_on BETWEEN (date_trunc('month', :run_date) - interval '1 year') and date_trunc('month', :run_date))
+                (fdi.modified_on BETWEEN (date_trunc('month', :run_date) - interval '1 year') and date_trunc('month', :run_date) + interval '1 month')
                 AND LOWER(fdi.status) NOT IN ('ongoing', 'won')
             )
             ORDER BY fdi.actual_land_date, fdi.estimated_land_date ASC


### PR DESCRIPTION
### Description of change

Ensure that the end date of the fdi report is the last day of the month that the DAG is being executed for.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
