### PR TITLE
Increase page size for interactions dataset scrape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Updated the Market Access Trade Barriers to no longer read the `resolved_date` field, which was removed in the upstream API.
+- Updated the Interactions pipeline to include a page_size=1000 query param (the default is 100), so that this pipeline hopefully completes sooner.
 
 ## 2020-04-08
 

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -291,7 +291,9 @@ class InvestmentProjectsDatasetPipeline(_DatasetPipeline):
 
 
 class InteractionsDatasetPipeline(_DatasetPipeline):
-    source_url = '{}/v4/dataset/interactions-dataset'.format(config.DATAHUB_BASE_URL)
+    source_url = '{}/v4/dataset/interactions-dataset?page_size=1000'.format(
+        config.DATAHUB_BASE_URL
+    )
     table_config = TableConfig(
         table_name='interactions_dataset',
         field_mapping=[


### PR DESCRIPTION
### Description of change
We scrape around 2.9M records of the interactions dataset daily, which
takes about 3 hours. We do this in chunks of 100, which feels pretty
inefficient. A PR on the data-hub-api
(https://github.com/uktrade/data-hub-api/pull/2749) allows clients to
specify their own page size, which will mean we can scrape in larger
chunks. This should reduce the total time-to-scrape as well as the time
to insert data into the DB (currently about 3.5 hours). Given a lot of
pipelines rely on this one, the faster it completes, the faster the
other pipelines can start and finish.

**Note:** This query param may not be available yet, so this won't start working immediately. But it's been merged so should get released sooner or later. 

I wonder if it's also worth thinking about doing delta updates, assuming that the interactions dataset is append-only? I'm not sure if that assumption holds though - but it might be worth considering that sort of approach for certain datasets.

### Checklist

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?