### PR TITLE
Add new companies house companies dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-03
+
+### Added
+
+- New data set for companies house company data
+
 ## 2020-07-02
 
 ### Added

--- a/dataflow/dags/companies_house_pipelines.py
+++ b/dataflow/dags/companies_house_pipelines.py
@@ -1,0 +1,140 @@
+import sqlalchemy as sa
+from airflow.operators.python_operator import PythonOperator
+
+from dataflow.dags import _PipelineDAG
+from dataflow.operators.companies_house import fetch_companies_house_companies
+from dataflow.utils import TableConfig
+
+
+class CompaniesHouseCompaniesPipeline(_PipelineDAG):
+    schedule_interval = '0 0 10 * *'
+    allow_null_columns = True
+    number_of_files = 6
+    source_url = 'http://download.companieshouse.gov.uk/BasicCompanyData-{file_date}-part{file_num}_{num_files}.zip'
+    table_config = TableConfig(
+        schema='companieshouse',
+        table_name='companies',
+        field_mapping=[
+            ('CompanyName', sa.Column('company_name', sa.String)),
+            ('CompanyNumber', sa.Column('company_number', sa.String)),
+            ('RegAddress.CareOf', sa.Column('care_of', sa.String)),
+            ('RegAddress.POBox', sa.Column('po_box', sa.String)),
+            ('RegAddress.AddressLine1', sa.Column('address_line_1', sa.Text)),
+            ('RegAddress.AddressLine2', sa.Column('address_line_2', sa.Text)),
+            ('RegAddress.PostTown', sa.Column('post_town', sa.String)),
+            ('RegAddress.County', sa.Column('county', sa.String)),
+            ('RegAddress.Country', sa.Column('country', sa.String)),
+            ('RegAddress.PostCode', sa.Column('postcode', sa.String)),
+            ('CompanyCategory', sa.Column('company_category', sa.String)),
+            ('CompanyStatus', sa.Column('company_status', sa.String)),
+            ('CountryOfOrigin', sa.Column('country_of_origin', sa.String)),
+            ('DissolutionDate', sa.Column('dissolution_date', sa.String)),
+            ('IncorporationDate', sa.Column('incorporation_date', sa.String)),
+            ('Accounts.AccountRefDay', sa.Column('account_ref_day', sa.String)),
+            ('Accounts.AccountRefMonth', sa.Column('account_ref_month', sa.String)),
+            ('Accounts.NextDueDate', sa.Column('account_next_due_date', sa.String)),
+            (
+                'Accounts.LastMadeUpDate',
+                sa.Column('account_last_made_up_date', sa.String),
+            ),
+            ('Accounts.AccountCategory', sa.Column('account_category', sa.String)),
+            ('Returns.NextDueDate', sa.Column('return_next_due_date', sa.String)),
+            (
+                'Returns.LastMadeUpDate',
+                sa.Column('return_last_made_up_date', sa.String),
+            ),
+            ('Mortgages.NumMortCharges', sa.Column('num_mort_charges', sa.String)),
+            (
+                'Mortgages.NumMortOutstanding',
+                sa.Column('num_mort_outstanding', sa.String),
+            ),
+            (
+                'Mortgages.NumMortPartSatisfied',
+                sa.Column('num_mort_parts_satisified', sa.String),
+            ),
+            ('Mortgages.NumMortSatisfied', sa.Column('num_mort_satisfied', sa.String)),
+            ('SICCode.SicText_1', sa.Column('sic_code_1', sa.String)),
+            ('SICCode.SicText_2', sa.Column('sic_code_2', sa.String)),
+            ('SICCode.SicText_3', sa.Column('sic_code_3', sa.String)),
+            ('SICCode.SicText_4', sa.Column('sic_code_4', sa.String)),
+            (
+                'LimitedPartnerships.NumGenPartners',
+                sa.Column('num_gen_partners', sa.String),
+            ),
+            (
+                'LimitedPartnerships.NumLimPartners',
+                sa.Column('num_lim_partners', sa.String),
+            ),
+            ('URI', sa.Column('uri', sa.String)),
+            (
+                'PreviousName_1.CONDATE',
+                sa.Column('previous_name_1_change_date', sa.String),
+            ),
+            ('PreviousName_1.CompanyName', sa.Column('previous_name_1', sa.String)),
+            (
+                'PreviousName_2.CONDATE',
+                sa.Column('previous_name_2_change_date', sa.String),
+            ),
+            ('PreviousName_2.CompanyName', sa.Column('previous_name_2', sa.String)),
+            (
+                'PreviousName_3.CONDATE',
+                sa.Column('previous_name_3_change_date', sa.String),
+            ),
+            ('PreviousName_3.CompanyName', sa.Column('previous_name_3', sa.String)),
+            (
+                'PreviousName_4.CONDATE',
+                sa.Column('previous_name_4_change_date', sa.String),
+            ),
+            ('PreviousName_4.CompanyName', sa.Column('previous_name_4', sa.String)),
+            (
+                'PreviousName_5.CONDATE',
+                sa.Column('previous_name_5_change_date', sa.String),
+            ),
+            ('PreviousName_5.CompanyName', sa.Column('previous_name_5', sa.String)),
+            (
+                'PreviousName_6.CONDATE',
+                sa.Column('previous_name_6_change_date', sa.String),
+            ),
+            ('PreviousName_6.CompanyName', sa.Column('previous_name_6', sa.String)),
+            (
+                'PreviousName_7.CONDATE',
+                sa.Column('previous_name_7_change_date', sa.String),
+            ),
+            ('PreviousName_7.CompanyName', sa.Column('previous_name_7', sa.String)),
+            (
+                'PreviousName_8.CONDATE',
+                sa.Column('previous_name_8_change_date', sa.String),
+            ),
+            ('PreviousName_8.CompanyName', sa.Column('previous_name_8', sa.String)),
+            (
+                'PreviousName_9.CONDATE',
+                sa.Column('previous_name_9_change_date', sa.String),
+            ),
+            ('PreviousName_9.CompanyName', sa.Column('previous_name_9', sa.String)),
+            (
+                'PreviousName_10.CONDATE',
+                sa.Column('previous_name_10_change_date', sa.String),
+            ),
+            ('PreviousName_10.CompanyName', sa.Column('previous_name_10', sa.String)),
+            (
+                'ConfStmtNextDueDate',
+                sa.Column('conf_statement_next_due_date', sa.String),
+            ),
+            (
+                'ConfStmtLastMadeUpDate',
+                sa.Column('conf_statement_last_made_up_date', sa.String),
+            ),
+        ],
+    )
+
+    def get_fetch_operator(self) -> PythonOperator:
+        return PythonOperator(
+            task_id='run-fetch',
+            python_callable=fetch_companies_house_companies,
+            provide_context=True,
+            op_args=[
+                self.table_config.table_name,
+                self.source_url,
+                self.number_of_files,
+            ],
+        )

