### PR TITLE
Remove `dumping_margin_applies` column from tariff dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Remove field `dumping_margin_applies` from global tariff dataset
+
+## 2020-06-29
+
+### Changed
+
 - New field `cet_applies_until_trade_remedy_transition_reviews_concluded` added to tariff dataset
 
 ## 2020-06-23

--- a/dataflow/dags/tariff_pipelines.py
+++ b/dataflow/dags/tariff_pipelines.py
@@ -22,7 +22,6 @@ class GlobalUKTariffPipeline(_PipelineDAG):
             ('ukgt_duty_rate', sa.Column('ukgt_duty_rate', sa.String)),
             ('change', sa.Column('change', sa.String)),
             ('trade_remedy_applies', sa.Column('trade_remedy_applies', sa.Boolean)),
-            ('dumping_margin_applies', sa.Column('dumping_margin_applies', sa.Boolean)),
             (
                 'cet_applies_until_trade_remedy_transition_reviews_concluded',
                 sa.Column(


### PR DESCRIPTION
### Description of change

Updates the global tariff data DAG. A new release of the tariff tool has been deployed which removes the `dumping_margin_applies` column.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
