### PR TITLE
Add dependencies to daily and monthly CSV pipelines

### DIFF
--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -1,6 +1,19 @@
 from datetime import datetime
 
 from dataflow.dags import _CSVPipelineDAG
+from dataflow.dags.dataset_pipelines import (
+    AdvisersDatasetPipeline,
+    CompaniesDatasetPipeline,
+    ContactsDatasetPipeline,
+    EventsDatasetPipeline,
+    ExportWinsAdvisersDatasetPipeline,
+    ExportWinsBreakdownsDatasetPipeline,
+    ExportWinsHVCDatasetPipeline,
+    ExportWinsWinsDatasetPipeline,
+    InteractionsDatasetPipeline,
+    InvestmentProjectsDatasetPipeline,
+    TeamsDatasetPipeline,
+)
 
 
 class _DailyCSVPipeline(_CSVPipelineDAG):
@@ -8,7 +21,7 @@ class _DailyCSVPipeline(_CSVPipelineDAG):
     Base DAG to allow subclasses to be picked up by airflow
     """
 
-    schedule_interval = '0 5 * * *'
+    schedule_interval = "@daily"
     start_date = datetime(2020, 2, 11)
     timestamp_output = False
     static = True
@@ -17,6 +30,15 @@ class _DailyCSVPipeline(_CSVPipelineDAG):
 
 class DataHubFDIDailyCSVPipeline(_DailyCSVPipeline):
     """Pipeline meta object for Completed OMIS Order CSV."""
+
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        InvestmentProjectsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
 
     base_file_name = 'datahub-foreign-direct-investment-daily'
     query = '''
@@ -207,6 +229,15 @@ class DataHubFDIDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubServiceDeliveriesCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated service deliveries report"""
 
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        EventsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
+
     base_file_name = 'datahub-service-deliveries-current-calendar-year'
     query = '''
         WITH interactions AS (
@@ -285,6 +316,15 @@ class DataHubServiceDeliveriesCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
 
 class DataHubInteractionsCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated interactions report"""
+
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        EventsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
 
     base_file_name = 'datahub-interactions-current-calendar-year'
     query = '''
@@ -365,6 +405,15 @@ class DataHubInteractionsCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubServiceDeliveriesPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated service deliveries report for previous calendar year"""
 
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        EventsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
+
     base_file_name = 'datahub-service-deliveries-previous-calendar-year'
     query = '''
         WITH interactions AS (
@@ -444,6 +493,15 @@ class DataHubServiceDeliveriesPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
 class DataHubInteractionsPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated interactions report for previous calendar year"""
 
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        EventsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
+
     base_file_name = 'datahub-interactions-previous-calendar-year'
     query = '''
         WITH interactions AS (
@@ -521,6 +579,13 @@ class DataHubInteractionsPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
 
 class ExportWinsCurrentFinancialYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated export wins for current financial year"""
+
+    dependencies = [
+        ExportWinsAdvisersDatasetPipeline,
+        ExportWinsBreakdownsDatasetPipeline,
+        ExportWinsHVCDatasetPipeline,
+        ExportWinsWinsDatasetPipeline,
+    ]
 
     base_file_name = 'export-wins-current-financial-year'
     query = '''

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -1,6 +1,16 @@
 from datetime import datetime
 
 from dataflow.dags import _CSVPipelineDAG
+from dataflow.dags.dataset_pipelines import (
+    AdvisersDatasetPipeline,
+    CompaniesDatasetPipeline,
+    ContactsDatasetPipeline,
+    EventsDatasetPipeline,
+    InteractionsDatasetPipeline,
+    InvestmentProjectsDatasetPipeline,
+    OMISDatasetPipeline,
+    TeamsDatasetPipeline,
+)
 
 
 class _MonthlyCSVPipeline(_CSVPipelineDAG):
