### PR TITLE
Bugfix/circleci build fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install wheel
             pip install -r requirements-dev.txt
       - run:
           name: Run static checks

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,5 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 10
   reviewers:
-  - allait
   - niross
   rebase-strategy: disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-02
+
+### Changed
+
+- Install wheel before requirements file to fix circle ci build issue
+- Remove Alexey from depndabot config
+
+## 2020-07-01
+
+### Changed
+
+- Changed People Finder pipeline to support new/updated fields
 ## 2020-07-01
 
 ### Changed


### PR DESCRIPTION
### Description of change

This fixes the issue we were having with builds failing on circleci with the error `ERROR: Command errored out with exit status 1: WARNING: The wheel package is not available.`.

Also removes Alexey from the dependabot config.
 
### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
