### PR TITLE
Move local docker-compose ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
-      - "5432:5432"
+      - "15432:5432"
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
 
   data-flow-redis:
     image: redis
     ports: 
-      - "6379:6379"
+      - "16379:6379"
 
   data-flow:
     build:


### PR DESCRIPTION
### Description of change
At the moment, data-workspace and data-flow services (postgres/redis)
both run on the same port for the dev docker-compose file, meaning that
you can't run both at the same time locally.

This moves the local ports for data-flow's postgres and redis containers
up by 10000 so that both can be run at the same time.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
