### PR TITLE
Add apple covid19 mobility pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-08-03
+
+### Added
+
+- Apple covid19 mobility report pipeline
+
 ## 2020-07-28
 
 ### Added

--- a/dataflow/operators/covid19.py
+++ b/dataflow/operators/covid19.py
@@ -1,0 +1,37 @@
+import io
+from typing import Callable
+
+import requests
+import pandas as pd
+
+from dataflow.utils import S3Data, logger
+
+
+def fetch_apple_mobility_data(
+    table_name: str,
+    base_url: str,
+    config_path: str,
+    df_transform: Callable[[pd.DataFrame], pd.DataFrame],
+    page_size: int = 1000,
+    **kwargs,
+):
+    s3 = S3Data(table_name, kwargs['ts_nodash'])
+
+    api_config = requests.get(base_url + config_path).json()
+    source_url = (
+        base_url + api_config['basePath'] + api_config['regions']['en-us']['csvPath']
+    )
+    logger.info(f'Fetching csv from {source_url}')
+    response = requests.get(source_url)
+    df = pd.read_csv(io.StringIO(response.content.decode('utf-8')))
+    df = df_transform(df)
+
+    page = 1
+    for i in range((len(df) // page_size) + 1):
+        results = df.iloc[page_size * i : page_size * (i + 1)].to_json(
+            orient="records", date_format="iso"
+        )
+        s3.write_key(f"{page:010}.json", results, jsonify=False)
+        page += 1
+
+    logger.info('Fetching from source completed')

--- a/tests/unit/operators/test_covid19.py
+++ b/tests/unit/operators/test_covid19.py
@@ -1,0 +1,44 @@
+from unittest import mock
+
+from dataflow.dags.covid19_pipelines import AppleCovid19MobilityTrendsPipeline
+from dataflow.operators import covid19
+
+
+def test_fetch_apple_mobility_data(mocker, requests_mock):
+    s3_mock = mock.Mock()
+
+    mocker.patch.object(covid19, 'S3Data', return_value=s3_mock, autospec=True)
+
+    requests_mock.get(
+        'http://test/config',
+        json={'basePath': '/base/', 'regions': {'en-us': {'csvPath': 'test.csv'}}},
+    )
+
+    requests_mock.get(
+        "http://test/base/test.csv",
+        text=(
+            'geo_type,region,transportation_type,alternative_name,sub-region,country,2020-01-13,2020-01-14\n'
+            'country/region,Australia,transit,AU,,,100,101.78\n'
+        ),
+    )
+
+    covid19.fetch_apple_mobility_data(
+        table_name='test',
+        base_url='http://test',
+        config_path='/config',
+        df_transform=AppleCovid19MobilityTrendsPipeline().transform_dataframe,
+        ts_nodash="123",
+    )
+    # raise Exception(s3_mock.write_key.call_args_list)
+    s3_mock.write_key.assert_has_calls(
+        [
+            mock.call(
+                '0000000001.json',
+                '[{"geo_type":"country\\/region","region":"Australia","sub-region":null,"country":"Australia",'
+                '"date":"2020-01-13","transit":0.0,"adm_area_1":null,"adm_area_2":null},'
+                '{"geo_type":"country\\/region","region":"Australia","sub-region":null,"country":"Australia",'
+                '"date":"2020-01-14","transit":1.78,"adm_area_1":null,"adm_area_2":null}]',
+                jsonify=False,
+            )
+        ]
+    )

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -3,4 +3,4 @@ from airflow.models.dagbag import DagBag
 
 def test_pipelines_dags():
     dagbag = DagBag('dataflow')
-    assert dagbag.size() == 98
+    assert dagbag.size() == 99


### PR DESCRIPTION
### Description of change

Adds a new dataset for apple covid mobility data.

Trello Card: https://trello.com/c/Hy1eaWjT/609-apple-covid-19-mobility-trends-pipeline


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
