### PR TITLE
Force http for consent service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - New field `cet_applies_until_trade_remedy_transition_reviews_concluded` added to tariff dataset
 
+## 2020-06-26
+
+### Changed
+
+- Force http requests for consent service to fix hawk auth issue
+
 ## 2020-06-23
 
 ### Changed

--- a/dataflow/dags/consent_pipelines.py
+++ b/dataflow/dags/consent_pipelines.py
@@ -20,7 +20,9 @@ class _ConsentPipeline(_PipelineDAG):
         return PythonOperator(
             task_id="fetch-consent-api-data",
             python_callable=partial(
-                fetch_from_hawk_api, hawk_credentials=config.CONSENT_HAWK_CREDENTIALS,
+                fetch_from_hawk_api,
+                hawk_credentials=config.CONSENT_HAWK_CREDENTIALS,
+                force_http=True,
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],


### PR DESCRIPTION
### Description of change

We are hitting the internal domain for the consent service via http as requested but it returns https next/prev urls in it's response. This forces http for all requests.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
