### PR TITLE
Add field to tariff pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-29
+
+### Changed
+
+- New field `cet_applies_until_trade_remedy_transition_reviews_concluded` added to tariff dataset
+
 ## 2020-06-23
 
 ### Changed

--- a/dataflow/dags/tariff_pipelines.py
+++ b/dataflow/dags/tariff_pipelines.py
@@ -23,6 +23,13 @@ class GlobalUKTariffPipeline(_PipelineDAG):
             ('change', sa.Column('change', sa.String)),
             ('trade_remedy_applies', sa.Column('trade_remedy_applies', sa.Boolean)),
             ('dumping_margin_applies', sa.Column('dumping_margin_applies', sa.Boolean)),
+            (
+                'cet_applies_until_trade_remedy_transition_reviews_concluded',
+                sa.Column(
+                    'cet_applies_until_trade_remedy_transition_reviews_concluded',
+                    sa.Boolean,
+                ),
+            ),
             ('suspension_applies', sa.Column('suspension_applies', sa.Boolean)),
             ('atq_applies', sa.Column('atq_applies', sa.Boolean)),
         ],


### PR DESCRIPTION
### Description of change

Adds a new field `cet_applies_until_trade_remedy_transition_reviews_concluded` to the global tariffs dataset

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
