### PR TITLE
Add maintenance DAG with tasks to clean up old S3 files and DB tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-04-08
 
+### Added
+
+- Maintenance DAG with tasks to clean up old S3 files and temporary DB tables
+
 ### Changed
 
 - ONS UK Trade in services pipelines now include period types, and shouldn't have duplicated data for quarterly rows.
@@ -14,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated duty type field type to text on raw world bank tariff pipeline
 - Added columns eu_rep_rate and eu_part_rate to world bank tariff pipeline
 - Updated partner and reporter field types to text on world bank tariff pipeline
+- S3Data methods are now retried in case of temporary network failure
 
 ## 2020-04-07
 

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -25,7 +25,6 @@ DATAHUB_BASE_URL = os.environ.get("DATAHUB_BASE_URL")
 EXPORT_WINS_BASE_URL = os.environ.get("EXPORT_WINS_BASE_URL")
 
 DEBUG = True if os.environ.get("DEBUG") == "True" else False
-INGEST_TASK_CONCURRENCY = int(os.environ.get("INGEST_TASK_CONCURRENCY", 1))
 REDIS_URL = os.environ.get("AIRFLOW__CELERY__BROKER_URL")
 COUNTRIES_OF_INTEREST_BASE_URL = os.environ.get(
     "COUNTRIES_OF_INTEREST_BASE_URL", "localhost:5000"
@@ -35,6 +34,11 @@ DATA_STORE_SERVICE_BASE_URL = os.environ.get(
 )
 
 S3_IMPORT_DATA_BUCKET = os.environ.get("S3_IMPORT_DATA_BUCKET")
+S3_RETENTION_PERIOD_DAYS = os.environ.get("S3_RETENTION_PERIOD_DAYS", 7)
+
+DB_TEMP_TABLE_RETENTION_PERIOD_DAYS = os.environ.get(
+    "DB_TEMP_TABLE_RETENTION_PERIOD_DAYS", 3
+)
 
 ONS_SPARQL_URL = os.environ.get(
     "ONS_SPARQL_URL",

--- a/dataflow/dags/maintenance.py
+++ b/dataflow/dags/maintenance.py
@@ -1,0 +1,108 @@
+import re
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.hooks.S3_hook import S3Hook
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.operators.python_operator import PythonOperator
+
+import sqlalchemy as sa
+
+from dataflow import config
+from dataflow.utils import logger
+
+
+def cleanup_old_s3_files(*args, **kwargs):
+    s3 = S3Hook("DEFAULT_S3")
+    bucket = s3.get_bucket(config.S3_IMPORT_DATA_BUCKET)
+
+    current_time = datetime.strptime(kwargs["ts_nodash"], "%Y%m%dT%H%M%S")
+    logger.info(
+        f"Retention period is {config.S3_RETENTION_PERIOD_DAYS} days before {current_time}"
+    )
+
+    pipelines = s3.list_prefixes(
+        config.S3_IMPORT_DATA_BUCKET, prefix="import-data/", delimiter="/"
+    )
+
+    for pipeline in pipelines:
+        run_ids = s3.list_prefixes(
+            config.S3_IMPORT_DATA_BUCKET, prefix=pipeline, delimiter="/"
+        )
+
+        for run_id in run_ids:
+            run_dt = datetime.strptime(run_id.split("/")[-2], "%Y%m%dT%H%M%S")
+            if current_time - run_dt >= timedelta(days=config.S3_RETENTION_PERIOD_DAYS):
+                logger.info(
+                    f"Deleting {pipeline} run {run_id} ({run_dt}) older than retention period"
+                )
+                bucket.objects.filter(Prefix=run_id).delete()
+            else:
+                logger.info(f"Keeping {pipeline} run {run_id} ({run_dt})")
+
+
+def cleanup_old_datasets_db_tables(*args, **kwargs):
+    engine = sa.create_engine(
+        'postgresql+psycopg2://',
+        creator=PostgresHook(postgres_conn_id=config.DATASETS_DB_NAME).get_conn,
+    )
+
+    current_time = datetime.strptime(kwargs["ts_nodash"], "%Y%m%dT%H%M%S")
+    logger.info(
+        f"Retention period is {config.DB_TEMP_TABLE_RETENTION_PERIOD_DAYS} days before {current_time}"
+    )
+
+    with engine.begin() as conn:
+        tables = [
+            table
+            for table, in conn.execute(
+                "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public'"
+            )
+        ]
+
+        for table in tables:
+            table_match = re.match(r"(.*)_(\d{8}t\d{6})(?:_swap)?", table)
+            if not table_match:
+                logger.info(f"Skipping {table}")
+                continue
+
+            table_dt = datetime.strptime(table_match.groups()[1], "%Y%m%dt%H%M%S")
+
+            if current_time - table_dt >= timedelta(
+                days=config.DB_TEMP_TABLE_RETENTION_PERIOD_DAYS
+            ):
+                if table_match.groups()[0] not in tables:
+                    logger.warning(
+                        f"Main table {table_match.groups()[0]} missing for {table}, skipping"
+                    )
+                else:
+                    logger.info(
+                        f"Deleting temporary table {table} ({table_dt}) older than retention period"
+                    )
+                    conn.execute(
+                        "DROP TABLE {}".format(
+                            engine.dialect.identifier_preparer.quote(table)
+                        )
+                    )
+            else:
+                logger.info("Keeping table {table}")
+
+
+dag = DAG(
+    "Maintenance",
+    catchup=False,
+    start_date=datetime(2020, 4, 7),
+    schedule_interval="@daily",
+)
+
+
+dag << PythonOperator(
+    task_id='clean-up-s3', python_callable=cleanup_old_s3_files, provide_context=True
+)
+
+
+dag << PythonOperator(
+    task_id='clean-up-datasets-db',
+    python_callable=cleanup_old_datasets_db_tables,
+    provide_context=True,
+)

--- a/sample.env
+++ b/sample.env
@@ -42,7 +42,6 @@ AUTHBROKER_ALLOWED_DOMAINS="digital.trade.gov.uk,trade.gov.uk,mobile.ukti.gov.uk
 
 DATAHUB_BASE_URL=https://datahub-api-demo.london.cloudapps.digital
 FINANCIAL_YEAR_FIRST_DAY_MONTH='4-1'
-INGEST_TASK_CONCURRENCY=4
 COUNTRIES_OF_INTEREST_BASE_URL=https://countries-of-interest-service-dev.london.cloudapps.digital
 DATA_STORE_SERVICE_BASE_URL=https://data-store-service-dev.london.cloudapps.digital
 

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 76
+    assert dagbag.size() == 77

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+import pytest
+
+from dataflow.dags import maintenance
+
+
+@pytest.fixture
+def s3(mocker):
+    s3_mock = mock.MagicMock()
+    mocker.patch.object(maintenance, "S3Hook", return_value=s3_mock, autospec=True)
+
+    return s3_mock
+
+
+@pytest.fixture
+def postgres_hook(mocker):
+    return mocker.patch.object(maintenance, "PostgresHook")
+
+
+def test_cleanup_old_s3_files(s3):
+    s3.list_prefixes.side_effect = [
+        ['pipeline1/', 'pipeline2/'],
+        ['pipeline1/20000101T000000/', 'pipeline1/20000104T000000/'],
+        ['pipeline2/20000101T000000/', 'pipeline2/20000104T000000/'],
+    ]
+
+    maintenance.cleanup_old_s3_files(ts_nodash="20000110T000000")
+
+    assert s3.get_bucket().objects.filter.mock_calls == [
+        mock.call(Prefix='pipeline1/20000101T000000/'),
+        mock.call().delete(),
+        mock.call(Prefix='pipeline2/20000101T000000/'),
+        mock.call().delete(),
+    ]
+
+
+def test_cleanup_old_dataset_db_tables(mock_db_conn):
+    mock_db_conn.execute.return_value = [
+        ('table1',),
+        ('table1_20000101t000000',),
+        ('table1_20000101t000000_swap',),
+        ('table1_20000108t000000',),
+        ('table1_20000108t000000_swap',),
+        ('table2_20000101t000000',),
+    ]
+
+    maintenance.cleanup_old_datasets_db_tables(ts_nodash="20000110T000000")
+
+    assert mock_db_conn.execute.mock_calls == [
+        mock.call(
+            "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public'"
+        ),
+        mock.call("DROP TABLE QUOTED<table1_20000101t000000>"),
+        mock.call("DROP TABLE QUOTED<table1_20000101t000000_swap>"),
+    ]


### PR DESCRIPTION
### Description of change

### Add retries to S3Data read, write and list boto requests

Retries temporary boto EndpointConnectionError similar to how we retry API requests to other services

### Add maintenance DAG with tasks to clean up old S3 files and DB tables

Deletes old S3 fetch cache older than the specified retention period (7 days by default).

Deletes old DB dataset tables (older than 3 days by default), only if a table with a matching prefix exists.


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
