### PR TITLE
Do not pass self in super call to JSONEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix typo in ministerial interactions column name
 - Remove unnecessary casting of all fields to text on the fdi dashboard pipeline 
+- Fix bug where TypeError was not being raised correctly on JsonEncoder
 
 ## 2020-05-13
 

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -188,7 +188,7 @@ class DateTimeJsonEncoder(JSONEncoder):
             pass
 
         # Let the base class default method raise the TypeError
-        super().default(self, o)
+        super().default(o)
 
 
 class S3Data:


### PR DESCRIPTION
### Description of change

Do not pass `self` when letting parent class handle `TypeError` for `DateTimeJsonEncoder`

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
