### PR TITLE
disable `force_http` for consent api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-23
+
+### Changed
+
+- Disable `force_http` when making api calls to Consent Service
+
 ## 2020-07-22
 
 ### Changed

--- a/dataflow/dags/consent_pipelines.py
+++ b/dataflow/dags/consent_pipelines.py
@@ -20,8 +20,7 @@ class _ConsentPipeline(_PipelineDAG):
         return PythonOperator(
             task_id="fetch-consent-api-data",
             python_callable=partial(
-                fetch_from_hawk_api,
-                hawk_credentials=config.CONSENT_HAWK_CREDENTIALS,
+                fetch_from_hawk_api, hawk_credentials=config.CONSENT_HAWK_CREDENTIALS,
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],

--- a/dataflow/dags/consent_pipelines.py
+++ b/dataflow/dags/consent_pipelines.py
@@ -22,7 +22,6 @@ class _ConsentPipeline(_PipelineDAG):
             python_callable=partial(
                 fetch_from_hawk_api,
                 hawk_credentials=config.CONSENT_HAWK_CREDENTIALS,
-                force_http=True,
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],


### PR DESCRIPTION
This PR is to disable `force_http` for Consent api, so that api calls default to https. We are moving from internal address to external. This should resolve the broken pipeline issue with Consent api, where subsequent page calls are moving from `http` to `https`.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
