### PR TITLE
Set max time to retry requests to Hawk APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Bump page_size for interactions dataset in order to (hopefully) reduce run time.
+- Set max time for requests to try to error earlier if things get stuck.
 
 ## 2020-04-22
 

--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -8,7 +8,9 @@ from mohawk.exc import HawkFail
 from dataflow.utils import S3Data, get_nested_key, logger
 
 
-@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
+@backoff.on_exception(
+    backoff.expo, requests.exceptions.RequestException, max_tries=5, max_time=600
+)
 def _hawk_api_request(
     url: str,
     credentials: dict,


### PR DESCRIPTION
### Description of change
Relatively frequently we're waking up to find that some of our pipelines
seem to have just stalled in making requests, sometimes for 8+ hours. It
would be nice if these simply die rather than hang, so that we can
notice the problem sooner.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
