### PR TITLE
Update market access trade barriers pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-09
+
+### Changed
+
+- Updated the Market Access Trade Barriers to no longer read the `resolved_date` field, which was removed in the upstream API.
+
 ## 2020-04-08
 
 ### Added

--- a/dataflow/dags/market_access_pipelines.py
+++ b/dataflow/dags/market_access_pipelines.py
@@ -42,7 +42,6 @@ class MarketAccessTradeBarriersPipeline(_PipelineDAG):
             ('import_market_size', sa.Column('import_market_size', sa.BigInteger)),
             ('commercial_value', sa.Column('commercial_value', sa.BigInteger)),
             ('export_value', sa.Column('export_value', sa.BigInteger)),
-            ('resolved_date', sa.Column('resolved_date', sa.Date)),
             ('team_count', sa.Column('team_count', sa.Integer)),
             ('company_names', sa.Column('company_names', sa.ARRAY(sa.Text))),
             ('company_ids', sa.Column('company_ids', sa.ARRAY(sa.Text))),


### PR DESCRIPTION
### Description of change
The Market Access API has removed the `resolved_date` field, so we need
to update our pipeline to not expect it any more.

https://github.com/uktrade/market-access-api/pull/110

### Checklist

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
