### PR TITLE
URL quote schema/table names

### DIFF
--- a/dataflow/operators/dss_generic.py
+++ b/dataflow/operators/dss_generic.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 import sqlalchemy as sa
 
 import dataflow.operators.db_tables
@@ -77,7 +79,7 @@ def get_table_config(**context):
         return sa.Column(column_name, sa_data_type)
 
     schema_name, table_name = _get_schema_and_table(context)
-    source_url = f'{DATA_STORE_SERVICE_BASE_URL}/api/v1/table-structure/{schema_name}/{table_name}'
+    source_url = f'{DATA_STORE_SERVICE_BASE_URL}/api/v1/table-structure/{quote(schema_name)}/{quote(table_name)}'
 
     # transform schema and table in line with dataflow conventions
     schema_parts = schema_name.split('.')

--- a/tests/operators/test_dss_generic.py
+++ b/tests/operators/test_dss_generic.py
@@ -42,6 +42,23 @@ def test_get_table_config(mocker):
     )
 
 
+def test_get_table_config_quotes_schema_and_table_name(mocker):
+    api_response = {'columns': []}
+    config = {
+        'data_uploader_table_name': 'L0',
+        'data_uploader_schema_name': 'bad schema.name',
+    }
+    request, context = _patch_get_table_config(mocker, api_response, config)
+    dss_generic.get_table_config(**context)
+
+    request.assert_called_once_with(
+        credentials={'id': 'test_id', 'key': 'test_key', 'algorithm': 'sha256'},
+        next_key=None,
+        results_key='columns',
+        url='http://test/api/v1/table-structure/bad%20schema.name/L0',
+    )
+
+
 def test_get_table_config_invalid_schema(mocker):
     api_response = {
         'columns': [


### PR DESCRIPTION
### Description of change
Data Store Service has been accepting invalid DB identifiers for schemas
and table names (e.g. with spaces in) and sending these to Data Flow.
Data Flow then queries the Data Store Service again to read the table
config. When forming the URL, it puts the schema and table name in
without url encoding it, so when a space is present in the schema name
this isn't changed to %20 by Data Flow. DSS is protected by hawk
authentication, which is a signature formed from the URL and possibly
some other metadata. Data Flow therefore creates the hawk signature from
the non-encoded URL, but our request handler is smart enough to encode
the spaces to %20 before sending it off. When Data Store Service
receives this request and validates the signature, then, the URL doesn't
match the signature Data Flow constructed, and rejects the request with
a 401.

While the problem here originates from Data Store Service, and a
separate fix will go out to hopefully stop it sending us invalid db
identifiers in the first place, it would be good to fix this gap as
well.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
