### PR TITLE
Add People Finder integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-18
+
+### Added
+
+- Ability to fetch data from client-generated JWT authenticated API
+- DIT People Finder ("Digital Workspace") people data
+
 ## 2020-06-12
 
 ### Changed

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -96,3 +96,6 @@ DIT_SHAREPOINT_CREDENTIALS = {
     'client_id': os.environ.get('DIT_SHAREPOINT_CLIENT_ID'),
     'client_secret': os.environ.get('DIT_SHAREPOINT_CLIENT_SECRET'),
 }
+
+PEOPLE_FINDER_BASE_URL = os.environ.get('PEOPLE_FINDER_BASE_URL')
+PEOPLE_FINDER_PRIVATE_KEY = os.environ.get('PEOPLE_FINDER_PRIVATE_KEY')

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -931,3 +931,49 @@ class ExportWinsCurrentFinancialYearDailyCSVPipeline(_DailyCSVPipeline):
         ) a
         WHERE (confirmation_created_financial_year IS NULL OR confirmation_created_financial_year = current_financial_year)
 '''
+
+
+class PeopleFinderPeopleDailyCSVPipeline(_DailyCSVPipeline):
+    """Daily updated People Finder people report"""
+
+    base_file_name = 'people-finder-people'
+    query = '''
+    SELECT
+        people_finder_id AS "People Finder user ID",
+        staff_sso_id AS "Staff SSO user ID",
+        email AS "Preferred email",
+        full_name AS "Full name",
+        first_name AS "First name",
+        last_name AS "Last name",
+        profile_url AS "Profile URL",
+        roles AS "Roles",
+        manager_people_finder_id AS "Manager's People Finder user ID",
+        completion_score AS "Profile completion score",
+        works_monday AS "Works Monday",
+        works_tuesday AS "Works Tuesday",
+        works_wednesday AS "Works Wednesday",
+        works_thursday AS "Works Thursday",
+        works_friday AS "Works Friday",
+        works_saturday AS "Works Saturday",
+        works_sunday AS "Works Sunday",
+        primary_phone_number AS "Preferred contact number",
+        secondary_phone_number AS "Additional phone number",
+        skype_name AS "Skype name",
+        place_of_work AS "Place(s) I usually work",
+        city AS "City",
+        country AS "Country",
+        location_in_building AS "Locations in building",
+        location_other_uk AS "Other location - UK regional",
+        location_other_overseas AS "Other location - overseas",
+        key_skills AS "Key skills",
+        learning_and_development AS "Learning and development interests",
+        networks AS "Networks I belong to",
+        professions AS "Professions I belong to",
+        additional_responsibilities AS "My additional roles and responsibilities",
+        language_fluent AS "Fluent languages",
+        language_intermediate AS "Intermediate languages",
+        created_at AS "First created at",
+        last_edited_or_confirmed_at AS "Last edited/confirmed by user action at"
+    FROM people_finder__people
+    ORDER BY created_at ASC
+    '''

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -14,6 +14,7 @@ from dataflow.dags.dataset_pipelines import (
     InvestmentProjectsDatasetPipeline,
     TeamsDatasetPipeline,
 )
+from dataflow.dags.people_finder_pipelines import PeopleFinderPeoplePipeline
 
 
 class _DailyCSVPipeline(_CSVPipelineDAG):
@@ -937,6 +938,7 @@ class PeopleFinderPeopleDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated People Finder people report"""
 
     base_file_name = 'people-finder-people'
+    dependencies = [PeopleFinderPeoplePipeline]
     query = '''
     SELECT
         people_finder_id AS "People Finder user ID",

