### PR TITLE
Set a monthly schedule for HMRC uktradeinfo data

### DIFF
--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -1,4 +1,6 @@
 """A module that defines Airflow DAGS for HMRC pipelines"""
+from datetime import datetime
+
 import sqlalchemy as sa
 
 from airflow.operators.python_operator import PythonOperator
@@ -11,6 +13,9 @@ class _HMRCPipeline(_PipelineDAG):
     base_filename: str
 
     table_config: TableConfig
+
+    schedule_interval = '0 5 12 * *'
+    start_date = datetime(2020, 3, 11)
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/operators/hmrc.py
+++ b/dataflow/operators/hmrc.py
@@ -7,7 +7,7 @@ import backoff
 import requests
 
 from dataflow import config
-from dataflow.utils import S3Data
+from dataflow.utils import logger, S3Data
 
 
 def fetch_uktradeinfo_non_eu_data(table_name: str, base_filename: str, **kwargs):
@@ -15,9 +15,11 @@ def fetch_uktradeinfo_non_eu_data(table_name: str, base_filename: str, **kwargs)
     # New files are uploaded to uktradeinfo 2 months later, usually on 10th of the month.
     # 45 day offest allows us to pick up new files within 5 days of them being uploaded
     # without parsing the downloads page.
-    run_date = kwargs.get("run_date", kwargs.get("execution_date")) - timedelta(days=45)
+    run_date = kwargs.get("run_date", kwargs.get("execution_date")) - timedelta(days=60)
     filename = f"{base_filename}{run_date:%y%m}"
     source_url = f"{config.HMRC_UKTRADEINFO_URL}/{filename}.zip"
+
+    logger.info(f"Fetching {source_url}")
 
     file_contents = _download(source_url)
 


### PR DESCRIPTION
### Description of change

Data files are uploaded on 11th of each month for the period 2
months before, so we set the job to run once a month on 12th.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
