### PR TITLE
Allow for specifying target schema in TableConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-22
+
+### Changed
+
+- Optionally allow for use of a db schema other than public
+
 ## 2020-05-21
 
 ### Changed

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -72,6 +72,7 @@ class TableConfig:
 
     transforms: Iterable[Transform] = tuple()
     temp_table_suffix: Optional[str] = None
+    schema: str = 'public'
 
     _table = None
     _temp_table = None
@@ -110,6 +111,7 @@ class TableConfig:
                 self.table_name,
                 sqlalchemy.MetaData(),
                 *[column.copy() for _, column in self.columns],
+                schema=self.schema,
             )
         return self._table
 
@@ -126,6 +128,7 @@ class TableConfig:
                 f"{self.table.name}_{self.temp_table_suffix}".lower(),
                 self.table.metadata,
                 *[column.copy() for column in self.table.columns],
+                schema=self.schema,
             )
 
         return self._temp_table

--- a/tests/operators/test_db_tables.py
+++ b/tests/operators/test_db_tables.py
@@ -15,6 +15,7 @@ def table():
         sqlalchemy.MetaData(),
         sqlalchemy.Column("id", sqlalchemy.Integer(), nullable=False),
         sqlalchemy.Column("data", sqlalchemy.Integer()),
+        schema='public',
     )
 
 
@@ -263,8 +264,8 @@ def test_swap_dataset_tables(mock_db_conn, table):
             call().fetchall(),
             call(
                 '''
-                ALTER TABLE IF EXISTS QUOTED<test_table> RENAME TO QUOTED<test_table_123_swap>;
-                ALTER TABLE QUOTED<test_table_123> RENAME TO QUOTED<test_table>;
+                ALTER TABLE IF EXISTS QUOTED<public>.QUOTED<test_table> RENAME TO QUOTED<test_table_123_swap>;
+                ALTER TABLE QUOTED<public>.QUOTED<test_table_123> RENAME TO QUOTED<test_table>;
                 '''
             ),
             call('GRANT SELECT ON QUOTED<test_table> TO testuser'),


### PR DESCRIPTION
### Description of change

Allow for specifying a db schema at the dag level - as part of the ongoing dataset renaming work

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
