### PR TITLE
Data Hub SPI Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-03-12
+
+### Changed
+
+- Fix operator log messages not being included in task S3 logs
+
+
 ## 2020-03-11
 
 ### Added
@@ -11,11 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `TableConfig` as the canonical way to specify how data is pulled into SQL tables. This includes the ability to handle nested (and deeply nested) related resources.
 - A pipeline for Data Hub Service Performance Indicator (SPI) Investment Reports.
 
-## 2020-03-12
-
 ### Changed
 
-- Fix operator log messages not being included in task S3 logs
+- The existing `AdvisorDatasetPipeline` to use the new `TableConfig` process.
 
 
 ## 2020-03-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-03-11
+
+### Added
+
+- `TableConfig` as the canonical way to specify how data is pulled into SQL tables. This includes the ability to handle nested (and deeply nested) related resources.
+- A pipeline for Data Hub Service Performance Indicator (SPI) Investment Reports.
 
 ## 2020-03-12
 

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -14,7 +14,7 @@ from dataflow.operators.db_tables import (
     create_temp_tables,
     drop_temp_tables,
     insert_data_into_db,
-    swap_dataset_table,
+    swap_dataset_tables,
 )
 from dataflow.utils import FieldMapping
 
@@ -125,9 +125,9 @@ class _PipelineDAG(metaclass=PipelineMeta):
             op_kwargs={'allow_null_columns': self.allow_null_columns},
         )
 
-        _swap_dataset_table = PythonOperator(
+        _swap_dataset_tables = PythonOperator(
             task_id="swap-dataset-table",
-            python_callable=swap_dataset_table,
+            python_callable=swap_dataset_tables,
             provide_context=True,
             op_args=[self.target_db, self.table],
         )
@@ -144,7 +144,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
             [_fetch, _create_tables]
             >> _insert_into_temp_table
             >> _check_tables
-            >> _swap_dataset_table
+            >> _swap_dataset_tables
             >> _drop_tables
         )
 

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -1,7 +1,7 @@
 import sys
 
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, Sequence
 
 import sqlalchemy as sa
 from airflow import DAG
@@ -16,7 +16,7 @@ from dataflow.operators.db_tables import (
     insert_data_into_db,
     swap_dataset_tables,
 )
-from dataflow.utils import FieldMapping
+from dataflow.utils import TableConfig, SingleTableFieldMapping
 
 
 class PipelineMeta(type):
@@ -56,12 +56,16 @@ class _PipelineDAG(metaclass=PipelineMeta):
     # have at least one non-null value
     allow_null_columns: bool = False
 
+    # ∨∨∨∨∨ DEPRECATED - USE `table_config` BELOW ∨∨∨∨∨
     # A list of (field/path, Column) pairs, defining which source data
     # keys end up in which DB columns. Each field/path can be one of:
     # * None (indicating an autopopulated field like an auto-increment primary key))
     # * A string for a top-level key access
     # * A tuple of strings or integers for a nested key access
-    field_mapping: FieldMapping
+    field_mapping: SingleTableFieldMapping
+    # ∧∧∧∧∧ DEPRECATED ∧∧∧∧∧
+
+    table_config: Optional[TableConfig] = None
 
     def get_fetch_operator(self) -> PythonOperator:
         raise NotImplementedError(
@@ -69,16 +73,22 @@ class _PipelineDAG(metaclass=PipelineMeta):
         )
 
     @property
-    def table(self) -> sa.Table:
-        if not hasattr(self, "_table"):
-            meta = sa.MetaData()
-            self._table = sa.Table(
-                self.table_name,
-                meta,
-                *[column.copy() for _, column in self.field_mapping],
-            )
+    def tables(self) -> Sequence[sa.Table]:
+        if not hasattr(self, "_tables"):
+            if self.table_config:
+                self._tables = self.table_config.tables
 
