### PR TITLE
ONS dataset 1 flat CSV structure

### DIFF
--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -30,10 +30,6 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
             (("period", "value"), sa.Column("period", sa.String)),
             (("geography_name", "value"), sa.Column("geography_name", sa.String)),
             (("geography_code", "value"), sa.Column("geography_code", sa.String)),
-            (
-                ("parent_geography_code", "value"),
-                sa.Column("parent_geography_code", sa.String),
-            ),
             (("direction", "value"), sa.Column("direction", sa.String)),
             (("total", "value"), sa.Column("total", sa.Numeric)),
             (("unit", "value"), sa.Column("unit", sa.String)),
@@ -44,10 +40,10 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-    SELECT ?period ?geography_name ?geography_code ?parent_geography_code ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit
+    SELECT ?period ?geography_name ?geography_code ?direction (xsd:decimal(?gbp_total) AS ?total) ?unit
     WHERE {
         ?s <http://purl.org/linked-data/cube#dataSet> <http://gss-data.org.uk/data/gss_data/trade/ons-uk-sa-trade-in-goods> ;
-            <http://gss-data.org.uk/def/dimension/flow> ?direction_s ;
+            <http://gss-data.org.uk/def/dimension/flow-directions> ?direction_s ;
             <http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure> ?unit_s ;
             <http://gss-data.org.uk/def/measure/gbp-total> ?gbp_total ;
             <http://gss-data.org.uk/def/dimension/ons-partner-geography> ?geography_s ;
@@ -59,10 +55,6 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
         ?geography_s <http://www.w3.org/2004/02/skos/core#notation> ?geography_code .
         ?unit_s <http://www.w3.org/2000/01/rdf-schema#label> ?unit .
 
-        OPTIONAL {
-            ?geography_s <http://www.w3.org/2004/02/skos/core#broader> ?parent_geography_s .
-            ?parent_geography_s <http://www.w3.org/2004/02/skos/core#notation> ?parent_geography_code .
-        }
     }
     ORDER BY ?period ?geography_s
     """


### PR DESCRIPTION
### Description of change

Adds rolling trade total, trade balance and rolling totals for each
of the metric types as separate rows of the output CSV file.

This removes parent geography column and is_eu28 CSV column since the
data is not currently being exported by the ONS SPARQL API.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
