### PR TITLE
Always keep S3 data for latest DAG run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-23
+
+### Changed
+
+- S3 maintenance job will always retain data files from the latest run of each pipeline.
+
 ## 2020-06-22
 
 ### Changed

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -20,9 +20,10 @@ def postgres_hook(mocker):
 
 def test_cleanup_old_s3_files(s3):
     s3.list_prefixes.side_effect = [
-        ['pipeline1/', 'pipeline2/'],
+        ['pipeline1/', 'pipeline2/', 'pipeline3/'],
         ['pipeline1/20000101T000000/', 'pipeline1/20000104T000000/'],
         ['pipeline2/20000101T000000/', 'pipeline2/20000104T000000/'],
+        ['pipeline3/20000101T000000/'],
     ]
 
     maintenance.cleanup_old_s3_files(ts_nodash="20000110T000000")


### PR DESCRIPTION
### Description of change
Our S3 maintenance job cleans up old files used to store data during the
'fetch from api' phase of a pipeline. By default it drops data older
than 7 days. Some of our pipelines run monthly. Airflow pipelines record
their execution date related to the start of the period they're meant to
run for, which means that for monthly jobs the datetime tag on a
pipeline is always a month old - which means when our maintenance job
scans S3 files, it sees a date from a month ago and elects to clean it
up.

This patch forces our S3 maintenance job to always retain the latest
copy of the DAG run, regardless of how old it is.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
