### PR TITLE
Add additional fields to People Finder pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-01
+
+### Changed
+
+- Changed People Finder pipeline to support new/updated fields
+
 ## 2020-06-30
 
 ### Removed

--- a/dataflow/dags/people_finder_pipelines.py
+++ b/dataflow/dags/people_finder_pipelines.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import sqlalchemy as sa
 from airflow.operators.python_operator import PythonOperator
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from dataflow import config
 from dataflow.dags import _PipelineDAG
@@ -30,12 +30,14 @@ class PeopleFinderPeoplePipeline(_PipelineDAG):
             ("first_name", sa.Column("first_name", sa.Text)),
             ("last_name", sa.Column("last_name", sa.Text)),
             ("profile_url", sa.Column("profile_url", sa.Text)),
-            ("roles", sa.Column("roles", sa.ARRAY(sa.String))),
+            ("roles", sa.Column("roles", JSONB)),
+            ("formatted_roles", sa.Column("formatted_roles", sa.ARRAY(sa.String))),
             (
                 "manager_people_finder_id",
                 sa.Column("manager_people_finder_id", sa.Integer),
             ),
             ("completion_score", sa.Column("completion_score", sa.Integer)),
+            ("is_stale", sa.Column("is_stale", sa.Boolean)),
             ("works_monday", sa.Column("works_monday", sa.Boolean)),
             ("works_tuesday", sa.Column("works_tuesday", sa.Boolean)),
             ("works_wednesday", sa.Column("works_wednesday", sa.Boolean)),
@@ -46,22 +48,47 @@ class PeopleFinderPeoplePipeline(_PipelineDAG):
             ("primary_phone_number", sa.Column("primary_phone_number", sa.Text)),
             ("secondary_phone_number", sa.Column("secondary_phone_number", sa.Text)),
             ("skype_name", sa.Column("skype_name", sa.Text)),
-            ("place_of_work", sa.Column("place_of_work", sa.Text)),
+            ("formatted_location", sa.Column("formatted_location", sa.Text)),
+            ("buildings", sa.Column("buildings", sa.ARRAY(sa.String))),
+            ("formatted_buildings", sa.Column("formatted_buildings", sa.Text)),
             ("city", sa.Column("city", sa.Text)),
             ("country", sa.Column("country", sa.Text)),
+            ("country_name", sa.Column("country_name", sa.Text)),
+            ("grade", sa.Column("grade", sa.Text)),
+            ("formatted_grade", sa.Column("formatted_grade", sa.Text)),
             ("location_in_building", sa.Column("location_in_building", sa.Text)),
             ("location_other_uk", sa.Column("location_other_uk", sa.Text)),
             ("location_other_overseas", sa.Column("location_other_overseas", sa.Text)),
-            ("key_skills", sa.Column("key_skills", sa.Text)),
+            ("key_skills", sa.Column("key_skills", sa.ARRAY(sa.String))),
+            ("other_key_skills", sa.Column("other_key_skills", sa.Text)),
+            ("formatted_key_skills", sa.Column("formatted_key_skills", sa.Text)),
             (
                 "learning_and_development",
-                sa.Column("learning_and_development", sa.Text),
+                sa.Column("learning_and_development", sa.ARRAY(sa.String)),
             ),
-            ("networks", sa.Column("networks", sa.Text)),
-            ("professions", sa.Column("professions", sa.Text)),
+            (
+                "other_learning_and_development",
+                sa.Column("other_learning_and_development", sa.Text),
+            ),
+            (
+                "formatted_learning_and_development",
+                sa.Column("formatted_learning_and_development", sa.Text),
+            ),
+            ("networks", sa.Column("networks", sa.ARRAY(sa.String))),
+            ("formatted_networks", sa.Column("formatted_networks", sa.Text)),
+            ("professions", sa.Column("professions", sa.ARRAY(sa.String))),
+            ("formatted_professions", sa.Column("formatted_professions", sa.Text)),
             (
                 "additional_responsibilities",
-                sa.Column("additional_responsibilities", sa.Text),
+                sa.Column("additional_responsibilities", sa.ARRAY(sa.String)),
+            ),
+            (
+                "other_additional_responsibilities",
+                sa.Column("other_additional_responsibilities", sa.Text),
+            ),
+            (
+                "formatted_additional_responsibilities",
+                sa.Column("formatted_additional_responsibilities", sa.Text),
             ),
             ("language_fluent", sa.Column("language_fluent", sa.Text)),
             ("language_intermediate", sa.Column("language_intermediate", sa.Text)),
@@ -70,6 +97,8 @@ class PeopleFinderPeoplePipeline(_PipelineDAG):
                 "last_edited_or_confirmed_at",
                 sa.Column("last_edited_or_confirmed_at", sa.DateTime),
             ),
+            ("login_count", sa.Column("login_count", sa.Integer)),
+            ("last_login_at", sa.Column("last_login_at", sa.DateTime)),
         ],
     )
 


### PR DESCRIPTION
### Description of change

The API on People Finder has been updated to expose a number of
additional fields (some have also been renamed for clarity). This adds
support for the new data structure to the People Finder pipeline.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
