### PR TITLE
Fix company matching pipeline

### DIFF
--- a/dataflow/dags/company_matching.py
+++ b/dataflow/dags/company_matching.py
@@ -19,18 +19,21 @@ from dataflow.utils import TableConfig
 
 class _CompanyMatchingPipeline(_PipelineDAG):
     timeout: int = 7200
-    table_config = TableConfig(
-        table_name='set-by-get-dag-method',
-        field_mapping=[
-            ("id", sa.Column("id", sa.Text, primary_key=True)),
-            ("match_id", sa.Column("match_id", sa.Integer)),
-            ("similarity", sa.Column("similarity", sa.Text)),
-        ],
-    )
 
     company_match_query: str
     controller_pipeline: Type[_PipelineDAG]
     dependencies: List[Type[_PipelineDAG]] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.table_config = TableConfig(
+            table_name='set-by-get-dag-method',
+            field_mapping=[
+                ("id", sa.Column("id", sa.Text, primary_key=True)),
+                ("match_id", sa.Column("match_id", sa.Integer)),
+                ("similarity", sa.Column("similarity", sa.Text)),
+            ],
+        )
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/operators/company_matching.py
+++ b/dataflow/operators/company_matching.py
@@ -3,7 +3,7 @@ import re
 from airflow.hooks.postgres_hook import PostgresHook
 
 from dataflow import config
-from dataflow.config import DATAHUB_HAWK_CREDENTIALS
+from dataflow.config import MATCHING_SERVICE_HAWK_CREDENTIALS
 from dataflow.operators.api import _hawk_api_request
 from dataflow.utils import logger, S3Data
 
@@ -32,7 +32,7 @@ def fetch_from_company_matching(
                 url=f'{config.MATCHING_SERVICE_BASE_URL}/api/v1/company/{match_type}/',
                 method='POST',
                 query=request,
-                credentials=DATAHUB_HAWK_CREDENTIALS,
+                credentials=MATCHING_SERVICE_HAWK_CREDENTIALS,
                 expected_response_structure='matches',
             )
             s3.write_key(f"{next_batch:010}.json", data['matches'])


### PR DESCRIPTION
Use an instance property rather than a shared class attribute for the
table config on the company matching base pipeline, as the table config
is mutated during the DAG run - so we don't want to change a shared
table config instance.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
