### PR TITLE
Save transformed CSSE COVID data as a DB table

### DIFF
--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 88
+    assert dagbag.size() == 89


### PR DESCRIPTION
### Description of change

Analysts need to access transformed and grouped CSSE data from tools
and data visualisations, so we need to save it in a DB table instead
of a CSV


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
