### PR TITLE
Updates ONS datasets 1, 3, 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Use financial year rather than tax year on export wins financial year csv 
 - Fix typos in oxford covid19 dataset
+- ONS datasets 1,3,4 queries based on feedback from data team.
 
 ## 2020-06-03
 


### PR DESCRIPTION
### Description of change
Owen has come back with some changes we need to make to rationalise
these datasets.

* Rolling totals are now recorded as period types rather than measures.
* `measure` column is renamed `trade_value`.
* `trade_type`='goods' added to ONS dataset 1.
* `trade_type`='services' added to ONS dataset 3.
* `product_type` renamed to `trade_type` in ONS dataset 4.
* `geography_code` renamed to `ons_iso_alpha_2_code`.
* `geography_name` renamed to `ons_region_name`.
* 'derived' added to `marker` column for all derived values (e.g. trade
balance).
* Change e.g. '12 month rolling total' to e.g. '12 months ending'
* Use 'gbp' and 'gbp-million' value consistently.
* `type` renamed to `direction`.
* Added `marker` column to ONS dataset 1.
 * Update dataset 3+4 queries to match dataset 1 style.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
