### PR TITLE
Timeout requests after 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove primary key from consent service pipeline
+- Timeout hawk API requests after 5 minutes, so that retries can happen.
+- Enable run-fetch full task retries on the Interactions pipeline.
 
 ## 2020-04-29
 

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -17,6 +17,8 @@ class _DatasetPipeline(_PipelineDAG):
 
     source_url: str
 
+    fetch_retries = 0
+
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(
             task_id='run-fetch',
@@ -25,6 +27,7 @@ class _DatasetPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )
 
 
@@ -294,6 +297,7 @@ class InteractionsDatasetPipeline(_DatasetPipeline):
             ),
         ],
     )
+    fetch_retries = 3
 
 
 class InteractionsExportCountryDatasetPipeline(_DatasetPipeline):

--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -8,9 +8,7 @@ from mohawk.exc import HawkFail
 from dataflow.utils import S3Data, get_nested_key, logger
 
 
-@backoff.on_exception(
-    backoff.expo, requests.exceptions.RequestException, max_tries=5, max_time=600
-)
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
 def _hawk_api_request(
     url: str,
     credentials: dict,
@@ -32,7 +30,9 @@ def _hawk_api_request(
 
     logger.info(f"Fetching page {url}")
     response = requests.get(
-        url, headers={"Authorization": sender.request_header, "Content-Type": ""}
+        url,
+        headers={"Authorization": sender.request_header, "Content-Type": ""},
+        timeout=300,
     )
 
     try:


### PR DESCRIPTION
### Description of change
We keep waking up to the interactions dataset having hung for hours
trying to fetch data. By adding timeouts on the requests we're hoping to
enable them to get retried if they do get stuck for a little while.

This also adds retries to the fetch task for the interactions pipeline
as a whole, so that if the entire task dies it will automatically retry.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
