### PR TITLE
Clean up normalisation on ons total and marker fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-09
+
+### Changed
+
+- Updates to normalised fields across ons datasets
+    - Normalise totals fields to int as all values are rounded to millions
+    - Replace empty strings with nulls on marker fields
+    - Replace 'N/A' and 'not-applicable' with 'not-available' on marker fields
+
 ## 2020-07-08
 
 ### Added

--- a/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
+++ b/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
@@ -51,7 +51,7 @@ FROM (
         og_direction,
         norm_total as trade_value,
         og_unit,
-        og_marker AS marker
+        norm_marker AS marker
     FROM ons__uk_sa_trade_in_goods
     UNION (
         SELECT
@@ -178,7 +178,7 @@ FROM (
         og_product_name as product_name,
         norm_total as trade_value,
         og_unit as unit,
-        og_marker as marker
+        norm_marker as marker
     FROM ons__uk_trade_in_services_by_country_nsa
     UNION (
         SELECT
@@ -239,7 +239,7 @@ FROM (
         og_product_name as product_name,
         norm_total as total,
         og_unit as unit,
-        og_marker as marker
+        norm_marker as marker
     FROM ons__uk_total_trade_all_countries_nsa
     UNION (
         SELECT
@@ -354,7 +354,7 @@ WITH all_rows_plus_balances AS (
            unnest(array[imports_t.og_direction, exports_t.og_direction, 'trade balance', 'total trade']) AS direction,
            unnest(array[imports_t.norm_total, exports_t.norm_total, exports_t.norm_total - imports_t.norm_total, exports_t.norm_total + imports_t.norm_total]) AS total,
            imports_t.og_unit as unit,
-           unnest(array[imports_t.og_marker, exports_t.og_marker, 'derived', 'derived']) AS marker
+           unnest(array[imports_t.norm_marker, exports_t.norm_marker, 'derived', 'derived']) AS marker
     FROM ons__uk_trade_goods_by_country_commodity AS imports_t
     JOIN ons__uk_trade_goods_by_country_commodity AS exports_t ON imports_t.og_ons_iso_alpha_2_code = exports_t.og_ons_iso_alpha_2_code AND imports_t.og_product_code = exports_t.og_product_code AND imports_t.og_period = exports_t.og_period AND imports_t.og_direction = 'imports' AND exports_t.og_direction = 'exports'
 ),

--- a/dataflow/dags/ons_parsing_pipelines.py
+++ b/dataflow/dags/ons_parsing_pipelines.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from dataflow.dags import _PipelineDAG
 from dataflow.operators.db_tables import insert_csv_data_into_db
 from dataflow.operators.ons import run_ipython_ons_extraction
+from dataflow.transforms import transform_ons_marker_field
 from dataflow.utils import TableConfig
 
 
@@ -41,9 +42,11 @@ class ONSUKTradeInServicesByPartnerCountryNSAPipeline(_ONSParserPipeline):
                 **record,
                 "norm_period": record["Period"].split("/")[1],
                 "norm_period_type": record["Period"].split("/")[0],
-                "norm_total": record["Value"]
-                or None,  # Convert redacted values ('') to Nones (NULL in DB).
+                "norm_total": int(float(record["Value"]))
+                if "Value" in record and record["Value"] != ""
+                else None,  # Convert redacted values ('') to Nones (NULL in DB)
             },
+            transform_ons_marker_field,
         ],
         field_mapping=[
             (
@@ -62,9 +65,10 @@ class ONSUKTradeInServicesByPartnerCountryNSAPipeline(_ONSParserPipeline):
             ("Trade Services Code", sa.Column("og_product_code", sa.String)),
             ("Trade Services Name", sa.Column("og_product_name", sa.String)),
             ("Value", sa.Column("og_total", sa.String)),
-            ("norm_total", sa.Column("norm_total", sa.Numeric)),
+            ("norm_total", sa.Column("norm_total", sa.Integer)),
             ("Unit", sa.Column("og_unit", sa.String)),
             ("Marker", sa.Column("og_marker", sa.String)),
+            ("norm_marker", sa.Column("norm_marker", sa.String)),
         ],
     )
 
@@ -82,9 +86,11 @@ class ONSUKTotalTradeAllCountriesNSA(_ONSParserPipeline):
                 **record,
                 "norm_period": record["Period"].split("/")[1],
                 "norm_period_type": record["Period"].split("/")[0],
-                "norm_total": record["Value"]
-                or None,  # Convert redacted values ('') to Nones (NULL in DB).
+                "norm_total": int(float(record["Value"]))
+                if "Value" in record and record["Value"] != ""
+                else None,  # Convert redacted values ('') to Nones (NULL in DB)
             },
+            transform_ons_marker_field,
         ],
         field_mapping=[
             (
@@ -102,9 +108,10 @@ class ONSUKTotalTradeAllCountriesNSA(_ONSParserPipeline):
             ("norm_period_type", sa.Column("norm_period_type", sa.String)),
             ("Flow", sa.Column("og_direction", sa.String)),
             ("Value", sa.Column("og_total", sa.String)),
-            ("norm_total", sa.Column("norm_total", sa.Numeric)),
+            ("norm_total", sa.Column("norm_total", sa.Integer)),
             ("Unit", sa.Column("og_unit", sa.String)),
             ("Marker", sa.Column("og_marker", sa.String)),
+            ("norm_marker", sa.Column("norm_marker", sa.String)),
         ],
     )
 
@@ -122,9 +129,11 @@ class ONSUKTradeInGoodsByCountryAndCommodity(_ONSParserPipeline):
                 **record,
                 "norm_period": record["Period"].split("/")[1],
                 "norm_period_type": record["Period"].split("/")[0],
-                "norm_total": record["Value"]
-                or None,  # Convert redacted values ('') to Nones (NULL in DB).
+                "norm_total": int(float(record["Value"]))
+                if "Value" in record and record["Value"] != ""
+                else None,  # Convert redacted values ('') to Nones (NULL in DB)
             },
+            transform_ons_marker_field,
         ],
         field_mapping=[
             (
@@ -143,9 +152,10 @@ class ONSUKTradeInGoodsByCountryAndCommodity(_ONSParserPipeline):
             ("norm_period_type", sa.Column("norm_period_type", sa.String)),
             ("Flow", sa.Column("og_direction", sa.String)),
             ("Value", sa.Column("og_total", sa.String)),
-            ("norm_total", sa.Column("norm_total", sa.Numeric)),
+            ("norm_total", sa.Column("norm_total", sa.Integer)),
             ("Unit", sa.Column("og_unit", sa.String)),
             ("Marker", sa.Column("og_marker", sa.String)),
+            ("norm_marker", sa.Column("norm_marker", sa.String)),
         ],
     )
 

