### PR TITLE
Add clearer error for insert step when no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-03
+
+### Changed
+
+- Clearer error when insert task fails due to no data in S3.
+
 ## 2020-03-30
 
 ### Added

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -153,8 +153,10 @@ def insert_data_into_db(
         creator=PostgresHook(postgres_conn_id=target_db).get_conn,
     )
 
+    count = 0
     for page, records in s3.iter_keys():
         logger.info(f'Processing page {page}')
+        count += 1
 
         with engine.begin() as conn:
             if table_config:
@@ -180,6 +182,9 @@ def insert_data_into_db(
                     )
 
         logger.info(f'Page {page} ingested successfully')
+
+    if count == 0:
+        raise MissingDataError("There are no pages of records in S3 to insert.")
 
 
 def _check_table(

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -178,7 +178,7 @@ class S3Data:
             yield key, self.read_key(key, jsonify=json)
 
     def list_keys(self):
-        return self.client.list_keys(bucket_name=self.bucket, prefix=self.prefix)
+        return self.client.list_keys(bucket_name=self.bucket, prefix=self.prefix) or []
 
     def read_key(self, full_key, jsonify=True):
         data = self.client.read_key(full_key, bucket_name=self.bucket)


### PR DESCRIPTION
### Description of change
Adds a specific error for the `insert_data_into_db` task when there's no data in S3.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
