### PR TITLE
Start export wins yearly pipeline from 2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-21
+
+### Changed
+
+- Start export wins yearly reports from 2016
+
 ## 2020-05-19
 
 ## Added

--- a/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
@@ -15,7 +15,7 @@ class ExportWinsYearlyCSVPipeline(_YearlyCSVPipeline):
     """Pipeline meta object for the yearly export wins report."""
 
     base_file_name = 'export-wins-yearly'
-    start_date = datetime(2018, 1, 1)
+    start_date = datetime(2016, 1, 1)
 
     query = '''
         SELECT


### PR DESCRIPTION
### Description of change

Set start date of export wins yearly pipeline to 01/01/2016. To be picked up by the daily csv refresh dag.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
