### PR TITLE
Ensure end date of dag run is used in file name when refreshing csvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-14
+
+### Changed
+
+- Use the dag run end date when refreshing CSV files
+
 ## 2020-04-09
 
 ### Changed

--- a/dataflow/operators/csv_outputs.py
+++ b/dataflow/operators/csv_outputs.py
@@ -16,8 +16,9 @@ def create_csv(
     Given a db, view name and a query create a csv file and upload it to s3.
     """
     if timestamp_output:
-        end_date = kwargs.get('run_date', kwargs.get('next_execution_date'))
-        file_name = f'{base_file_name}-{end_date.strftime("%Y-%m-%d")}.csv'
+        file_name = (
+            f'{base_file_name}-{kwargs["next_execution_date"].strftime("%Y-%m-%d")}.csv'
+        )
     else:
         file_name = f'{base_file_name}.csv'
 


### PR DESCRIPTION
### Description of change

Fix the issue where the csv refresh dag was recreating files using the start date rather than the end date of the dag run.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
