### PR TITLE
Add included_in_eu28 via hard-coded list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-17
+
+## Added
+
+- ONS dataset `ONSUKTradeInServicesByPartnerCountryNSA`, plus CSV pipeline.
+
 ## 2020-05-14
 
 ### Changed

--- a/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
+++ b/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
@@ -111,6 +111,7 @@ WITH rolling_import_totals AS (SELECT geography_code,
      imports_and_exports_with_rolling_totals AS (SELECT imports_t.geography_code,
                                                         imports_t.geography_name,
                                                         imports_t.product_code,
+                                                        imports_t.product_name,
                                                         imports_t.period,
                                                         imports_t.period_type,
                                                         unnest(
@@ -146,6 +147,7 @@ SELECT
     ELSE 'no'
     END AS included_in_eu28,
     product_code,
+    product_name,
     period,
     period_type,
     measure,

--- a/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
+++ b/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
@@ -138,7 +138,20 @@ WITH rolling_import_totals AS (SELECT geography_code,
                                                  WHERE imports_t.direction = 'imports'
                                                    AND exports_t.direction = 'exports')
 SELECT
-    *
+    geography_code,
+    geography_name,
+    CASE
+        -- Taken from http://gss-data.org.uk/concept?uri=http%3A%2F%2Fgss-data.org.uk%2Fdef%2Fconcept%2Fons-partner-geography%2FB5
+        WHEN geography_name IN ('Austria', 'Belgium', 'Bulgaria', 'Croatia', 'Cyprus', 'Czech Republic', 'Denmark', 'Estonia', 'Finland', 'France', 'Germany', 'Greece', 'Hungary', 'Ireland', 'Italy', 'Latvia', 'Lithuania', 'Luxembourg', 'Malta', 'Netherlands', 'Poland', 'Portugal', 'Romania', 'Slovakia', 'Slovenia', 'Spain', 'Sweden') THEN 'yes'
+    ELSE 'no'
+    END AS included_in_eu28,
+    product_code,
+    period,
+    period_type,
+    measure,
+    value,
+    unit,
+    marker
 FROM
     imports_and_exports_with_rolling_totals
 WHERE


### PR DESCRIPTION
### Description of change
Add an `included_in_eu28` column to CSV export, using hard-coded list taken from http://gss-data.org.uk/concept?uri=http%3A%2F%2Fgss-data.org.uk%2Fdef%2Fconcept%2Fons-partner-geography%2FB5.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
