### PR TITLE
alter consent dataset's name to match our new standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-28
+
+### Changed
+
+- `consent_dataset` schema and table name were altered to match our new standards. It will be `dit`.`consent_service__current_consents` now.
+
 ## 2020-07-23
 
 ### Changed

--- a/dataflow/dags/consent_pipelines.py
+++ b/dataflow/dags/consent_pipelines.py
@@ -33,7 +33,8 @@ class ConsentPipeline(_ConsentPipeline):
         config.CONSENT_BASE_URL, config.CONSENT_RESULTS_PER_PAGE
     )
     table_config = TableConfig(
-        table_name="consent_dataset",
+        schema="dit",
+        table_name="consent_service__current_consents",
         field_mapping=[
             ("id", sa.Column("id", sa.Integer)),
             ("key", sa.Column("key", sa.String)),


### PR DESCRIPTION
### Description of change
This PR is to alter Consent dataset table/schema name to align with our new standards:
It's currently:
`public`.`consent_dataset`
changing it to:
`dit`.`consent_service__current_consents`

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
