### PR TITLE
General `fetch from hawk api` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-03-19
+
+### Changed
+
+- Moved datasets `fetch_from_api` to a more general `common.fetch_from_hawk_api`, as there may be a more general case for this.
+
 ## 2020-03-12
 
 ### Changed

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -2,8 +2,11 @@
 import os
 
 ACTIVITY_STREAM_BASE_URL = os.environ.get("ACTIVITY_STREAM_BASE_URL")
-ACTIVITY_STREAM_ID = os.environ.get("ACTIVITY_STREAM_ID", "")
-ACTIVITY_STREAM_SECRET = os.environ.get("ACTIVITY_STREAM_SECRET", "")
+ACTIVITY_STREAM_HAWK_CREDENTIALS = {
+    "id": os.environ.get("ACTIVITY_STREAM_ID", ""),
+    "key": os.environ.get("ACTIVITY_STREAM_SECRET", ""),
+    "algorithm": "sha256",
+}
 ACTIVITY_STREAM_RESULTS_PER_PAGE = os.environ.get(
     "ACTIVITY_STREAM_RESULTS_PER_PAGE", 100
 )
@@ -13,9 +16,11 @@ AUTHBROKER_CLIENT_SECRET = os.environ.get("AUTHBROKER_CLIENT_SECRET")
 AUTHBROKER_ALLOWED_DOMAINS = os.environ.get("AUTHBROKER_ALLOWED_DOMAINS")
 AUTHBROKER_URL = os.environ.get("AUTHBROKER_URL")
 
-HAWK_ID = os.environ.get("HAWK_ID")
-HAWK_KEY = os.environ.get("HAWK_KEY")
-HAWK_ALGORITHM = os.environ.get("HAWK_ALGORITHM", "sha256")
+DATAHUB_HAWK_CREDENTIALS = {
+    "id": os.environ.get("HAWK_ID"),
+    "key": os.environ.get("HAWK_KEY"),
+    "algorithm": "sha256",
+}
 DATAHUB_BASE_URL = os.environ.get("DATAHUB_BASE_URL")
 EXPORT_WINS_BASE_URL = os.environ.get("EXPORT_WINS_BASE_URL")
 