--- a/dataflow/dags/people_finder_pipelines.py
+++ b/dataflow/dags/people_finder_pipelines.py
@@ -1,0 +1,90 @@
+"""Defines pipeline DAGs for People Finder, the people directory on DIT's Digital Workspace"""
+import datetime
+from base64 import b64decode
+from functools import partial
+
+import sqlalchemy as sa
+from airflow.operators.python_operator import PythonOperator
+from sqlalchemy.dialects.postgresql import UUID
+
+from dataflow import config
+from dataflow.dags import _PipelineDAG
+from dataflow.operators.common import fetch_from_jwt_api
+from dataflow.utils import TableConfig
+
+
+class PeopleFinderPeoplePipeline(_PipelineDAG):
+    schedule_interval = "@daily"
+    path = "/api/v2/data_workspace_export"
+    source_url = f"{config.PEOPLE_FINDER_BASE_URL}{path}"
+    table_config = TableConfig(
+        table_name='people_finder__people',
+        field_mapping=[
+            (
+                "people_finder_id",
+                sa.Column("people_finder_id", sa.Integer, primary_key=True),
+            ),
+            ("staff_sso_id", sa.Column("staff_sso_id", UUID)),
+            ("email", sa.Column("email", sa.Text)),
+            ("full_name", sa.Column("full_name", sa.Text)),
+            ("first_name", sa.Column("first_name", sa.Text)),
+            ("last_name", sa.Column("last_name", sa.Text)),
+            ("profile_url", sa.Column("profile_url", sa.Text)),
+            ("roles", sa.Column("roles", sa.ARRAY(sa.String))),
+            (
+                "manager_people_finder_id",
+                sa.Column("manager_people_finder_id", sa.Integer),
+            ),
+            ("completion_score", sa.Column("completion_score", sa.Integer)),
+            ("works_monday", sa.Column("works_monday", sa.Boolean)),
+            ("works_tuesday", sa.Column("works_tuesday", sa.Boolean)),
+            ("works_wednesday", sa.Column("works_wednesday", sa.Boolean)),
+            ("works_thursday", sa.Column("works_thursday", sa.Boolean)),
+            ("works_friday", sa.Column("works_friday", sa.Boolean)),
+            ("works_saturday", sa.Column("works_saturday", sa.Boolean)),
+            ("works_sunday", sa.Column("works_sunday", sa.Boolean)),
+            ("primary_phone_number", sa.Column("primary_phone_number", sa.Text)),
+            ("secondary_phone_number", sa.Column("secondary_phone_number", sa.Text)),
+            ("skype_name", sa.Column("skype_name", sa.Text)),
+            ("place_of_work", sa.Column("place_of_work", sa.Text)),
+            ("city", sa.Column("city", sa.Text)),
+            ("country", sa.Column("country", sa.Text)),
+            ("location_in_building", sa.Column("location_in_building", sa.Text)),
+            ("location_other_uk", sa.Column("location_other_uk", sa.Text)),
+            ("location_other_overseas", sa.Column("location_other_overseas", sa.Text)),
+            ("key_skills", sa.Column("key_skills", sa.Text)),
+            (
+                "learning_and_development",
+                sa.Column("learning_and_development", sa.Text),
+            ),
+            ("networks", sa.Column("networks", sa.Text)),
+            ("professions", sa.Column("professions", sa.Text)),
+            (
+                "additional_responsibilities",
+                sa.Column("additional_responsibilities", sa.Text),
+            ),
+            ("language_fluent", sa.Column("language_fluent", sa.Text)),
+            ("language_intermediate", sa.Column("language_intermediate", sa.Text)),
+            ("created_at", sa.Column("created_at", sa.DateTime)),
+            (
+                "last_edited_or_confirmed_at",
+                sa.Column("last_edited_or_confirmed_at", sa.DateTime),
+            ),
+        ],
+    )
+
+    def get_fetch_operator(self) -> PythonOperator:
+        return PythonOperator(
+            task_id="run-fetch",
+            python_callable=partial(
+                fetch_from_jwt_api,
+                secret=b64decode(str(config.PEOPLE_FINDER_PRIVATE_KEY), validate=True),
+                algorithm="RS512",
+                payload={
+                    "fullpath": self.path,
+                    "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=60),
+                },
+            ),
+            provide_context=True,
+            op_args=[self.table_config.table_name, self.source_url],
+        )