@@ -8,12 +18,18 @@ class _MonthlyCSVPipeline(_CSVPipelineDAG):
     Base DAG to allow subclasses to be picked up by airflow
     """
 
-    schedule_interval = '0 5 1 * *'
+    schedule_interval = '@monthly'
     start_date = datetime(2019, 10, 1)
 
 
 class DataHubOMISCompletedOrdersCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for Completed OMIS Order CSV."""
+
+    dependencies = [
+        CompaniesDatasetPipeline,
+        OMISDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
 
     base_file_name = 'datahub-omis-completed-orders'
     query = '''
@@ -48,6 +64,12 @@ class DataHubOMISCompletedOrdersCSVPipeline(_MonthlyCSVPipeline):
 
 class DataHubOMISCancelledOrdersCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for Cancelled OMIS Order CSV."""
+
+    dependencies = [
+        CompaniesDatasetPipeline,
+        OMISDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
 
     base_file_name = 'datahub-omis-cancelled-orders'
     query = '''
@@ -91,6 +113,12 @@ class DataHubOMISAllOrdersCSVPipeline(_MonthlyCSVPipeline):
     """View pipeline for all OMIS orders created up to the end
      of the last calendar month"""
 
+    dependencies = [
+        CompaniesDatasetPipeline,
+        OMISDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
+
     base_file_name = 'datahub-omis-all-orders'
     start_date = datetime(2019, 12, 1)
     query = '''
@@ -124,6 +152,12 @@ class DataHubOMISAllOrdersCSVPipeline(_MonthlyCSVPipeline):
 
 class DataHubOMISClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for monthly OMIS Client Survey report."""
+
+    dependencies = [
+        CompaniesDatasetPipeline,
+        OMISDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
 
     base_file_name = 'datahub-omis-client-survey'
     static = True
@@ -162,9 +196,18 @@ class DataHubOMISClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
 class DataHubServiceDeliveryInteractionsCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for the data hub service deliveries and interactions report."""
 
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        EventsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
+
     base_file_name = 'datahub-service-deliveries-and-interactions'
     start_date = datetime(2019, 11, 15)
-    schedule_interval = '0 5 15 * *'
+    schedule_interval = '0 0 15 * *'
     query = '''
         WITH interactions AS (
             SELECT *
@@ -254,9 +297,18 @@ class DataHubServiceDeliveryInteractionsCSVPipeline(_MonthlyCSVPipeline):
 class DataHubExportClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
     """Pipeline meta object for the data hub export client survey report."""
 
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        ContactsDatasetPipeline,
+        EventsDatasetPipeline,
+        InteractionsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
+
     base_file_name = 'datahub-export-client-survey'
     start_date = datetime(2019, 11, 15)
-    schedule_interval = '0 5 15 * *'
+    schedule_interval = '0 0 15 * *'
     static = True
     query = '''
         WITH service_deliveries AS (
@@ -348,6 +400,14 @@ class DataHubExportClientSurveyStaticCSVPipeline(_MonthlyCSVPipeline):
 
 class DataHubFDIMonthlyStaticCSVPipeline(_MonthlyCSVPipeline):
     """Static monthly view of the FDI (investment projects) report"""
+
+    dependencies = [
+        AdvisersDatasetPipeline,
+        CompaniesDatasetPipeline,
+        InteractionsDatasetPipeline,
+        InvestmentProjectsDatasetPipeline,
+        TeamsDatasetPipeline,
+    ]
 
     base_file_name = 'datahub-foreign-direct-investment-monthly'
     start_date = datetime(2020, 1, 1)


### PR DESCRIPTION
### Description of change

This replaces the time offset based scheduling of CSV pipelines with
task dependencies on all related dataset pipelines. The pipelines
will all start at the same time as the dataset ones, but will wait
form them to continue using sensor tasks.

This will make sure that any failed pipeline will also fail any
upstream CSV pipelines, so that they are clearly marked and can
be rerun together.

This adds a relatively large number of sensor tasks to the Airflow
pool, so we'll need to check that this doesn't slow down / block
tasks in production and potentially tweak the pool sizes based on
that.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
