### PR TITLE
Add lead adviser details to service delivery csv pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Permitted applications for SSO Users
 
+### Changed
+
+- Add lead adviser details to service delivery csv pipelines
+
 ## 2020-07-15
 
 ### Added

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -303,13 +303,16 @@ class DataHubServiceDeliveriesCurrentYearDailyCSVPipeline(_DailyCSVPipeline):
             events_dataset.service_name AS "Event Service Name",
             to_char(interactions.created_on, 'DD/MM/YYYY') AS "Created On Date",
             interactions.communication_channel AS "Communication Channel",
-            interactions.interaction_link AS "Interaction Link"
+            interactions.interaction_link AS "Interaction Link",
+            CONCAT(lead_adviser.first_name, ' ', lead_adviser.last_name) as "Lead Adviser Name",
+            CONCAT(lead_adviser.contact_email) as "Lead Adviser Email"
         FROM interactions
         JOIN companies_dataset ON interactions.company_id = companies_dataset.id
         JOIN advisers_dataset ON interactions.adviser_ids[1]::uuid = advisers_dataset.id
         JOIN teams_dataset ON advisers_dataset.team_id = teams_dataset.id
         LEFT JOIN events_dataset ON interactions.event_id = events_dataset.id
         LEFT JOIN contacts ON contacts.interaction_id = interactions.id
+        LEFT JOIN advisers_dataset lead_adviser ON companies_dataset.one_list_account_owner_id = lead_adviser.id
         ORDER BY interactions.interaction_date
     '''
 
@@ -479,13 +482,16 @@ class DataHubServiceDeliveriesPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
             events_dataset.service_name AS "Event Service Name",
             to_char(interactions.created_on, 'DD/MM/YYYY') AS "Created On Date",
             interactions.communication_channel AS "Communication Channel",
-            interactions.interaction_link AS "Interaction Link"
+            interactions.interaction_link AS "Interaction Link",
+            CONCAT(lead_adviser.first_name, ' ', lead_adviser.last_name) as "Lead Adviser Name",
+            CONCAT(lead_adviser.contact_email) as "Lead Adviser Email"
         FROM interactions
         JOIN companies_dataset ON interactions.company_id = companies_dataset.id
         JOIN advisers_dataset ON interactions.adviser_ids[1]::uuid = advisers_dataset.id
         JOIN teams_dataset ON advisers_dataset.team_id = teams_dataset.id
         LEFT JOIN events_dataset ON interactions.event_id = events_dataset.id
         LEFT JOIN contacts ON contacts.interaction_id = interactions.id
+        LEFT JOIN advisers_dataset lead_adviser ON companies_dataset.one_list_account_owner_id = lead_adviser.id
         ORDER BY interactions.interaction_date
     '''
 

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -283,13 +283,17 @@ class DataHubServiceDeliveryInteractionsCSVPipeline(_MonthlyCSVPipeline):
             events_dataset.service_name AS "Event Service Name",
             to_char(interactions.created_on, 'DD/MM/YYYY') AS "Created On Date",
             interactions.communication_channel AS "Communication Channel",
-            interactions.interaction_link AS "Interaction Link"
+            interactions.interaction_link AS "Interaction Link",
+            companies_dataset.one_list_tier as "Company Classification",
+            CONCAT(lead_adviser.first_name, ' ', lead_adviser.last_name) as "Lead Adviser Name",
+            CONCAT(lead_adviser.contact_email) as "Lead Adviser Email"
         FROM interactions
         JOIN companies_dataset ON interactions.company_id = companies_dataset.id
         JOIN advisers_dataset ON interactions.adviser_ids[1]::uuid = advisers_dataset.id
         LEFT JOIN events_dataset ON interactions.event_id = events_dataset.id
         LEFT JOIN contacts ON contacts.interaction_id = interactions.id
         LEFT JOIN team_names ON team_names.iid = interactions.id
+        LEFT JOIN advisers_dataset lead_adviser ON companies_dataset.one_list_account_owner_id = lead_adviser.id
         ORDER BY interactions.interaction_date
     '''
 


### PR DESCRIPTION
### Description of change

Update service delivery queries to include lead adviser details.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
