### PR TITLE
Bugfix/data workspace auth fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-21
+
+### Changed
+
+- Add a workaround for http/https hawk auth issues on data workspace
+- Catch type errors when passing records and the nested field is None
+
 ## 2020-04-15
 
 ### Added

--- a/dataflow/dags/data_workspace_pipelines.py
+++ b/dataflow/dags/data_workspace_pipelines.py
@@ -22,6 +22,7 @@ class _DataWorkspacePipeline(_PipelineDAG):
                 fetch_from_hawk_api,
                 hawk_credentials=config.DATA_WORKSPACE_HAWK_CREDENTIALS,
                 validate_response=False,
+                force_http=True,  # This is a workaround until hawk auth is sorted on data workspace
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],

--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -15,9 +15,17 @@ def _hawk_api_request(
     results_key: Optional[str],
     next_key: Optional[str],
     validate_response: Optional[bool] = True,
+    force_http: Optional[bool] = False,
 ):
     sender = Sender(
-        credentials, url, "get", content="", content_type="", always_hash_content=True
+        credentials,
+        # Currently data workspace denies hawk requests signed with https urls.
+        # Once fixed the protocol replacement can be removed.
+        url.replace('https', 'http') if force_http else url,
+        "get",
+        content="",
+        content_type="",
+        always_hash_content=True,
     )
 
     logger.info(f"Fetching page {url}")
@@ -59,6 +67,7 @@ def fetch_from_hawk_api(
     results_key: str = "results",
     next_key: Optional[str] = "next",
     validate_response: Optional[bool] = True,
+    force_http: Optional[bool] = False,
     **kwargs,
 ):
     s3 = S3Data(table_name, kwargs["ts_nodash"])
@@ -72,6 +81,7 @@ def fetch_from_hawk_api(
             results_key=results_key,
             next_key=next_key,
             validate_response=validate_response,
+            force_http=force_http,
         )
 
         results = get_nested_key(data, results_key)

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -173,7 +173,7 @@ def slack_alert(context, success=False):
                         ],
                     }
                 ],
-            },
+            }
         ],
     ).execute()
 
@@ -222,7 +222,7 @@ def get_nested_key(
     for key in path:
         try:
             data = data[key]
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, TypeError):
             if required:
                 raise
             else:

--- a/tests/operators/test_dataset.py
+++ b/tests/operators/test_dataset.py
@@ -7,11 +7,7 @@ from requests import HTTPError
 from dataflow.operators import common
 
 
-FAKE_HAWK_CREDENTIALS = {
-    "id": "some-id",
-    "key": "some-key",
-    "algorithm": "sha256",
-}
+FAKE_HAWK_CREDENTIALS = {"id": "some-id", "key": "some-key", "algorithm": "sha256"}
 
 
 @pytest.fixture
@@ -115,6 +111,7 @@ def test_fetch(mocker):
                 next_key='next',
                 results_key='results',
                 validate_response=True,
+                force_http=False,
             )
         ]
     )


### PR DESCRIPTION
### Description of change

**Add a workaround for http/https hawk auth issues on data workspace**
We have an issue with our homegrown hawk authentication on data workspace where requests signed with https urls are automatically 401'd. It's potentially something that can be fixed easily but i'm worried about the ramifications for other systems that use the api currently. So I've created a separate card to get the data workspace issues fixed and have added a workaround to data flow for now - much the same as they did on countries of interest service.

**Catch type errors when passing records and the nested field is None**
DRF serializers return null if a nested relationship doesn't exist. This caused issues when gett the data from for e.g. ('nested_serializer', 'id') if nested_serializer was None in the response.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
