### PR TITLE
Update UK trade in services pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-08
+
+### Changed
+
+- ONS UK Trade in services pipelines now include period types, and shouldn't have duplicated data for quarterly rows.
+
 ## 2020-04-07
 
 ### Added

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -143,6 +143,7 @@ class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
             (("geography_code", "value"), sa.Column("geography_code", sa.String)),
             (("product_label", "value"), sa.Column("product", sa.String)),
             (("period", "value"), sa.Column("period", sa.String)),
+            (("period_type", "value"), sa.Column("period_type", sa.String)),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
             (("unit", "value"), sa.Column("unit", sa.String)),
@@ -153,7 +154,7 @@ class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?geography_name ?geography_code ?product_label ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    SELECT ?geography_name ?geography_code ?product_label ?period ?period_type ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
     ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-trade-in-services> ;
         <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
         <http://gss-data.org.uk/def/dimension/product> ?product_s ;
@@ -165,10 +166,11 @@ class ONSUKTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
     ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
     ?product_s <http://www.w3.org/2000/01/rdf-schema#label> ?product_label .
-    ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
     ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
     ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
-    } ORDER BY ?geography_name ?product_label ?period
+    BIND(IF(STRSTARTS(xsd:string(?period_s), "http://reference.data.gov.uk/id/quarter/") = true, "quarter", "year") AS ?period_type) .
+    BIND(STRAFTER(STRAFTER(xsd:string(?period_s), "http://reference.data.gov.uk/id/"), "/") AS ?period) .
+    } ORDER BY ?geography_name ?product_label ASC(?period)
     """
 
 
@@ -180,6 +182,7 @@ class ONSUKTotalTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
             (("geography_code", "value"), sa.Column("geography_code", sa.String)),
             (("period", "value"), sa.Column("period", sa.String)),
+            (("period_type", "value"), sa.Column("period_type", sa.String)),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
             (("unit", "value"), sa.Column("unit", sa.String)),
@@ -190,7 +193,7 @@ class ONSUKTotalTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?geography_name ?geography_code ?period ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
+    SELECT ?geography_name ?geography_code ?period ?period_type ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit WHERE {
     ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-total-trade> ;
         <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
         <http://gss-data.org.uk/def/dimension/product> ?product_s ;
@@ -201,8 +204,9 @@ class ONSUKTotalTradeInServicesByPartnerCountryPipeline(_ONSPipeline):
     ?geography_s <http://www.w3.org/2000/01/rdf-schema#label> ?geography_name .
     ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
     ?product_s <http://www.w3.org/2000/01/rdf-schema#label> "Services" .
-    ?period_s <http://www.w3.org/2000/01/rdf-schema#label> ?period .
     ?direction_s <http://www.w3.org/2000/01/rdf-schema#label> ?direction .
     ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
-    } ORDER BY ?geography_name ?period
+    BIND(IF(STRSTARTS(xsd:string(?period_s), "http://reference.data.gov.uk/id/quarter/") = true, "quarter", "year") AS ?period_type) .
+    BIND(STRAFTER(STRAFTER(xsd:string(?period_s), "http://reference.data.gov.uk/id/"), "/") AS ?period) .
+    } ORDER BY ?geography_name ASC(?period)
     """


### PR DESCRIPTION
### Description of change
Changes:
* Don't join on period for the label, as the period has two labels for
reason and this was leading to duplicated data.
* Include the period types (quarter or year)

These pipelines will probably fail when this is deployed, as the new
pipeline will pull in less data. We'll need to manually delete the
existing tables so that the comparison doesn't happen. This should be OK
as the data is not currently published for users.

### Checklist

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?