### PR TITLE
Feature/csv output naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated the Market Access Trade Barriers to no longer read the `resolved_date` field, which was removed in the upstream API.
 - Updated the Interactions pipeline to include a page_size=1000 query param (the default is 100), so that this pipeline hopefully completes sooner.
+- Set the timestamp on CSVs to the date that the file is created (rather than the start date of the task)
 
 ## 2020-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated the Market Access Trade Barriers to no longer read the `resolved_date` field, which was removed in the upstream API.
 - Updated the Interactions pipeline to include a page_size=1000 query param (the default is 100), so that this pipeline hopefully completes sooner.
 - Set the timestamp on CSVs to the date that the file is created (rather than the start date of the task)
+- Bring CSV output file names in line with the agreed naming conventions
 
 ## 2020-04-08
 

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -18,7 +18,7 @@ class _DailyCSVPipeline(_CSVPipelineDAG):
 class DataHubFDIDailyCSVPipeline(_DailyCSVPipeline):
     """Pipeline meta object for Completed OMIS Order CSV."""
 
-    base_file_name = 'fdi_daily'
+    base_file_name = 'datahub-foreign-direct-investment-daily'
     query = '''
         WITH fdi_report AS (
             WITH companies_last_version AS (
@@ -207,7 +207,7 @@ class DataHubFDIDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubServiceDeliveriesCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated service deliveries report"""
 
-    base_file_name = 'data_hub_service_deliveries_current_calendar_year'
+    base_file_name = 'datahub-service-deliveries-current-calendar-year'
     query = '''
         WITH interactions AS (
             SELECT *
@@ -286,7 +286,7 @@ class DataHubServiceDeliveriesCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubInteractionsCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated interactions report"""
 
-    base_file_name = 'data_hub_interactions_current_calendar_year'
+    base_file_name = 'datahub-interactions-current-calendar-year'
     query = '''
         WITH interactions AS (
             SELECT *
@@ -365,7 +365,7 @@ class DataHubInteractionsCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubServiceDeliveriesPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated service deliveries report for previous calendar year"""
 
-    base_file_name = 'data_hub_service_deliveries_previous_calendar_year'
+    base_file_name = 'datahub-service-deliveries-previous-calendar-year'
     query = '''
         WITH interactions AS (
             SELECT *
@@ -444,7 +444,7 @@ class DataHubServiceDeliveriesPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubInteractionsPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated interactions report for previous calendar year"""
 
-    base_file_name = 'data_hub_interactions_previous_calendar_year'
+    base_file_name = 'datahub-interactions-previous-calendar-year'
     query = '''
         WITH interactions AS (
             SELECT *
@@ -522,7 +522,7 @@ class DataHubInteractionsPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
 class ExportWinsCurrentFinancialYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated export wins for current financial year"""
 
-    base_file_name = 'export_wins_current_financial_year'
+    base_file_name = 'export-wins-current-financial-year'
     query = '''
         SELECT
             "ID",

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -15,7 +15,7 @@ class _MonthlyCSVPipeline(_CSVPipelineDAG):
 class DataHubOMISCompletedOrdersCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for Completed OMIS Order CSV."""
 
-    base_file_name = 'completed_omis_orders'
+    base_file_name = 'datahub-omis-completed-orders'
     query = '''
         SELECT
             omis_dataset.omis_order_reference AS "OMIS Order Reference",
@@ -49,7 +49,7 @@ class DataHubOMISCompletedOrdersCSVPipeline(_MonthlyCSVPipeline):
 class DataHubOMISCancelledOrdersCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for Cancelled OMIS Order CSV."""
 
-    base_file_name = 'cancelled_omis_orders'
+    base_file_name = 'datahub-omis-cancelled-orders'
     query = '''
         WITH omis AS (
             SELECT
@@ -91,7 +91,7 @@ class DataHubOMISAllOrdersCSVPipeline(_MonthlyCSVPipeline):
     """View pipeline for all OMIS orders created up to the end
      of the last calendar month"""
 
-    base_file_name = 'all_omis_orders'
+    base_file_name = 'datahub-omis-all-orders'
     start_date = datetime(2019, 12, 1)
     query = '''
         SELECT
@@ -125,7 +125,7 @@ class DataHubOMISAllOrdersCSVPipeline(_MonthlyCSVPipeline):
 class DataHubOMISClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for monthly OMIS Client Survey report."""
 
-    base_file_name = 'omis_client_survey_static'
+    base_file_name = 'datahub-omis-client-survey'
     static = True
     query = '''
         SELECT
@@ -162,7 +162,7 @@ class DataHubOMISClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
 class DataHubServiceDeliveryInteractionsCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for the data hub service deliveries and interactions report."""
 
-    base_file_name = 'datahub_service_interactions'
+    base_file_name = 'datahub-service-deliveries-and-interactions'
     start_date = datetime(2019, 11, 15)
     schedule_interval = '0 5 15 * *'
     query = '''
@@ -254,7 +254,7 @@ class DataHubServiceDeliveryInteractionsCSVPipeline(_MonthlyCSVPipeline):
 class DataHubExportClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for the data hub export client survey report."""
 
-    base_file_name = 'datahub_export_client_survey'
+    base_file_name = 'datahub-export-client-survey'
     start_date = datetime(2019, 11, 15)
     schedule_interval = '0 5 15 * *'
     static = True
@@ -349,7 +349,7 @@ class DataHubExportClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
 class DataHubFDIMonthlyStaticCSVPipeline(_MonthlyCSVPipeline):
     """Static monthly view of the FDI (investment projects) report"""
 
-    base_file_name = 'data_hub_fdi_monthly_static'
+    base_file_name = 'datahub-foreign-direct-investment-monthly'
     start_date = datetime(2020, 1, 1)
     static = True
     query = '''

--- a/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
@@ -14,7 +14,7 @@ class _YearlyCSVPipeline(_CSVPipelineDAG):
 class ExportWinsYearlyCSVPipeline(_YearlyCSVPipeline):
     """Pipeline meta object for the yearly export wins report."""
 
-    base_file_name = 'export_wins_yearly'
+    base_file_name = 'export-wins-yearly'
     start_date = datetime(2018, 1, 1)
 
     query = '''

--- a/dataflow/dags/csv_pipelines/csv_refresh_pipeline.py
+++ b/dataflow/dags/csv_pipelines/csv_refresh_pipeline.py
@@ -80,6 +80,7 @@ class DailyCSVRefreshPipeline(_CSVPipelineDAG):
                                 task_id=f'{pipeline.__name__}-{run_date.strftime("%Y-%m-%d")}',
                                 python_callable=create_csv,
                                 provide_context=True,
+                                params={'run_date': run_date.strftime('%Y-%m-%d')},
                                 op_args=[
                                     pipeline.target_db,
                                     pipeline.base_file_name,

--- a/dataflow/operators/csv_outputs.py
+++ b/dataflow/operators/csv_outputs.py
@@ -15,9 +15,9 @@ def create_csv(
     """
     Given a db, view name and a query create a csv file and upload it to s3.
     """
-    run_date = kwargs.get('run_date', kwargs.get('execution_date'))
     if timestamp_output:
-        file_name = f'{base_file_name}_{run_date.strftime("%Y_%m_%d")}.csv'
+        end_date = kwargs.get('run_date', kwargs.get('next_execution_date'))
+        file_name = f'{base_file_name}_{end_date.strftime("%Y_%m_%d")}.csv'
     else:
         file_name = f'{base_file_name}.csv'
 
@@ -27,6 +27,7 @@ def create_csv(
         echo=config.DEBUG,
     )
     row_count = 0
+    run_date = kwargs.get('run_date', kwargs.get('execution_date'))
     with engine.begin() as conn:
         result = conn.execution_options(stream_results=True).execute(
             sa.text(query), run_date=run_date.date()

--- a/dataflow/operators/csv_outputs.py
+++ b/dataflow/operators/csv_outputs.py
@@ -17,7 +17,7 @@ def create_csv(
     """
     if timestamp_output:
         end_date = kwargs.get('run_date', kwargs.get('next_execution_date'))
-        file_name = f'{base_file_name}_{end_date.strftime("%Y_%m_%d")}.csv'
+        file_name = f'{base_file_name}-{end_date.strftime("%Y-%m-%d")}.csv'
     else:
         file_name = f'{base_file_name}.csv'
 

--- a/tests/operators/test_csv_outputs.py
+++ b/tests/operators/test_csv_outputs.py
@@ -32,7 +32,8 @@ def test_create_csv(mocker, mock_db_conn, timestamp_file, output_filename):
         'test_base_file',
         timestamp_file,
         'select * from tmp',
-        execution_date=datetime(2020, 1, 1),
+        execution_date=datetime(2019, 12, 1),
+        next_execution_date=datetime(2020, 1, 1),
     )
 
     mock_csv.writer().writerow.assert_has_calls(

--- a/tests/operators/test_csv_outputs.py
+++ b/tests/operators/test_csv_outputs.py
@@ -8,7 +8,7 @@ from dataflow.operators import csv_outputs
 
 @pytest.mark.parametrize(
     'timestamp_file,output_filename',
-    [(True, 'test_base_file_2020_01_01.csv'), (False, 'test_base_file.csv')],
+    [(True, 'test_base_file-2020-01-01.csv'), (False, 'test_base_file.csv')],
 )
 def test_create_csv(mocker, mock_db_conn, timestamp_file, output_filename):
     mocker.patch.object(csv_outputs.config, 'DATA_WORKSPACE_S3_BUCKET', 'test-bucket')


### PR DESCRIPTION
### Description of change

- Rename csv outputs to match naming conventions (i.e. separate with hyphens)
- Use end date of scheduled dag run when naming csv outputs
  - This has been requested by various users of monthly reports which currently use the start date of the scheduled period.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
