### PR TITLE
Add a dataflow logger for operator logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-03-12
+
+### Changed
+
+- Fix operator log messages not being included in task S3 logs
+
+
 ## 2020-03-03
 
 ### Added

--- a/dataflow/logging_config.py
+++ b/dataflow/logging_config.py
@@ -42,6 +42,7 @@ LOGGING_CONFIG: dict = {
         },
     },
     "loggers": {
+        "dataflow": {"handlers": ["task"], "level": LOG_LEVEL, "propagate": False},
         "airflow.task": {"handlers": ["task"], "level": LOG_LEVEL, "propagate": False},
         "airflow.task_runner": {
             "handlers": ["console"],

--- a/dataflow/operators/activity_stream.py
+++ b/dataflow/operators/activity_stream.py
@@ -1,8 +1,6 @@
-import logging
-
 from dataflow import config
 from dataflow.operators.api import _hawk_api_request
-from dataflow.utils import S3Data
+from dataflow.utils import logger, S3Data
 
 
 def fetch_from_activity_stream(table_name: str, index_name: str, query: dict, **kwargs):
@@ -19,7 +17,7 @@ def fetch_from_activity_stream(table_name: str, index_name: str, query: dict, **
     source_url = f"{config.ACTIVITY_STREAM_BASE_URL}/v3/{index_name}/_search"
 
     while next_page:
-        logging.info(f"Fetching page {next_page} of {source_url}")
+        logger.info(f"Fetching page {next_page} of {source_url}")
         data = _hawk_api_request(
             source_url,
             "GET",
@@ -32,7 +30,7 @@ def fetch_from_activity_stream(table_name: str, index_name: str, query: dict, **
             'hits',
         )
         if "failures" in data["_shards"]:
-            logging.warning(
+            logger.warning(
                 "Request failed on {} shards: {}".format(
                     data['_shards']['failed'], data['_shards']['failures']
                 )
@@ -46,7 +44,7 @@ def fetch_from_activity_stream(table_name: str, index_name: str, query: dict, **
             f"{next_page:010}.json", [item["_source"] for item in data["hits"]["hits"]]
         )
 
-        logging.info(
+        logger.info(
             f"Fetched {len(data['hits']['hits'])} of {data['hits']['total']} records"
         )
 
@@ -55,4 +53,4 @@ def fetch_from_activity_stream(table_name: str, index_name: str, query: dict, **
 
         next_page += 1
 
-    logging.info(f"Fetching from source completed, total {data['hits']['total']}")
+    logger.info(f"Fetching from source completed, total {data['hits']['total']}")

--- a/dataflow/operators/api.py
+++ b/dataflow/operators/api.py
@@ -1,9 +1,10 @@
 import json
-import logging
 
 import backoff
 import requests
 from mohawk import Sender
+
+from dataflow.utils import logger
 
 
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
@@ -29,7 +30,7 @@ def _hawk_api_request(
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logging.error(f"Request failed: {response.text}")
+        logger.error(f"Request failed: {response.text}")
         raise
 
     response_json = response.json()

--- a/dataflow/operators/company_matching.py
+++ b/dataflow/operators/company_matching.py
@@ -1,11 +1,10 @@
-import logging
 import re
 
 from airflow.hooks.postgres_hook import PostgresHook
 
 from dataflow import config
 from dataflow.operators.api import _hawk_api_request
-from dataflow.utils import S3Data
+from dataflow.utils import logger, S3Data
 
 credentials = {
     'id': config.MATCHING_SERVICE_HAWK_ID,
@@ -18,7 +17,7 @@ valid_email = re.compile(r"[^@]+@[^@]+\.[^@]+")
 def fetch_from_company_matching(
     target_db: str, table_name: str, company_match_query: str, batch_size=str, **kwargs
 ):
-    logging.info(f"starting company matching")
+    logger.info(f"starting company matching")
 
     s3 = S3Data(table_name, kwargs["ts_nodash"])
     next_batch = 1
@@ -56,7 +55,7 @@ def _build_request(cursor, batch_size, update):
         rows = cursor.fetchmany(batch_size)
         if not rows:
             break
-        logging.info(
+        logger.info(
             f"matching companies {f'{batch_count*batch_size}-{batch_count*batch_size+len(rows)}'}"
         )
         for row in rows:

--- a/dataflow/operators/csv_outputs.py
+++ b/dataflow/operators/csv_outputs.py
@@ -1,5 +1,4 @@
 import csv
-import logging
 import tempfile
 
 import sqlalchemy as sa
@@ -7,6 +6,7 @@ from airflow.hooks.S3_hook import S3Hook
 from airflow.hooks.postgres_hook import PostgresHook
 
 from dataflow import config
+from dataflow.utils import logger
 
 
 def create_csv(
@@ -51,4 +51,4 @@ def create_csv(
                 bucket_name=config.DATA_WORKSPACE_S3_BUCKET,
                 replace=True,
             )
-            logging.info(f'Wrote {row_count} rows to file {s3_output_path}')
+            logger.info(f'Wrote {row_count} rows to file {s3_output_path}')

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -1,6 +1,7 @@
 """A module that defines useful utils."""
 
 import json
+import logging
 from typing import Any, List, Tuple, Union
 
 import sqlalchemy
@@ -12,6 +13,9 @@ from dataflow import config
 FieldMapping = List[
     Tuple[Union[str, Tuple[Union[str, int], ...], None], sqlalchemy.Column]
 ]
+
+
+logger = logging.getLogger('dataflow')
 
 
 class S3Data:


### PR DESCRIPTION
### Description of change

Airflow upgrade changed something in the logging configuration so
our operator log messages were no longer included in the task logs.

This creates and configures a new `dataflow` logger that should be
used by all operators for logs to be stored and shipped to S3 with
the airflow task logs.


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