--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -1,9 +1,10 @@
 import codecs
 import csv
 from contextlib import closing
-from typing import Optional
+from typing import Optional, Union
 
 import backoff
+import jwt
 import requests
 from mohawk import Sender
 from mohawk.exc import HawkFail
@@ -102,6 +103,22 @@ def fetch_from_hawk_api(
         page += 1
 
     logger.info("Fetching from source completed")
+
+
+def fetch_from_jwt_api(
+    table_name: str,
+    source_url: str,
+    payload: dict,
+    secret: Union[bytes, str],
+    algorithm: str,
+    results_key: Optional[str] = "results",
+    next_key: Optional[str] = "next",
+    **kwargs,
+):
+    auth_token = jwt.encode(payload, secret, algorithm=algorithm).decode("utf-8")
+    fetch_from_api_endpoint(
+        table_name, source_url, auth_token, results_key, next_key, **kwargs
+    )
 
 
 def fetch_from_api_endpoint(

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 apache-airflow[postgres,crypto,celery,s3,sentry,slack]
 backoff
 mohawk
+pyjwt[crypto]
 redis
 requests
 requests-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,7 @@ pyexcel-xls==0.5.8        # via gssutils
 pyexcel==0.6.1            # via gssutils
 pygments==2.5.1           # via apache-airflow, ipython
 pyhamcrest==2.0.2         # via databaker
-pyjwt[crypto]==1.7.1      # via flask-appbuilder, flask-jwt-extended, msal
+pyjwt[crypto]==1.7.1      # via -r requirements.in, flask-appbuilder, flask-jwt-extended, msal
 pyparsing==2.4.7          # via rdflib
 pyrsistent==0.15.6        # via jsonschema
 python-daemon==2.1.2      # via apache-airflow

--- a/sample.env
+++ b/sample.env
@@ -82,3 +82,6 @@ DIT_SHAREPOINT_TENANT_ID=get-from-vault
 DIT_SHAREPOINT_TENANT_DOMAIN=get-from-vault
 DIT_SHAREPOINT_CLIENT_ID=get-from-vault
 DIT_SHAREPOINT_CLIENT_SECRET=get-from-vault
+
+PEOPLE_FINDER_BASE_URL=https://peoplefinder-dev.london.cloudapps.digital
+PEOPLE_FINDER_PRIVATE_KEY=get-from-vault

--- a/tests/operators/test_dataset.py
+++ b/tests/operators/test_dataset.py
@@ -1,6 +1,7 @@
 import io
 from unittest import mock
 
+import jwt
 import pytest
 from mohawk.exc import HawkFail
 from requests import HTTPError
@@ -190,6 +191,20 @@ def test_token_auth_request(mocker, requests_mock):
             ),
             mock.call('0000000002.json', [{'id': 3, 'name': 'record3'}]),
         ]
+    )
+
+
+def test_fetch_from_jwt_api(mocker):
+    token_api_fetch_method = mocker.patch.object(
+        common, 'fetch_from_api_endpoint', autospec=True,
+    )
+    mocker.patch.object(jwt, "encode", return_value=b"jwt-token")
+
+    common.fetch_from_jwt_api(
+        'test_table', 'http://test', {"foo": "bar"}, "s3cr3t", "FAKE123"
+    )
+    token_api_fetch_method.assert_called_once_with(
+        'test_table', 'http://test', 'jwt-token', 'results', 'next'
     )
 
 

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 88
+    assert dagbag.size() == 90


### PR DESCRIPTION
This adds an initial import pipeline and a CSV pipeline for People
Finder, the staff directory of DIT's Digital Workspace.

- Add ability to fetch data from client-generated JWT authenticated API
- Add import pipeline for People Finder
- Add daily CSV pipeline for People Finder data

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [x] Has the README been updated (if needed)?
