### PR TITLE
Log dataflow task output to stdout

### DIFF
--- a/dataflow/logging_config.py
+++ b/dataflow/logging_config.py
@@ -42,7 +42,11 @@ LOGGING_CONFIG: dict = {
         },
     },
     "loggers": {
-        "dataflow": {"handlers": ["task"], "level": LOG_LEVEL, "propagate": False},
+        "dataflow": {
+            "handlers": ["task", "console"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
         "airflow.task": {"handlers": ["task"], "level": LOG_LEVEL, "propagate": False},
         "airflow.models.dagbag": {"level": DAG_PARSING_LOG_LEVEL},
         "airflow.processor": {"level": DAG_PARSING_LOG_LEVEL},


### PR DESCRIPTION
### Description of change
We recently reduced airflow's logging to stdout to remove spam, mostly
in development environments. It still feels useful to have actual task
output logged to stdout though (e.g. "fetched page x", "processed x
records").

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