--- a/dataflow/dags/companies_house_pipelines.py
+++ b/dataflow/dags/companies_house_pipelines.py
@@ -124,6 +124,7 @@ class CompaniesHouseCompaniesPipeline(_PipelineDAG):
                 'ConfStmtLastMadeUpDate',
                 sa.Column('conf_statement_last_made_up_date', sa.String),
             ),
+            ('publish_date', sa.Column('publish_date', sa.Date)),
         ],
     )
 

--- a/dataflow/operators/companies_house.py
+++ b/dataflow/operators/companies_house.py
@@ -1,0 +1,61 @@
+import codecs
+import csv
+import io
+import zipfile
+
+import backoff
+import requests
+
+from dataflow.utils import S3Data, logger
+
+
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
+def _download(source_url):
+    response = requests.get(source_url)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.error(f"Request failed: {response.text}")
+        raise
+
+    return response.content
+
+
+def fetch_companies_house_companies(
+    table_name: str,
+    source_url: str,
+    number_of_files: int,
+    page_size: int = 10000,
+    **kwargs,
+):
+    """
+    Loop through `number_of_files`, build the url, download the zip file,
+    extract and write data in batches of `page_size` to s3
+    """
+    s3 = S3Data(table_name, kwargs['ts_nodash'])
+    page = 1
+    results = []
+    for file_num in range(1, number_of_files + 1):
+        url = source_url.format(
+            file_date=kwargs['next_execution_date'].strftime('%Y-%m-01'),
+            file_num=file_num,
+            num_files=number_of_files,
+        )
+        logger.info(f'Fetching zip file from {url}')
+        with zipfile.ZipFile(io.BytesIO(_download(url))) as archive:
+            with archive.open(archive.namelist()[0], 'r') as f:
+                reader = csv.DictReader(codecs.iterdecode(f.readlines(), 'utf-8'))
+                if reader.fieldnames is not None:
+                    reader.fieldnames = [x.strip() for x in reader.fieldnames]
+                for row in reader:
+                    results.append(row)
+                    if len(results) >= page_size:
+                        s3.write_key(f'{page:010}.json', results)
+                        results = []
+                        page += 1
+
+    if results:
+        s3.write_key(f'{page:010}.json', results)
+
+    logger.info('Fetching from source completed')

