### PR TITLE
Added indexes to WorldBankTariffPipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-03-03
 
+### Changed
+
+- Updated World bank tariff pipeline
+    - removed prf_rate
+    - added indexes to partner, reporter, product and year columns
+
+
+## 2020-03-03
+
 ### Added
 
 - World bank tariff (data-store-service) pipeline

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -687,16 +687,16 @@ class WorldBankTariffPipeline(_DatasetPipeline):
 
     table_name = 'world_bank_tariffs'
     source_url = f'{config.DATA_STORE_SERVICE_BASE_URL}/api/v1/get-world-bank-tariffs/?orientation=records'
+    allow_null_columns = True
     field_mapping = [
         ('appRate', sa.Column('app_rate', sa.Numeric)),
         ('assumedTariff', sa.Column('assumed_tariff', sa.Numeric)),
         ('bndRate', sa.Column('bnd_rate', sa.Numeric)),
         ('countryAverage', sa.Column('country_average', sa.Numeric)),
         ('mfnRate', sa.Column('mfn_rate', sa.Numeric)),
-        ('partner', sa.Column('partner', sa.Integer)),
-        ('prfRate', sa.Column('prf_rate', sa.Numeric)),
-        ('product', sa.Column('product', sa.Integer)),
-        ('reporter', sa.Column('reporter', sa.Integer)),
+        ('partner', sa.Column('partner', sa.Integer, index=True)),
+        ('product', sa.Column('product', sa.Integer, index=True)),
+        ('reporter', sa.Column('reporter', sa.Integer, index=True)),
         ('worldAverage', sa.Column('world_average', sa.Numeric)),
-        ('year', sa.Column('year', sa.Integer)),
+        ('year', sa.Column('year', sa.Integer, index=True)),
     ]


### PR DESCRIPTION
### Description of change
This change adds indexes to several columns on the world_bank_tariffs table and removes the prf_rate column. 

I tested this locally and the indexes are created without issue the only concern I had is when the tables get swapped and renamed. The indexes will keep their original names (like sequences currently do) but I don't think this will be an issue as the temp tables are named with a timestamp so next run will be able to create indexes without issue. 


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
