### PR TITLE
CSSE COVID-19 global time series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## 2020-06-11
+
+### Added
+
+- COVID-19 Johns Hopkins University global time series data
+
+
 ## 2020-06-10
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ check:
 
 .PHONY: format
 format:
-	black --check --exclude='/(venv|dataflow\/ons_scripts)/' --skip-string-normalization .
+	black --exclude='/(venv|dataflow\/ons_scripts)/' --skip-string-normalization .
 
 .PHONY: test
 test:

--- a/dataflow/operators/csv_inputs.py
+++ b/dataflow/operators/csv_inputs.py
@@ -1,0 +1,34 @@
+import io
+from typing import Callable, Dict
+
+import pandas as pd
+import requests
+
+from dataflow.utils import S3Data, logger
+
+
+def fetch_mapped_hosted_csvs(
+    table_name: str,
+    source_urls: Dict[str, str],
+    df_transform: Callable[[pd.DataFrame], pd.DataFrame],
+    page_size: int = 10000,
+    **kwargs,
+):
+    s3 = S3Data(table_name, kwargs["ts_nodash"])
+
+    page = 1
+    for type_, source_url in source_urls.items():
+        logger.info(f"Fetching {source_url}")
+        response = requests.get(source_url)
+        df = pd.read_csv(io.StringIO(response.content.decode('utf-8')))
+        df = df_transform(df)
+        df["source_url_key"] = type_
+
+        for i in range((len(df) // page_size) + 1):
+            results = df.iloc[page_size * i : page_size * (i + 1)].to_json(
+                orient="records", date_format="iso"
+            )
+            s3.write_key(f"{page:010}.json", results, jsonify=False)
+            page += 1
+
+    logger.info("Fetching from source completed")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
           airflow initdb
           ./bin/airflow-scheduler.sh &
           airflow worker &
-          airflow worker --queues high-memory-usage --concurrency 1
+          airflow worker --queues high-memory-usage --concurrency 1 &
           airflow webserver --pid /tmp/airflow-webserver.pid -p 8080
     links:
       - "data-flow-db"

--- a/tests/operators/test_csv_inputs.py
+++ b/tests/operators/test_csv_inputs.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+from dataflow.operators import csv_inputs
+
+
+def test_fetch_mapped_hosted_csvs(mocker, requests_mock):
+    s3_mock = mock.Mock()
+
+    def transform(x):
+        x["modified"] = True
+
+        return x
+
+    mocker.patch.object(csv_inputs, "S3Data", return_value=s3_mock, autospec=True)
+    requests_mock.get("http://test1", text="1\n1\n1\n1\n")
+    requests_mock.get("http://test2", text="2\n2\n2\n2\n")
+
+    csv_inputs.fetch_mapped_hosted_csvs(
+        table_name="test",
+        source_urls={"one": "http://test1", "two": "http://test2"},
+        df_transform=transform,
+        page_size=2,
+        ts_nodash="123",
+    )
+
+    s3_mock.write_key.assert_has_calls(
+        [
+            mock.call(
+                '0000000001.json',
+                '[{"1":1,"modified":true,"source_url_key":"one"},{"1":1,"modified":true,"source_url_key":"one"}]',
+                jsonify=False,
+            ),
+            mock.call(
+                '0000000002.json',
+                '[{"1":1,"modified":true,"source_url_key":"one"}]',
+                jsonify=False,
+            ),
+            mock.call(
+                '0000000003.json',
+                '[{"2":2,"modified":true,"source_url_key":"two"},{"2":2,"modified":true,"source_url_key":"two"}]',
+                jsonify=False,
+            ),
+            mock.call(
+                '0000000004.json',
+                '[{"2":2,"modified":true,"source_url_key":"two"}]',
+                jsonify=False,
+            ),
+        ]
+    )

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 88
+    assert dagbag.size() == 89


### PR DESCRIPTION
### Description of change

### Add Covid-19 Johns Hopkins University global time series data

The 3 CSVs published by CSSE are combined into one table using a new operator that iterates over a mapping of source_urls and adds the URL key as a "type" column to the CSV data, allowing us to combine datasets that are published as separate files (for example separate import and export data CSVs) into one table, which is easier to use in the upcoming tools (since they don't generally allow UNION queries).

The data is transformed from a wide format (with a column for each date) into a normalized `(location, date, value)` list of measurements.

The new operator is using pandas to transform data, which means the entire dataset is loaded into memory. This is not an issue for the CSSE data, since it's relatively small (~60k rows), but might not be appropriate for larger datasets without some changes.

### Fix `make format` not formatting files


### Update CHANGELOG


### Fix docker-compose not starting up airflow webserver



### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