--- a/tests/operators/test_companies_house.py
+++ b/tests/operators/test_companies_house.py
@@ -46,9 +46,24 @@ def test_fetch_companies(mocker, requests_mock):
             mock.call(
                 '0000000001.json',
                 [
-                    {'field1': 'text1', 'field2': '010121000', 'field3': '00150'},
-                    {'field1': 'text2', 'field2': '010121000', 'field3': '00150'},
-                    {'field1': 'text3', 'field2': '010121000', 'field3': '00150'},
+                    {
+                        'field1': 'text1',
+                        'field2': '010121000',
+                        'field3': '00150',
+                        'publish_date': '2020-01-01',
+                    },
+                    {
+                        'field1': 'text2',
+                        'field2': '010121000',
+                        'field3': '00150',
+                        'publish_date': '2020-01-01',
+                    },
+                    {
+                        'field1': 'text3',
+                        'field2': '010121000',
+                        'field3': '00150',
+                        'publish_date': '2020-01-01',
+                    },
                 ],
             ),
             mock.call(
@@ -58,8 +73,14 @@ def test_fetch_companies(mocker, requests_mock):
                         'field1': 'text3',
                         'field2': '000000000',
                         'field3': '0000000195241',
+                        'publish_date': '2020-01-01',
                     },
-                    {'field1': 'text4', 'field2': '999999999', 'field3': '00000'},
+                    {
+                        'field1': 'text4',
+                        'field2': '999999999',
+                        'field3': '00000',
+                        'publish_date': '2020-01-01',
+                    },
                 ],
             ),
         ]

--- a/tests/operators/test_companies_house.py
+++ b/tests/operators/test_companies_house.py
@@ -1,0 +1,66 @@
+import io
+import zipfile
+from datetime import datetime
+from unittest import mock
+
+from dataflow.operators import companies_house
+
+
+def test_fetch_companies(mocker, requests_mock):
+    file1 = io.BytesIO()
+    with zipfile.ZipFile(file1, "w") as zf:
+        zf.writestr(
+            'dummy_companies',
+            'field1,field2,field3\ntext1,010121000,00150\ntext2,010121000,00150\ntext3,010121000,00150\n',
+        )
+
+    file2 = io.BytesIO()
+    with zipfile.ZipFile(file2, "w") as zf:
+        zf.writestr(
+            'dummy_companies',
+            'field1,field2,field3\ntext3,000000000,0000000195241\ntext4,999999999,00000\n',
+        )
+
+    requests_mock.get(
+        'http://test/BasicCompanyData-2020-01-01-part1_2.zip', content=file1.getvalue(),
+    )
+
+    requests_mock.get(
+        'http://test/BasicCompanyData-2020-01-01-part2_2.zip', content=file2.getvalue(),
+    )
+
+    s3_mock = mock.MagicMock()
+    mocker.patch.object(companies_house, "S3Data", return_value=s3_mock, autospec=True)
+
+    companies_house.fetch_companies_house_companies(
+        'companies',
+        'http://test/BasicCompanyData-{file_date}-part{file_num}_{num_files}.zip',
+        2,
+        page_size=3,
+        ts_nodash='task-1',
+        next_execution_date=datetime(2020, 1, 10),
+    )
+
+    s3_mock.write_key.assert_has_calls(
+        [
+            mock.call(
+                '0000000001.json',
+                [
+                    {'field1': 'text1', 'field2': '010121000', 'field3': '00150'},
+                    {'field1': 'text2', 'field2': '010121000', 'field3': '00150'},
+                    {'field1': 'text3', 'field2': '010121000', 'field3': '00150'},
+                ],
+            ),
+            mock.call(
+                '0000000002.json',
+                [
+                    {
+                        'field1': 'text3',
+                        'field2': '000000000',
+                        'field3': '0000000195241',
+                    },
+                    {'field1': 'text4', 'field2': '999999999', 'field3': '00000'},
+                ],
+            ),
+        ]
+    )

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 92
+    assert dagbag.size() == 93


### PR DESCRIPTION
### Description of change

Adds a new pipeline for ingesting companies house company data. The data is hosted as 6 dated zipped csv files and is updated within 5 business days of the first of the month. This pipeline will run on the 10th of the month and will download and extract each file, writing the data to s3 in chunks of 10,000 rows

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
