### PR TITLE
Reduce default pool slots to 16 by default

### DIFF
--- a/bin/airflow-scheduler.sh
+++ b/bin/airflow-scheduler.sh
@@ -2,6 +2,7 @@
 
 airflow upgradedb
 
+airflow pool -s default_pool ${AIRFLOW_DEFAULT_POOL_SLOTS:-16} "Main tasks"
 airflow pool -s sensors ${AIRFLOW_SENSORS_POOL_SLOTS:-16} "External task sensors"
 
 airflow scheduler


### PR DESCRIPTION
### Description of change

With global task parallelism set to 32 this gives us 16 task slots
and 16 sensor ones.

We don't want to set tasks any higher for the moment since some of
them are memory intensive and can cause an OOM.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
