### PR TITLE
ONS UK seasonally adjusted trade in goods CSV pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-04-03
 
+### Added
+
+- Support for dependencies for the CSV pipelines
+- ONSUKSATradeInGoodsCSV pipeline
+
 ### Changed
 
 - Clearer error when insert task fails due to no data in S3.

--- a/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
+++ b/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
@@ -1,0 +1,48 @@
+# This comment brought to you by the ** airflow DAG ** discovery process
+
+from datetime import datetime
+
+from dataflow.dags import _CSVPipelineDAG
+from dataflow.dags.ons_pipelines import ONSUKSATradeInGoodsPipeline
+
+
+class ONSUKSATradeInGoodsCSV(_CSVPipelineDAG):
+    schedule_interval = ONSUKSATradeInGoodsPipeline.schedule_interval
+
+    start_date = datetime(2020, 4, 1)
+    catchup = False
+    static = True
+
+    dependencies = [ONSUKSATradeInGoodsPipeline]
+
+    base_file_name = "ons_uk_sa_trade_in_goods"
+    timestamp_output = False
+
+    query = """
+
+    SELECT
+        import_t.geography_code AS ons_geography_code,
+        import_t.geography_name,
+        CASE
+            WHEN import_t.parent_geography_code = 'B5' THEN 'yes'
+            ELSE 'no'
+        END AS included_in_eu28,
+        import_t.period,
+        CASE
+            WHEN char_length(import_t.period) = 4 THEN 'year'
+            ELSE 'month'
+        END AS period_type,
+        import_t.total AS import,
+        export_t.total AS export,
+        export_t.total + import_t.total AS total_trade,
+        export_t.total - import_t.total AS trade_balance,
+        import_t.unit
+    FROM
+        {{ dependencies[0].table_config.table_name }} import_t INNER JOIN {{ dependencies[0].table_config.table_name }} export_t
+        ON import_t.geography_code = export_t.geography_code AND import_t.period = export_t.period
+    WHERE
+        import_t.direction = 'Imports' AND
+        export_t.direction = 'Exports'
+    ORDER BY
+        import_t.geography_name, import_t.period
+    """

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -28,6 +28,7 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
             (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
             (("period", "value"), sa.Column("period", sa.String)),
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
+            (("geography_code", "value"), sa.Column("geography_code", sa.String)),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
             (("unit", "value"), sa.Column("unit", sa.String)),
@@ -38,7 +39,7 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?period ?geography_name ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    SELECT ?period ?geography_name ?geography_code ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
         ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-sa-trade-in-goods> ;
             <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
             <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s ;
@@ -65,6 +66,7 @@ class ONSUKTradeInGoodsPipeline(_ONSPipeline):
             (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
             (("period", "value"), sa.Column("period", sa.String)),
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
+            (("geography_code", "value"), sa.Column("geography_code", sa.String)),
             (("product", "value"), sa.Column("product", sa.String)),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
@@ -97,7 +99,7 @@ class ONSUKTradeInGoodsPipeline(_ONSPipeline):
 
     {% raw %}
 
-    SELECT ?period ?geography_name ?product ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {{
+    SELECT ?period ?geography_name ?geography_code ?product ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {{
 
         BIND(<{compvalue[value]}> AS ?period_s)
 
@@ -127,6 +129,7 @@ class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
         field_mapping=[
             (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
+            (("geography_code", "value"), sa.Column("geography_code", sa.String)),
             (("product_label", "value"), sa.Column("product", sa.String)),
             (("period", "value"), sa.Column("period", sa.String)),
             (("direction", "value"), sa.Column("direction", sa.String)),
@@ -139,7 +142,7 @@ class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?geography_name ?product_label ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    SELECT ?geography_name ?geography_code ?product_label ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
     ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-services> ;
         <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
         <http://gss-data.org.uk/def/dimension/product> ?product_s ;
@@ -147,7 +150,9 @@ class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
         <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
         <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
         <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s .
+
     ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
+    ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
     ?product_s <http://www.w3.org/2000/01/rdf-schema#label> ?product_label .
     ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
     ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
@@ -162,6 +167,7 @@ class ONSUKTotalTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
         field_mapping=[
             (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
+            (("geography_code", "value"), sa.Column("geography_code", sa.String)),
             (("period", "value"), sa.Column("period", sa.String)),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
@@ -173,7 +179,7 @@ class ONSUKTotalTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?geography_name ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    SELECT ?geography_name ?geography_code ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
     ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-total-trade> ;
         <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
         <http://gss-data.org.uk/def/dimension/product> ?product_s ;
@@ -182,6 +188,7 @@ class ONSUKTotalTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
         <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
         <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s .
     ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
+    ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
     ?product_s <http://www.w3.org/2000/01/rdf-schema#label> "Services" .
     ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
     ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -121,48 +121,6 @@ class ONSUKTradeInGoodsPipeline(_ONSPipeline):
     """
 
 
-class ONSUKTradeInGoodsByCommodityPipeline(_ONSPipeline):
-    table_config = TableConfig(
-        table_name="ons_uk_trade_in_goods_by_commodity",
-        field_mapping=[
-            (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
-            (("period", "value"), sa.Column("period", sa.String)),
-            (("geography_name", "value"), sa.Column("geography_name", sa.String)),
-            (("direction", "value"), sa.Column("direction", sa.String)),
-            (("total", "value"), sa.Column("total", sa.Numeric)),
-            (("unit", "value"), sa.Column("unit", sa.String)),
-            (("sic_label", "value"), sa.Column("sector", sa.String)),
-            (("product_label", "value"), sa.Column("product", sa.String)),
-        ],
-    )
-
-    query = """
-    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
-    SELECT ?geography_name ?sic_label ?product_label ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
-        ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-goods-by-industry-country-and-commodity> ;
-        <http://gss-data.org.uk/def/dimension/product> ?product_s ;
-        <http://gss-data.org.uk/def/dimension/sic-industry> ?sic_industry_s ;
-            <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
-            <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s ;
-            <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
-            <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
-            <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> ?period_s .
-
-    ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
-    ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
-    ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
-    ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
-    ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
-    ?sic_industry_s <http://www.w3.org/2000/01/rdf-schema#label> ?sic_label .
-    ?sic_industry_s <http://business.data.gov.uk/companies/def/sic-2007/sicNotation> ?sic_code .
-    ?product_s <http://www.w3.org/2000/01/rdf-schema#label> ?product_label .
-
-    } ORDER BY ?product_s ?sic_industry_s ?geography_s ?period_s
-    """
-
-
 class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     table_config = TableConfig(
         table_name="ons_uk_trade_in_services_by_country",

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -29,6 +29,10 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
             (("period", "value"), sa.Column("period", sa.String)),
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
             (("geography_code", "value"), sa.Column("geography_code", sa.String)),
+            (
+                ("parent_geography_code", "value"),
+                sa.Column("parent_geography_code", sa.String),
+            ),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
             (("unit", "value"), sa.Column("unit", sa.String)),
@@ -39,7 +43,8 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?period ?geography_name ?geography_code ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    SELECT ?period ?geography_name ?geography_code ?parent_geography_code ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit
+    WHERE {
         ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-sa-trade-in-goods> ;
             <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
             <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s ;
@@ -47,13 +52,19 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
             <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
             <http://purl.org/linked-data/sdmx/2009/dimension#refPeriod> ?period_s .
 
-    ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
-    ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
-    ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
-    ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
-    ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
+        ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
+        ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
+        ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
+        ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
+        ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
 
-    } ORDER BY ?period ?geography_s
+        OPTIONAL {
+            ?geography_s <http://www.w3.org/2004/02/skos/core#broader> ?parent_geography_s .
+            ?parent_geography_s <http://www.w3.org/2004/02/skos/core#notation> ?parent_geography_code .
+        }
+
+    }
+    ORDER BY ?period ?geography_s
     """
 
 


### PR DESCRIPTION
### Description of change

<img width="763" alt="image" src="https://user-images.githubusercontent.com/246664/78384782-ba747e00-75d2-11ea-9524-622765968c0a.png">


### Remove ONSUKTradeInGoodsByCommodityPipeline

The pipeline was added alongside other ONS trade in goods pipelines but isn't actually required/used by anyone.

### Add geography_code field to ONS trade pipelines


### Remove empty csv_pipeline.py file


### Add support for dependencies to the base CSV pipelines DAG class

This also makes 'dependencies' available as a template variable so that they can be used to retrieve table names in DB queries.

### Add parent_geography_code to the ONS SA trade pipeline

Parent geography allows separating EU and non-EU countries to label them in the output CSV.

### Add a CSV output pipeline for ONS UK SA trade in goods data



### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