-        return self._table
+            else:
+                meta = sa.MetaData()
+                self._tables = [
+                    sa.Table(
+                        self.table_name,
+                        meta,
+                        *[column.copy() for _, column in self.field_mapping],
+                    )
+                ]
+
+        return self._tables
 
     def get_dag(self) -> DAG:
         dag = DAG(
@@ -106,7 +116,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
             task_id="create-temp-tables",
             python_callable=create_temp_tables,
             provide_context=True,
-            op_args=[self.target_db, self.table],
+            op_args=[self.target_db, *self.tables],
             dag=dag,
         )
 
@@ -114,14 +124,23 @@ class _PipelineDAG(metaclass=PipelineMeta):
             task_id="insert-into-temp-table",
             python_callable=insert_data_into_db,
             provide_context=True,
-            op_args=[self.target_db, self.table, self.field_mapping],
+            op_args=(
+                []
+                if self.table_config
+                else [self.target_db, *self.tables, self.field_mapping]
+            ),
+            op_kwargs=(
+                dict(target_db=self.target_db, table_config=self.table_config)
+                if self.table_config
+                else []
+            ),
         )
 
         _check_tables = PythonOperator(
             task_id="check-temp-table-data",
             python_callable=check_table_data,
             provide_context=True,
-            op_args=[self.target_db, self.table],
+            op_args=[self.target_db, *self.tables],
             op_kwargs={'allow_null_columns': self.allow_null_columns},
         )
 
@@ -129,7 +148,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
             task_id="swap-dataset-table",
             python_callable=swap_dataset_tables,
             provide_context=True,
