### PR TITLE
Remove public information asset register dag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-08
+
+### Added
+
+- Remove public information asset register DAG
+
 ## 2020-07-03
 
 ### Added

--- a/dataflow/dags/sharepoint_pipelines.py
+++ b/dataflow/dags/sharepoint_pipelines.py
@@ -100,20 +100,3 @@ class InformationAssetRegisterPipeline(_SharepointPipeline):
             ('Path', sa.Column('path', sa.String)),
         ],
     )
-
-
-class PublicInformationAssetRegisterPipeline(_SharepointPipeline):
-    sub_site_id = config.SHAREPOINT_KIM_SITE_ID
-    list_id = config.SHAREPOINT_PUBLIC_IAR_LIST_ID
-    allow_null_columns = True
-    table_config = TableConfig(
-        schema='dit',
-        table_name='public_information_asset_register',
-        field_mapping=[
-            ('#', sa.Column('id', sa.String)),
-            ('Information Asset', sa.Column('information_asset', sa.String)),
-            ('Description', sa.Column('description', sa.String)),
-            ('Item Type', sa.Column('item_type', sa.String)),
-            ('Path', sa.Column('path', sa.String)),
-        ],
-    )

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -4,4 +4,4 @@ from airflow.models.dagbag import DagBag
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
 
-    assert dagbag.size() == 93
+    assert dagbag.size() == 92


### PR DESCRIPTION
### Description of change

Removes the public information asset register pipeline as it's deemed unnecessary (as requested by AL and JM).

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