--- a/dataflow/dags/ons_parsing_pipelines.py
+++ b/dataflow/dags/ons_parsing_pipelines.py
@@ -152,7 +152,7 @@ class ONSUKTradeInGoodsByCountryAndCommodity(_ONSParserPipeline):
             ("norm_period_type", sa.Column("norm_period_type", sa.String)),
             ("Flow", sa.Column("og_direction", sa.String)),
             ("Value", sa.Column("og_total", sa.String)),
-            ("norm_total", sa.Column("norm_total", sa.Integer)),
+            ("norm_total", sa.Column("norm_total", sa.BigInteger)),
             ("Unit", sa.Column("og_unit", sa.String)),
             ("Marker", sa.Column("og_marker", sa.String)),
             ("norm_marker", sa.Column("norm_marker", sa.String)),

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -9,6 +9,7 @@ from airflow.operators.python_operator import PythonOperator
 
 from dataflow.dags import _PipelineDAG
 from dataflow.operators.ons import fetch_from_ons_sparql
+from dataflow.transforms import transform_ons_marker_field
 from dataflow.utils import TableConfig
 
 
@@ -34,7 +35,11 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
                 "norm_period_type": "year"
                 if len(record["period"]["value"]) == 4
                 else "month",
+                "norm_total": int(float(record["total"]["value"]))
+                if "total" in record
+                else None,
             },
+            transform_ons_marker_field,
         ],
         field_mapping=[
             (
@@ -53,9 +58,10 @@ class ONSUKSATradeInGoodsPipeline(_ONSPipeline):
             (("norm_period_type"), sa.Column("norm_period_type", sa.String)),
             (("direction", "value"), sa.Column("og_direction", sa.String)),
             (("total", "value"), sa.Column("og_total", sa.String)),
-            (("total", "value"), sa.Column("norm_total", sa.Numeric)),
+            ("norm_total", sa.Column("norm_total", sa.Integer)),
             (("unit", "value"), sa.Column("og_unit", sa.String)),
             (("marker", "value"), sa.Column("og_marker", sa.String)),
+            ("norm_marker", sa.Column("norm_marker", sa.String)),
         ],
     )
 

--- a/dataflow/transforms.py
+++ b/dataflow/transforms.py
@@ -24,7 +24,7 @@ def drop_empty_string_fields(
 
 def transform_ons_marker_field(
     record: dict, table_config: TableConfig, contexts: Tuple[Dict, ...]
-) -> Optional[dict]:
+) -> dict:
     """
     Formats the ons trade marker field for consumption by analysts, specifically:
 

--- a/dataflow/transforms.py
+++ b/dataflow/transforms.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, Optional
+from typing import Tuple, Dict
 
 from dataflow.utils import TableConfig
 

--- a/dataflow/transforms.py
+++ b/dataflow/transforms.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Optional
 
 from dataflow.utils import TableConfig
 
@@ -20,3 +20,29 @@ def drop_empty_string_fields(
         return obj
 
     return _drop_keys_with_empty_string_values(record)
+
+
+def transform_ons_marker_field(
+    record: dict, table_config: TableConfig, contexts: Tuple[Dict, ...]
+) -> Optional[dict]:
+    """
+    Formats the ons trade marker field for consumption by analysts, specifically:
+
+    1. transform empty string to null
+    2. replaces 'not-applicable' with 'not-available'
+    """
+    marker = None
+    if 'marker' in record:
+        marker = record['marker']['value']
+    elif 'Marker' in record:
+        marker = record['Marker']
+
+    if marker == '':
+        marker = None
+    elif marker == 'not-applicable' or marker == 'N/A':
+        marker = 'not-available'
+
+    return {
+        **record,
+        'norm_marker': marker,
+    }


### PR DESCRIPTION
### Description of change

Adds some missing normalisation to the ons datasets. Requested by Owen and should be the last change before we go live.

- Normalise totals fields to int as "all values are rounded to millions"
- Replace empty strings with nulls on marker fields
- Replace 'N/A' and 'not-applicable' with 'not-available' on marker fields

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
