### PR TITLE
Add new dataset for datahub company referrals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-07-02
 
+### Added
+
+- New data hub dataset for company referrals
+
 ### Changed
 
 - Install wheel before requirements file to fix circle ci build issue
@@ -16,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Changed People Finder pipeline to support new/updated fields
+
 ## 2020-07-01
 
 ### Changed

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -855,3 +855,29 @@ class RawWorldBankBoundRatePipeline(_DatasetPipeline):
             ('totalNumberOfLines', sa.Column('number_of_total_lines', sa.Numeric)),
         ],
     )
+
+
+class DataHubCompanyReferralsDatasetPipeline(_DatasetPipeline):
+    """Pipeline meta object for data hub referrals."""
+
+    source_url = '{0}/v4/dataset/company-referrals-dataset'.format(
+        config.DATAHUB_BASE_URL
+    )
+    table_config = TableConfig(
+        schema='datahub',
+        table_name='company_referrals',
+        field_mapping=[
+            ('company_id', sa.Column('company_id', UUID)),
+            ('completed_by_id', sa.Column('completed_by_id', UUID)),
+            ('completed_on', sa.Column('completed_on', sa.DateTime)),
+            ('contact_id', sa.Column('contact_id', UUID)),
+            ('created_by_id', sa.Column('created_by_id', UUID)),
+            ('created_on', sa.Column('created_on', sa.DateTime)),
+            ('id', sa.Column('id', UUID, primary_key=True)),
+            ('interaction_id', sa.Column('interaction_id', UUID)),
+            ('notes', sa.Column('notes', sa.Text)),
+            ('recipient_id', sa.Column('recipient_id', UUID)),
+            ('status', sa.Column('status', sa.String)),
+            ('subject', sa.Column('subject', sa.String)),
+        ],
+    )

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 91
+    assert dagbag.size() == 92


### PR DESCRIPTION
### Description of change

Adds a new dataset for data hub company referrals. The need for this comes from the firebreak project [Mapping referrals as they travel around the world](https://trello.com/c/QLJ6186n/70-mapping-referrals-as-they-travel-around-the-world)

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
