### PR TITLE
Remove contacts email marketing field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-29
+
+### Changed
+
+- Remove Data Hub's obslete field `accepts_dit_email_marketing`, using consent service data instead.
+
 ## 2020-07-28
 
 ### Added

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -54,8 +54,10 @@ class DataHubFDIDailyCSVPipeline(_DailyCSVPipeline):
                             is_primary,
                             phone AS contact_phone,
                             email AS contact_email,
-                            accepts_dit_email_marketing AS contact_accepts_dit_email_marketing
+                            consent_dataset.email_marketing_consent AS contact_accepts_dit_email_marketing
                         FROM contacts_dataset
+                        JOIN dit.consent_service__current_consents AS consent_dataset
+                            ON contacts_dataset.email = consent_dataset.email
                         ORDER BY company_id, is_primary DESC, modified_on DESC
                     ) contacts
                 ON companies_dataset.id = contacts.joined_id

--- a/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_monthly.py
@@ -429,8 +429,10 @@ class DataHubFDIMonthlyStaticCSVPipeline(_MonthlyCSVPipeline):
                             is_primary,
                             phone AS contact_phone,
                             email AS contact_email,
-                            accepts_dit_email_marketing AS contact_accepts_dit_email_marketing
+                            consent_dataset.email_marketing_consent AS contact_accepts_dit_email_marketing
                         FROM contacts_dataset
+                        JOIN dit.consent_service__current_consents AS consent_dataset
+                            ON contacts_dataset.email = consent_dataset.email
                         ORDER BY company_id, is_primary DESC, modified_on DESC
                     ) contacts
                 ON companies_dataset.id = contacts.joined_id

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -330,10 +330,6 @@ class ContactsDatasetPipeline(_DatasetPipeline):
     table_config = TableConfig(
         table_name='contacts_dataset',
         field_mapping=[
-            (
-                'accepts_dit_email_marketing',
-                sa.Column('accepts_dit_email_marketing', sa.Boolean),
-            ),
             ('address_1', sa.Column('address_1', sa.String)),
             ('address_2', sa.Column('address_2', sa.String)),
             ('address_country__name', sa.Column('address_country', sa.Text)),


### PR DESCRIPTION
### Description of change
This PR is to update pipelines and remove Data Hub's obsolete field `accepts_dit_email_marketing` and use Consent service's data instead.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
