### PR TITLE
Remove rejected win filter from current year and add to yearly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Ensure rejected export wins are not included in current year report
+- Ensure rejected export wins are not included in yearly report
 
 ## 2020-04-21
 

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -865,5 +865,4 @@ class ExportWinsCurrentFinancialYearDailyCSVPipeline(_DailyCSVPipeline):
             ORDER BY export_wins.confirmation_created NULLS FIRST
         ) a
         WHERE (confirmation_created_financial_year IS NULL OR confirmation_created_financial_year = current_financial_year)
-        AND "Please confirm these details are correct" = 'Yes'
 '''

--- a/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
@@ -346,6 +346,8 @@ class ExportWinsYearlyCSVPipeline(_YearlyCSVPipeline):
             )
             LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
             LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
+            WHERE "Please confirm these details are correct" = 'Yes'
             ORDER BY export_wins.confirmation_created NULLS FIRST
         ) a
+        WHERE "Please confirm these details are correct" = 'Yes'
     '''

--- a/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
@@ -346,7 +346,6 @@ class ExportWinsYearlyCSVPipeline(_YearlyCSVPipeline):
             )
             LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
             LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
-            WHERE "Please confirm these details are correct" = 'Yes'
             ORDER BY export_wins.confirmation_created NULLS FIRST
         ) a
         WHERE "Please confirm these details are correct" = 'Yes'


### PR DESCRIPTION
### Description of change

Client has changed their mind...

- Reverts previous addition of rejected filter to current year wins report
- Adds rejected filter to yearly wins report

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
