### PR TITLE
Remove People Finder CSV pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-30
+
+### Removed
+
+- Removed People Finder CSV pipeline (this will be handled as data cuts in Data Workspace instead)
+
 ## 2020-06-29
 
 ### Changed

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -14,7 +14,6 @@ from dataflow.dags.dataset_pipelines import (
     InvestmentProjectsDatasetPipeline,
     TeamsDatasetPipeline,
 )
-from dataflow.dags.people_finder_pipelines import PeopleFinderPeoplePipeline
 
 
 class _DailyCSVPipeline(_CSVPipelineDAG):
@@ -932,50 +931,3 @@ class ExportWinsCurrentFinancialYearDailyCSVPipeline(_DailyCSVPipeline):
         ) a
         WHERE (confirmation_created_financial_year IS NULL OR confirmation_created_financial_year = current_financial_year)
 '''
-
-
-class PeopleFinderPeopleDailyCSVPipeline(_DailyCSVPipeline):
-    """Daily updated People Finder people report"""
-
-    base_file_name = 'people-finder-people'
-    dependencies = [PeopleFinderPeoplePipeline]
-    query = '''
-    SELECT
-        people_finder_id AS "People Finder user ID",
-        staff_sso_id AS "Staff SSO user ID",
-        email AS "Preferred email",
-        full_name AS "Full name",
-        first_name AS "First name",
-        last_name AS "Last name",
-        profile_url AS "Profile URL",
-        roles AS "Roles",
-        manager_people_finder_id AS "Manager's People Finder user ID",
-        completion_score AS "Profile completion score",
-        works_monday AS "Works Monday",
-        works_tuesday AS "Works Tuesday",
-        works_wednesday AS "Works Wednesday",
-        works_thursday AS "Works Thursday",
-        works_friday AS "Works Friday",
-        works_saturday AS "Works Saturday",
-        works_sunday AS "Works Sunday",
-        primary_phone_number AS "Preferred contact number",
-        secondary_phone_number AS "Additional phone number",
-        skype_name AS "Skype name",
-        place_of_work AS "Place(s) I usually work",
-        city AS "City",
-        country AS "Country",
-        location_in_building AS "Locations in building",
-        location_other_uk AS "Other location - UK regional",
-        location_other_overseas AS "Other location - overseas",
-        key_skills AS "Key skills",
-        learning_and_development AS "Learning and development interests",
-        networks AS "Networks I belong to",
-        professions AS "Professions I belong to",
-        additional_responsibilities AS "My additional roles and responsibilities",
-        language_fluent AS "Fluent languages",
-        language_intermediate AS "Intermediate languages",
-        created_at AS "First created at",
-        last_edited_or_confirmed_at AS "Last edited/confirmed by user action at"
-    FROM people_finder__people
-    ORDER BY created_at ASC
-    '''

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 92
+    assert dagbag.size() == 91


### PR DESCRIPTION
### Description of change

CSVs of People Finder data will be handled as data cuts in Data Workspace instead, so this pipeline is not needed

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [x] Has the README been updated (if needed)?
