### PR TITLE
Turn off catchup for daily csv dags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-06
+
+### Changed
+
+- Turn off catchup for daily csv dags
+
 ## 2020-04-03
 
 ### Added

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -12,6 +12,7 @@ class _DailyCSVPipeline(_CSVPipelineDAG):
     start_date = datetime(2020, 2, 11)
     timestamp_output = False
     static = True
+    catchup = False
 
 
 class DataHubFDIDailyCSVPipeline(_DailyCSVPipeline):


### PR DESCRIPTION
### Description of change

Turns off catch up for daily csv dags as there is no need for historic runs

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
