### PR TITLE
Add 10 minute statement timeout to DB table operators

### DIFF
--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -55,6 +55,7 @@ def create_temp_tables(target_db: str, *tables: sa.Table, **kwargs):
     )
 
     with engine.begin() as conn:
+        conn.execute("SET statement_timeout = 600000")
         for table in tables:
             table = _get_temp_table(table, kwargs["ts_nodash"])
             logger.info(f"Creating {table.name}")
@@ -290,6 +291,7 @@ def swap_dataset_tables(target_db: str, *tables: sa.Table, **kwargs):
 
         logger.info(f"Moving {temp_table.name} to {table.name}")
         with engine.begin() as conn:
+            conn.execute("SET statement_timeout = 600000")
             grantees = conn.execute(
                 """
                 SELECT grantee
@@ -339,6 +341,7 @@ def drop_temp_tables(target_db: str, *tables, **kwargs):
         creator=PostgresHook(postgres_conn_id=target_db).get_conn,
     )
     with engine.begin() as conn:
+        conn.execute("SET statement_timeout = 600000")
         for table in tables:
             temp_table = _get_temp_table(table, kwargs["ts_nodash"])
             logger.info(f"Removing {temp_table.name}")
@@ -357,6 +360,7 @@ def drop_swap_tables(target_db: str, *tables, **kwargs):
         creator=PostgresHook(postgres_conn_id=target_db).get_conn,
     )
     with engine.begin() as conn:
+        conn.execute("SET statement_timeout = 600000")
         for table in tables:
             swap_table = _get_temp_table(table, kwargs["ts_nodash"] + "_swap")
             logger.info(f"Removing {swap_table.name}")

--- a/tests/operators/test_db_tables.py
+++ b/tests/operators/test_db_tables.py
@@ -250,6 +250,7 @@ def test_swap_dataset_tables(mock_db_conn, table):
     mock_db_conn.execute.assert_has_calls(
         [
             call(),
+            call('SET statement_timeout = 600000'),
             call(
                 '''
                 SELECT grantee


### PR DESCRIPTION
### Description of change

DB table operations are usually quick, unless they get locked by
a long running transactions, in which case they can get stuck for
hours without alerting anyone.

Airflow `execution_timeout` that we set on these tasks doesn't seem
to work for this specific case. It will interrupt a sleep or a long
running operation, but doesn't seem to be able to interrupt a locked
DB transaction, so we set an additional statement timeout on these.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