@@ -39,11 +44,11 @@ ONS_SPARQL_URL = os.environ.get(
 MATCHING_SERVICE_BASE_URL = os.environ.get("MATCHING_SERVICE_BASE_URL")
 MATCHING_SERVICE_BATCH_SIZE = int(os.environ.get("MATCHING_SERVICE_BATCH_SIZE", 100000))
 MATCHING_SERVICE_UPDATE = os.environ.get("MATCHING_SERVICE_UPDATE") == "True"
-MATCHING_SERVICE_HAWK_ID = os.environ.get("MATCHING_SERVICE_HAWK_ID")
-MATCHING_SERVICE_HAWK_KEY = os.environ.get("MATCHING_SERVICE_HAWK_KEY")
-MATCHING_SERVICE_HAWK_ALGORITHM = os.environ.get(
-    "MATCHING_SERVICE_HAWK_ALGORITHM", "sha256"
-)
+MATCHING_SERVICE_HAWK_CREDENTIALS = {
+    "id": os.environ.get("MATCHING_SERVICE_HAWK_ID"),
+    "key": os.environ.get("MATCHING_SERVICE_HAWK_KEY"),
+    "algorithm": "sha256",
+}
 
 DATA_WORKSPACE_S3_BUCKET = os.environ.get("DATA_WORKSPACE_S3_BUCKET")
 DATASETS_DB_NAME = os.environ.get("DATASETS_DB_NAME", "datasets_db")

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -1,12 +1,14 @@
 """A module that defines Airflow DAGS for dataset pipelines."""
+from functools import partial
 
 import sqlalchemy as sa
 from airflow.operators.python_operator import PythonOperator
 from sqlalchemy.dialects.postgresql import UUID
 
 from dataflow import config
+from dataflow.config import DATAHUB_HAWK_CREDENTIALS
 from dataflow.dags import _PipelineDAG
-from dataflow.operators.dataset import fetch_from_api
+from dataflow.operators.common import fetch_from_hawk_api
 from dataflow.utils import TableConfig
 
 
@@ -18,7 +20,9 @@ class _DatasetPipeline(_PipelineDAG):
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(
             task_id='run-fetch',
-            python_callable=fetch_from_api,
+            python_callable=partial(
+                fetch_from_hawk_api, hawk_credentials=DATAHUB_HAWK_CREDENTIALS
+            ),
             provide_context=True,
             op_args=[self.table_name, self.source_url],
         )

--- a/dataflow/dags/spi_pipeline.py
+++ b/dataflow/dags/spi_pipeline.py
@@ -1,13 +1,14 @@
 from datetime import datetime
-
+from functools import partial
 
 import sqlalchemy as sa
 from airflow.operators.python_operator import PythonOperator
 from sqlalchemy.dialects.postgresql import UUID
 
 from dataflow import config
+from dataflow.config import DATAHUB_HAWK_CREDENTIALS
 from dataflow.dags import _PipelineDAG
-from dataflow.operators.dataset import fetch_from_api
+from dataflow.operators.common import fetch_from_hawk_api
 from dataflow.transforms import drop_empty_string_fields
 from dataflow.utils import TableConfig
 
@@ -71,7 +72,9 @@ class DataHubSPIPipeline(_PipelineDAG):
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(
             task_id='run-fetch',
-            python_callable=fetch_from_api,
+            python_callable=partial(
+                fetch_from_hawk_api, hawk_credentials=DATAHUB_HAWK_CREDENTIALS
+            ),
             provide_context=True,
             op_args=[self.table_config.table.name, self.source_url],
         )

--- a/dataflow/operators/activity_stream.py
+++ b/dataflow/operators/activity_stream.py
@@ -1,4 +1,5 @@
 from dataflow import config
+from dataflow.config import ACTIVITY_STREAM_HAWK_CREDENTIALS
 from dataflow.operators.api import _hawk_api_request
 from dataflow.utils import logger, S3Data
 
@@ -19,15 +20,7 @@ def fetch_from_activity_stream(table_name: str, index_name: str, query: dict, **
     while next_page:
         logger.info(f"Fetching page {next_page} of {source_url}")
         data = _hawk_api_request(
-            source_url,
-            "GET",
-            query,
-            {
-                "id": config.ACTIVITY_STREAM_ID,
-                "key": config.ACTIVITY_STREAM_SECRET,
-                "algorithm": config.HAWK_ALGORITHM,
-            },
-            'hits',
+            source_url, "GET", query, ACTIVITY_STREAM_HAWK_CREDENTIALS, 'hits',
         )
         if "failures" in data["_shards"]:
             logger.warning(

--- a/dataflow/operators/company_matching.py
+++ b/dataflow/operators/company_matching.py
@@ -3,14 +3,10 @@ import re
 from airflow.hooks.postgres_hook import PostgresHook
 
 from dataflow import config
+from dataflow.config import DATAHUB_HAWK_CREDENTIALS
 from dataflow.operators.api import _hawk_api_request
 from dataflow.utils import logger, S3Data
 
-credentials = {
-    'id': config.MATCHING_SERVICE_HAWK_ID,
-    'key': config.MATCHING_SERVICE_HAWK_KEY,
-    'algorithm': config.MATCHING_SERVICE_HAWK_ALGORITHM,
-}
 valid_email = re.compile(r"[^@]+@[^@]+\.[^@]+")
 
 
@@ -36,7 +32,7 @@ def fetch_from_company_matching(
                 url=f'{config.MATCHING_SERVICE_BASE_URL}/api/v1/company/{match_type}/',
                 method='POST',
                 query=request,
-                credentials=credentials,
+                credentials=DATAHUB_HAWK_CREDENTIALS,
                 expected_response_structure='matches',
             )
             s3.write_key(f"{next_batch:010}.json", data['matches'])

--- a/tests/operators/test_activity_stream.py
+++ b/tests/operators/test_activity_stream.py
@@ -3,14 +3,8 @@ from unittest import mock
 import pytest
 from requests.exceptions import HTTPError
 
-from dataflow import config
+from dataflow.config import ACTIVITY_STREAM_HAWK_CREDENTIALS
 from dataflow.operators import activity_stream, api
-
-credentials = {
-    'id': config.ACTIVITY_STREAM_ID,
-    'key': config.ACTIVITY_STREAM_SECRET,
-    'algorithm': 'sha256',
-}
 
 
 def test_activity_stream_request(requests_mock):
@@ -20,14 +14,16 @@ def test_activity_stream_request(requests_mock):
         json={'hits': []},
     )
 
-    api._hawk_api_request('http://test', "GET", {}, credentials)
+    api._hawk_api_request('http://test', "GET", {}, ACTIVITY_STREAM_HAWK_CREDENTIALS)
 
 
 def test_activity_stream_request_raises_error_without_hits(requests_mock):
     requests_mock.get('http://test', json={})
 
     with pytest.raises(ValueError):
-        api._hawk_api_request('http://test', "GET", {}, credentials, 'hits')
+        api._hawk_api_request(
+            'http://test', "GET", {}, ACTIVITY_STREAM_HAWK_CREDENTIALS, 'hits'
+        )
 
 
 def test_activity_stream_request_raises_for_non_2xx_status(mocker, requests_mock):
@@ -35,7 +31,9 @@ def test_activity_stream_request_raises_for_non_2xx_status(mocker, requests_mock
     requests_mock.get('http://test', status_code=404)
 
     with pytest.raises(HTTPError):
-        api._hawk_api_request('http://test', "GET", {}, credentials)
+        api._hawk_api_request(
+            'http://test', "GET", {}, ACTIVITY_STREAM_HAWK_CREDENTIALS
+        )
 
 
 def test_fetch_from_activity_stream(mocker):
@@ -69,7 +67,7 @@ def test_fetch_from_activity_stream(mocker):
                 'http://test/v3/index/_search',
                 'GET',
                 {'query': {}, 'size': 100, 'sort': [{'id': 'asc'}]},
-                credentials,
+                ACTIVITY_STREAM_HAWK_CREDENTIALS,
                 'hits',
             ),
             mock.call(
@@ -81,7 +79,7 @@ def test_fetch_from_activity_stream(mocker):
                     'sort': [{'id': 'asc'}],
                     'search_after': [120],
                 },
-                credentials,
+                ACTIVITY_STREAM_HAWK_CREDENTIALS,
                 'hits',
             ),
             mock.call(
@@ -93,7 +91,7 @@ def test_fetch_from_activity_stream(mocker):
                     'sort': [{'id': 'asc'}],
                     'search_after': [240],
                 },
-                credentials,
+                ACTIVITY_STREAM_HAWK_CREDENTIALS,
                 'hits',
             ),
         ]


### PR DESCRIPTION
### Description of change
Both Data Hub and Market Access are Hawk-authenticated APIs that can be
iterated over in similar ways, so this strips out the datahub-specific
config and allows passing in any hawk credentials and the response keys
to look for when iterating through pages.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