-            op_args=[self.target_db, self.table],
+            op_args=[self.target_db, *self.tables],
         )
 
         _drop_tables = PythonOperator(
@@ -137,7 +156,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
             python_callable=drop_temp_tables,
             provide_context=True,
             trigger_rule="all_done",
-            op_args=[self.target_db, self.table],
+            op_args=[self.target_db, *self.tables],
         )
 
         (

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from dataflow import config
 from dataflow.dags import _PipelineDAG
 from dataflow.operators.dataset import fetch_from_api
+from dataflow.utils import TableConfig
 
 
 class _DatasetPipeline(_PipelineDAG):
@@ -337,18 +338,23 @@ class CompaniesDatasetPipeline(_DatasetPipeline):
 class AdvisersDatasetPipeline(_DatasetPipeline):
     """Pipeline meta object for AdvisersDataset."""
 
-    table_name = 'advisers_dataset'
     source_url = '{0}/v4/dataset/advisers-dataset'.format(config.DATAHUB_BASE_URL)
-    field_mapping = [
-        ('id', sa.Column('id', UUID, primary_key=True)),
-        ('date_joined', sa.Column('date_joined', sa.Date)),
-        ('first_name', sa.Column('first_name', sa.String)),
-        ('last_name', sa.Column('last_name', sa.String)),
-        ('telephone_number', sa.Column('telephone_number', sa.String)),
-        ('contact_email', sa.Column('contact_email', sa.String)),
-        ('dit_team_id', sa.Column('team_id', UUID)),
-        ('is_active', sa.Column('is_active', sa.Boolean)),
-    ]
+    table_config = TableConfig(
+        table_name='advisers_dataset',
+        field_mapping=[
+            ('id', sa.Column('id', UUID, primary_key=True)),
+            ('date_joined', sa.Column('date_joined', sa.Date)),
+            ('first_name', sa.Column('first_name', sa.String)),
+            ('last_name', sa.Column('last_name', sa.String)),
+            ('telephone_number', sa.Column('telephone_number', sa.String)),
+            ('contact_email', sa.Column('contact_email', sa.String)),
+            ('dit_team_id', sa.Column('team_id', UUID)),
+            ('is_active', sa.Column('is_active', sa.Boolean)),
+        ],
+    )
+    table_name = (
+        table_config.table_name
+    )  # TODO: Remove me when all `_DatasetPipeline` sub-classes use table_config.
 
 
 class TeamsDatasetPipeline(_DatasetPipeline):

--- a/dataflow/dags/spi_pipeline.py
+++ b/dataflow/dags/spi_pipeline.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+
+
+import sqlalchemy as sa
+from airflow.operators.python_operator import PythonOperator
+from sqlalchemy.dialects.postgresql import UUID
+
+from dataflow import config
+from dataflow.dags import _PipelineDAG
+from dataflow.operators.dataset import fetch_from_api
+from dataflow.transforms import drop_empty_string_fields
+from dataflow.utils import TableConfig
+
+
+class DataHubSPIPipeline(_PipelineDAG):
+    target_db = config.DATASETS_DB_NAME
+    source_url = '{0}/v4/dataset/investment-projects-activity-dataset'.format(
+        config.DATAHUB_BASE_URL
+    )
+    start_date = datetime(2020, 2, 23)
+    end_date = None
+    schedule_interval = '@daily'
+    catchup = False
+    table_config = TableConfig(
+        table_name="datahub_spi",
+        transforms=[drop_empty_string_fields],
+        field_mapping=[
+            ("aftercare_offered_on", sa.Column("aftercare_offered_on", sa.DateTime)),
+            ("assigned_to_ist", sa.Column("assigned_to_ist", sa.DateTime)),
+            ("enquiry_processed", sa.Column("enquiry_processed", sa.DateTime)),
+            ("enquiry_processed_by_id", sa.Column("enquiry_processed_by", sa.Text)),
+            ("enquiry_type", sa.Column("enquiry_type", sa.Text)),
+            ("investment_project_id", sa.Column("investment_project_id", UUID)),
+            (
+                'project_manager_assigned',
+                sa.Column('project_manager_assigned', sa.Text),
+            ),
+            (
+                'project_manager_assigned_by_id',
+                sa.Column('project_manager_assigned_by', sa.Text),
+            ),
+            ('project_moved_to_won', sa.Column('project_moved_to_won', sa.DateTime)),
+            (
+                "propositions",
+                TableConfig(
+                    table_name="datahub_spi_propositions",
+                    transforms=[
+                        drop_empty_string_fields,
+                        lambda record, table_config, contexts: {
+                            **record,
+                            "investment_project_id": contexts[0][
+                                "investment_project_id"
+                            ],
+                        },
+                    ],
+                    field_mapping=[
+                        ("adviser_id", sa.Column("adviser_id", UUID)),
+                        ("deadline", sa.Column("deadline", sa.Date)),
+                        (
+                            "investment_project_id",
+                            sa.Column("investment_project_id", UUID),
+                        ),
+                        ("modified_on", sa.Column("modified_on", sa.DateTime)),
+                        ("status", sa.Column("status", sa.Text)),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+    def get_fetch_operator(self) -> PythonOperator:
+        return PythonOperator(
+            task_id='run-fetch',
+            python_callable=fetch_from_api,
+            provide_context=True,
+            op_args=[self.table_config.table.name, self.source_url],
+        )
+
+
+globals()['DataHubSPIPipeline__dag'] = DataHubSPIPipeline().get_dag()

--- a/dataflow/transforms.py
+++ b/dataflow/transforms.py
@@ -1,0 +1,22 @@
+from typing import Tuple, Dict
+
+from dataflow.utils import TableConfig
+
+
+def drop_empty_string_fields(
+    record: dict, mapping: TableConfig, contexts: Tuple[Dict, ...]
+) -> Dict:
+    """Remove keys (and nested keys) from this dictionary where the value is an empty string
+    """
+
+    def _drop_keys_with_empty_string_values(obj):
+        if type(obj) is dict:
+            return {
+                key: _drop_keys_with_empty_string_values(value)
+                for key, value in obj.items()
+                if value != ""
+            }
+
+        return obj
+
+    return _drop_keys_with_empty_string_values(record)

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -2,17 +2,135 @@
 
 import json
 import logging
-from typing import Any, List, Tuple, Union
+from dataclasses import dataclass
+from itertools import chain
+from typing import (
+    Any,
+    Tuple,
+    Union,
+    Iterable,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+)
 
 import sqlalchemy
 from airflow.hooks.S3_hook import S3Hook
+from cached_property import cached_property
 
 from dataflow import config
 
 
-FieldMapping = List[
+# This describes how a blob of data relates to our desired DB structure. This is generally just in a single table,
+# but if the response contains nested records then the FieldMapping can also include further `TableConfig` instances
+# to describe the shape of the related tables.
+FieldMapping = Sequence[
+    Tuple[
+        Union[str, Tuple[Union[str, int], ...], None],
+        Union[sqlalchemy.Column, "TableConfig"],
+    ]
+]
+
+# The below SingleTableFieldMapping describes only a single table, so only contains columns. It should not have
+# any other `TableConfig`s.
+SingleTableFieldMapping = Sequence[
     Tuple[Union[str, Tuple[Union[str, int], ...], None], sqlalchemy.Column]
 ]
+
+TableMapping = Sequence[
+    Tuple[Union[str, Tuple[Union[str, int], ...], None], "TableConfig"]
+]
+
+
+@dataclass
+class TableConfig:
+    """Wrapper for all the information needed to define how data (e.g. from an API) should be processed and
+    ingested into a database, including which fields to pull out and any transformations to apply.
+    """
+
+    table_name: str
+
+    # A list of (field/path, Column/TableConfig) pairs, defining which source data
+    # keys end up in which DB columns. Each field/path can be one of:
+    # * None (indicating an autopopulated field like an auto-increment primary key))
+    # * A string for a top-level key access
+    # * A tuple of strings or integers for a nested key access
+    #
+    # If the second element is another TableConfig, it implies that the first element points to an iterable which
+    # should be pulled into an additional table with the field mapping specified in that TableConfig. If sub-resources
+    # do not have a reference to the main record, you'll need to apply a custom transform to pull that data in.
+    # See DataHubSPIPipeline for an example.
+    field_mapping: FieldMapping
+
+    transforms: Iterable[
+        Callable[[Dict, "TableConfig", Tuple[Dict, ...]], Dict]
+    ] = tuple()
+    temp_table_suffix: Optional[str] = None
+
+    _table = None
+    _temp_table = None
+
+    @cached_property
+    def columns(self) -> SingleTableFieldMapping:
+        return [
+            pair for pair in self.field_mapping if not isinstance(pair[1], TableConfig)
+        ]
+
+    @cached_property
+    def related_table_configs(self,) -> TableMapping:
+        """Return directly-related TableConfigs, as a sequence of (key, TableConfig) pairs"""
+        return [
+            (key, column_or_table_config)
+            for key, column_or_table_config in self.field_mapping
+            if isinstance(column_or_table_config, TableConfig)
+        ]
+
+    @property
+    def tables(self) -> Sequence[sqlalchemy.Table]:
+        """Return all tables this TableConfig has information about, including this instance's table as well as
+        deeply related tables.
+        """
+        return [self.table] + list(
+            chain.from_iterable(
+                table_config.tables for key, table_config in self.related_table_configs
+            )
+        )
+
+    @property
+    def table(self) -> sqlalchemy.Table:
+        """Returns the immediate table this TableConfig has information about, excluding any related tables."""
+        if self._table is None:
+            self._table = sqlalchemy.Table(
+                self.table_name,
+                sqlalchemy.MetaData(),
+                *[column.copy() for _, column in self.columns],
+            )
+        return self._table
+
+    @property
+    def temp_table(self):
+        if not self.temp_table_suffix:
+            raise RuntimeError(
+                "`temp_table_suffix` is not set. "
+                "You need to call `table_config.configure(**kwargs)` before accessing this attribute."
+            )
+
+        if self._temp_table is None:
+            self._temp_table = sqlalchemy.Table(
+                f"{self.table.name}_{self.temp_table_suffix}".lower(),
+                self.table.metadata,
+                *[column.copy() for column in self.table.columns],
+            )
+
+        return self._temp_table
+
+    def configure(self, **kwargs):
+        self.temp_table_suffix = kwargs["ts_nodash"]
+
+        if self.related_table_configs:
+            for _, related_table in self.related_table_configs:
+                related_table.configure(**kwargs)
 
 
 logger = logging.getLogger('dataflow')

--- a/tests/operators/test_db_tables.py
+++ b/tests/operators/test_db_tables.py
@@ -130,26 +130,27 @@ def test_check_table_data(mock_db_conn, mocker, table):
     check_table.assert_called_once_with(mock.ANY, mock_db_conn, mock.ANY, table, False)
 
 
-def test_swap_dataset_table(mock_db_conn, table):
+def test_swap_dataset_tables(mock_db_conn, table):
     mock_db_conn.execute().fetchall.return_value = (('testuser',),)
-    db_tables.swap_dataset_table("test-db", table, ts_nodash="123")
+    db_tables.swap_dataset_tables("test-db", table, ts_nodash="123")
     mock_db_conn.execute.assert_has_calls(
         [
+            call(),
             call(
                 '''
-            SELECT grantee
-            FROM information_schema.role_table_grants
-            WHERE table_name='QUOTED<test_table>'
-            AND privilege_type = 'SELECT'
-            AND grantor != grantee
-            '''
+                SELECT grantee
+                FROM information_schema.role_table_grants
+                WHERE table_name='QUOTED<test_table>'
+                AND privilege_type = 'SELECT'
+                AND grantor != grantee
+                '''
             ),
             call().fetchall(),
             call(
                 '''
-            ALTER TABLE IF EXISTS QUOTED<test_table> RENAME TO QUOTED<test_table_123_swap>;
-            ALTER TABLE QUOTED<test_table_123> RENAME TO QUOTED<test_table>;
-            '''
+                ALTER TABLE IF EXISTS QUOTED<test_table> RENAME TO QUOTED<test_table_123_swap>;
+                ALTER TABLE QUOTED<test_table_123> RENAME TO QUOTED<test_table>;
+                '''
             ),
             call('GRANT SELECT ON QUOTED<test_table> TO testuser'),
         ]

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -7,6 +7,7 @@ from dataflow.dags import (
     company_matching,
     dataset_pipelines,
     ons_pipelines,
+    spi_pipeline,
 )
 from dataflow.dags.csv_pipelines import (
     csv_pipelines_daily,
@@ -38,6 +39,7 @@ def test_canary_tweets():
         csv_refresh_pipeline,
         dataset_pipelines,
         ons_pipelines,
+        spi_pipeline,
     ],
 )
 def test_pipelines_dags(module):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,27 @@
+import pytest
+
+from dataflow.transforms import drop_empty_string_fields
+from dataflow.utils import TableConfig
+
+
+@pytest.mark.parametrize(
+    "input_data, expected_data",
+    (
+        ({"key": "value"}, {"key": "value"}),
+        ({"key": "value", "blank": ""}, {"key": "value"}),
+        ({"key": "value", "empty_list": []}, {"key": "value", "empty_list": []}),
+        ({"key": "value", "empty_dict": {}}, {"key": "value", "empty_dict": {}}),
+        ({"key": "value", "space": " "}, {"key": "value", "space": " "}),
+        (
+            {"key": "value", "nested": {"key": "value"}},
+            {"key": "value", "nested": {"key": "value"}},
+        ),
+        (
+            {"key": "value", "nested": {"key": "value", "blank": ""}},
+            {"key": "value", "nested": {"key": "value"}},
+        ),
+    ),
+)
+def test_drop_empty_string_fields(input_data, expected_data):
+    table_config = TableConfig(table_name="foo", field_mapping=[])
+    assert drop_empty_string_fields(input_data, table_config, tuple()) == expected_data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,7 +147,7 @@ class TestTableConfig:
                             foo_col,
                             (
                                 "bar",
-                                TableConfig(table_name="bar", field_mapping=[bar_col,]),
+                                TableConfig(table_name="bar", field_mapping=[bar_col]),
                             ),
                         ],
                     ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 import pytest
+import sqlalchemy
+from sqlalchemy import Column, Integer, String
 
 from dataflow import utils
+from dataflow.utils import TableConfig
 
 
 @pytest.mark.parametrize(
@@ -68,3 +71,102 @@ def test_s3_data_iter_keys(mocker):
     mock_list.assert_called_once_with(
         bucket_name="test-bucket", prefix='import-data/table/20010101/'
     )
+
+
+class TestTableConfig:
+    def test_columns_property_only_returns_immediate_columns(self):
+        id_col = ("id", Column("id", Integer))
+        name_col = ("name", Column("name", String))
+
+        single_table_config = TableConfig(table_name="test", field_mapping=[id_col],)
+
+        nested_table_config = TableConfig(
+            table_name="test",
+            field_mapping=[
+                id_col,
+                (
+                    "relation",
+                    TableConfig(
+                        table_name="relation",
+                        field_mapping=[("foo", Column("foo", String))],
+                    ),
+                ),
+                name_col,
+            ],
+        )
+
+        assert single_table_config.columns == [id_col]
+        assert nested_table_config.columns == [id_col, name_col]
+
+    def test_table_property_returns_sqlalchemy_table(self):
+        single_table_config = TableConfig(
+            table_name="test", field_mapping=[("id", Column("id", Integer))],
+        )
+
+        table = single_table_config.table
+        assert type(table) is sqlalchemy.Table
+        assert {col.name for col in table.columns} == {"id"}
+
+    def test_tables_property_returns_all_tables(self):
+        id_col = ("id", Column("id", Integer))
+        name_col = ("name", Column("name", String))
+        nested_table_config = TableConfig(
+            table_name="test",
+            field_mapping=[
+                id_col,
+                (
+                    "relation",
+                    TableConfig(
+                        table_name="relation",
+                        field_mapping=[("foo", Column("foo", String))],
+                    ),
+                ),
+                name_col,
+            ],
+        )
+
+        tables = nested_table_config.tables
+        assert all(type(table) is sqlalchemy.Table for table in tables)
+        assert [table.name for table in tables] == ["test", "relation"]
+        assert {col.name for col in tables[0].columns} == {"id", "name"}
+        assert {col.name for col in tables[1].columns} == {"foo"}
+
+    def test_related_tables_property_returns_directly_related_tables(self):
+        id_col = ("id", Column("id", Integer))
+        foo_col = ("foo", Column("foo", Integer))
+        bar_col = ("bar", Column("bar", Integer))
+        config = TableConfig(
+            table_name="test",
+            field_mapping=[
+                id_col,
+                (
+                    "foo",
+                    TableConfig(
+                        table_name="foo",
+                        field_mapping=[
+                            foo_col,
+                            (
+                                "bar",
+                                TableConfig(table_name="bar", field_mapping=[bar_col,]),
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        assert len(config.related_table_configs) == 1
+        assert config.related_table_configs[0][0] == "foo"
+        assert type(config.related_table_configs[0][1]) is TableConfig
+        assert config.related_table_configs[0][1].table_name == "foo"
+
+        assert len(config.related_table_configs[0][1].related_table_configs)
+        assert config.related_table_configs[0][1].related_table_configs[0][0] == "bar"
+        assert (
+            type(config.related_table_configs[0][1].related_table_configs[0][1])
+            is TableConfig
+        )
+        assert (
+            config.related_table_configs[0][1].related_table_configs[0][1].table_name
+            == "bar"
+        )


### PR DESCRIPTION
### Description of change
Builds on the fabulous work of @niross in #116, mostly just refactoring away our `field_mapping` class attribute in favour of a `table_config` one, which has a more well-defined process for handling nested relations/resources. This removes a custom SPI operator that knows about the data it's handling in favour of more data-agnostic operators.

As part of this, I've converted the SPI pipeline to use TableConfig. I've also migrated  `AdvisersDatasetPipeline` as well, as a small proof-of-concept for how to migrate a pipeline as well as to help test that the migration doesn't have any issues.

If this migration goes well, I'll look to migrate the rest of the pipelines in one or two more batches so that we can drop the old code/way relatively quickly. But in the mean time a "not-big-bang" transition feels safer.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
