### PR TITLE
adding a new transform data task to pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-08-05
+
+### Added
+
+- A new pipeline task between `check-temp-table-data` task and `swap-dataset-table` task for transforming data before making public.
+- A new field `email_marketing_consent` to Contacts dataset to hold Email consent data joined from Consent dataset.
+
 ## 2020-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- A new pipeline task between `check-temp-table-data` task and `swap-dataset-table` task for transforming data before making public.
+- A new pipeline task between `insert-into-temp-table` task and `check-temp-table-data` task for transforming data before making public.
 - A new field `email_marketing_consent` to Contacts dataset to hold Email consent data joined from Consent dataset.
 
 ## 2020-08-03

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import List, Optional, Type
 
 from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.sensors import ExternalTaskSensor
 
@@ -80,6 +81,13 @@ class _PipelineDAG(metaclass=PipelineMeta):
     def get_insert_data_callable(self):
         return insert_data_into_db
 
+    def get_transform_operator(self):
+        """
+        Optional overridable task to transform/manipulate data
+        between check-temp-table-data task and swap-dataset-table task
+        """
+        return DummyOperator(task_id='transform-data')
+
     @classmethod
     def fq_table_name(cls):
         return f'"{cls.table_config.schema}"."{cls.table_config.table_name}"'
@@ -136,6 +144,9 @@ class _PipelineDAG(metaclass=PipelineMeta):
             op_kwargs={'allow_null_columns': self.allow_null_columns},
         )
 
+        _transform_data = self.get_transform_operator()
+        _transform_data.dag = dag
+
         _swap_dataset_tables = PythonOperator(
             task_id="swap-dataset-table",
             python_callable=swap_dataset_tables,
@@ -165,6 +176,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
             [_fetch, _create_tables]
             >> _insert_into_temp_table
             >> _check_tables
+            >> _transform_data
             >> _swap_dataset_tables
             >> _drop_swap_tables
         )

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -175,7 +175,11 @@ class _PipelineDAG(metaclass=PipelineMeta):
         (
             [_fetch, _create_tables]
             >> _insert_into_temp_table
-            >> (_check_tables << _transform_tables if _transform_tables else _check_tables)
+            >> (
+                _check_tables << _transform_tables
+                if _transform_tables
+                else _check_tables
+            )
             >> _swap_dataset_tables
             >> _drop_swap_tables
         )

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -168,20 +168,19 @@ class _PipelineDAG(metaclass=PipelineMeta):
             op_args=[self.target_db, *self.table_config.tables],
         )
 
+        _transform_tables = self.get_transform_operator()
+        if _transform_tables:
+            _transform_tables.dag = dag
+
         (
             [_fetch, _create_tables]
             >> _insert_into_temp_table
-            >> _check_tables
+            >> (_check_tables << _transform_tables if _transform_tables else _check_tables)
             >> _swap_dataset_tables
             >> _drop_swap_tables
         )
 
         _insert_into_temp_table >> _drop_temp_tables
-
-        _transform_operator = self.get_transform_operator()
-        if _transform_operator:
-            _transform_operator.dag = dag
-            _insert_into_temp_table >> _transform_operator >> _check_tables
 
         for dependency in self.dependencies:
             sensor = ExternalTaskSensor(

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -328,9 +328,7 @@ class InteractionsExportCountryDatasetPipeline(_DatasetPipeline):
 class ContactsDatasetPipeline(_DatasetPipeline):
     """Pipeline meta object for ContactsDataset."""
 
-    dependencies = [
-        ConsentPipeline,
-    ]
+    dependencies = [ConsentPipeline]
     source_url = '{0}/v4/dataset/contacts-dataset'.format(config.DATAHUB_BASE_URL)
     table_config = TableConfig(
         table_name='contacts_dataset',

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from dataflow import config
 from dataflow.config import DATAHUB_HAWK_CREDENTIALS
 from dataflow.dags import _PipelineDAG
+from dataflow.dags.consent_pipelines import ConsentPipeline
 from dataflow.operators.common import fetch_from_hawk_api
 from dataflow.operators.contact_consent import update_datahub_contact_consent
 from dataflow.utils import TableConfig
@@ -327,6 +328,9 @@ class InteractionsExportCountryDatasetPipeline(_DatasetPipeline):
 class ContactsDatasetPipeline(_DatasetPipeline):
     """Pipeline meta object for ContactsDataset."""
 
+    dependencies = [
+        ConsentPipeline,
+    ]
     source_url = '{0}/v4/dataset/contacts-dataset'.format(config.DATAHUB_BASE_URL)
     table_config = TableConfig(
         table_name='contacts_dataset',
@@ -369,7 +373,7 @@ class ContactsDatasetPipeline(_DatasetPipeline):
             task_id='update-contact-email-consent',
             python_callable=update_datahub_contact_consent,
             provide_context=True,
-            op_args=[self.target_db, self.table_config.tables[0],],
+            op_args=[self.target_db, self.table_config.tables[0]],
         )
 
 

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -369,10 +369,7 @@ class ContactsDatasetPipeline(_DatasetPipeline):
             task_id='update-contact-email-consent',
             python_callable=update_datahub_contact_consent,
             provide_context=True,
-            op_args=[
-                self.target_db,
-                self.table_config.tables[0],
-            ],
+            op_args=[self.target_db, self.table_config.tables[0],],
         )
 
 

--- a/dataflow/operators/contact_consent.py
+++ b/dataflow/operators/contact_consent.py
@@ -7,9 +7,7 @@ from dataflow.utils import get_temp_table, logger
 
 
 def update_datahub_contact_consent(
-    target_db: str,
-    table: sqlalchemy.Table,
-    **kwargs,
+    target_db: str, table: sqlalchemy.Table, **kwargs,
 ):
     """
     Updates Contacts temp table with email marketing consent data from Consent dataset.

--- a/dataflow/operators/contact_consent.py
+++ b/dataflow/operators/contact_consent.py
@@ -1,0 +1,32 @@
+from airflow.hooks.postgres_hook import PostgresHook
+import sqlalchemy
+
+from dataflow import config
+from dataflow.dags.consent_pipelines import ConsentPipeline
+from dataflow.utils import get_temp_table, logger
+
+
+def update_datahub_contact_consent(
+    target_db: str,
+    table: sqlalchemy.Table,
+    **kwargs,
+):
+    """
+    Updates Contacts temp table with email marketing consent data from Consent dataset.
+    """
+    table = get_temp_table(table, kwargs['ts_nodash'])
+    update_consent_query = f"""
+        UPDATE {table.name} AS contacts_temp
+        SET email_marketing_consent = consent.email_marketing_consent
+        FROM {ConsentPipeline.fq_table_name()} AS consent
+        WHERE contacts_temp.email = consent.email
+    """
+    engine = sqlalchemy.create_engine(
+        'postgresql+psycopg2://',
+        creator=PostgresHook(postgres_conn_id=target_db).get_conn,
+        echo=config.DEBUG,
+    )
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text(update_consent_query))
+
+    logger.info('Updated Contacts temp table with email consent from Consent dataset')

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -69,9 +69,7 @@ def _get_data_to_insert(field_mapping: SingleTableFieldMapping, record: Dict):
 
 
 def _insert_related_records(
-    conn: sa.engine.Connection,
-    table_config: TableConfig,
-    contexts: Tuple[Dict, ...],
+    conn: sa.engine.Connection, table_config: TableConfig, contexts: Tuple[Dict, ...],
 ):
     for key, related_table in table_config.related_table_configs:
         related_records = get_nested_key(contexts[-1], key) or []

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -4,13 +4,13 @@ import warnings
 from io import StringIO
 from typing import Tuple, Dict, Optional
 
-import sqlalchemy
 import sqlalchemy as sa
 from airflow.hooks.postgres_hook import PostgresHook
 
 from dataflow import config
 from dataflow.utils import (
     get_nested_key,
+    get_temp_table,
     S3Data,
     TableConfig,
     SingleTableFieldMapping,
@@ -24,22 +24,6 @@ class MissingDataError(ValueError):
 
 class UnusedColumnError(ValueError):
     pass
-
-
-def _get_temp_table(table, suffix):
-    """Get a Table object for the temporary dataset table.
-
-    Given a dataset `table` instance creates a new table with
-    a unique temporary name for the given DAG run and the same
-    columns as the dataset table.
-
-    """
-    return sa.Table(
-        f"{table.name}_{suffix}".lower(),
-        table.metadata,
-        *[column.copy() for column in table.columns],
-        schema=table.schema,
-    )
 
 
 def create_temp_tables(target_db: str, *tables: sa.Table, **kwargs):
@@ -61,7 +45,7 @@ def create_temp_tables(target_db: str, *tables: sa.Table, **kwargs):
     with engine.begin() as conn:
         conn.execute("SET statement_timeout = 600000")
         for table in tables:
-            table = _get_temp_table(table, kwargs["ts_nodash"])
+            table = get_temp_table(table, kwargs["ts_nodash"])
             logger.info(f"Creating schema {table.schema} if not exists")
             conn.execute(f"CREATE SCHEMA IF NOT EXISTS {table.schema}")
             logger.info(f"Creating {table.name}")
@@ -85,7 +69,7 @@ def _get_data_to_insert(field_mapping: SingleTableFieldMapping, record: Dict):
 
 
 def _insert_related_records(
-    conn: sqlalchemy.engine.Connection,
+    conn: sa.engine.Connection,
     table_config: TableConfig,
     contexts: Tuple[Dict, ...],
 ):
@@ -147,7 +131,7 @@ def insert_data_into_db(
         )
 
         s3 = S3Data(table.name, kwargs["ts_nodash"])
-        temp_table = _get_temp_table(table, kwargs["ts_nodash"])
+        temp_table = get_temp_table(table, kwargs["ts_nodash"])
 
     else:
         raise RuntimeError(
@@ -302,7 +286,7 @@ def check_table_data(
 
     with engine.begin() as conn:
         for table in tables:
-            temp_table = _get_temp_table(table, kwargs["ts_nodash"])
+            temp_table = get_temp_table(table, kwargs["ts_nodash"])
             _check_table(engine, conn, temp_table, table, allow_null_columns)
 
 
@@ -356,7 +340,7 @@ def swap_dataset_tables(target_db: str, *tables: sa.Table, **kwargs):
         creator=PostgresHook(postgres_conn_id=target_db).get_conn,
     )
     for table in tables:
-        temp_table = _get_temp_table(table, kwargs["ts_nodash"])
+        temp_table = get_temp_table(table, kwargs["ts_nodash"])
 
         logger.info(f"Moving {temp_table.name} to {table.name}")
         with engine.begin() as conn:
@@ -417,7 +401,7 @@ def drop_temp_tables(target_db: str, *tables, **kwargs):
     with engine.begin() as conn:
         conn.execute("SET statement_timeout = 600000")
         for table in tables:
-            temp_table = _get_temp_table(table, kwargs["ts_nodash"])
+            temp_table = get_temp_table(table, kwargs["ts_nodash"])
             logger.info(f"Removing {temp_table.name}")
             temp_table.drop(conn, checkfirst=True)
 
@@ -436,6 +420,6 @@ def drop_swap_tables(target_db: str, *tables, **kwargs):
     with engine.begin() as conn:
         conn.execute("SET statement_timeout = 600000")
         for table in tables:
-            swap_table = _get_temp_table(table, kwargs["ts_nodash"] + "_swap")
+            swap_table = get_temp_table(table, kwargs["ts_nodash"] + "_swap")
             logger.info(f"Removing {swap_table.name}")
             swap_table.drop(conn, checkfirst=True)

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -253,3 +253,19 @@ def get_nested_key(
             else:
                 return None
     return data
+
+
+def get_temp_table(table, suffix):
+    """Get a Table object for the temporary dataset table.
+
+    Given a dataset `table` instance creates a new table with
+    a unique temporary name for the given DAG run and the same
+    columns as the dataset table.
+
+    """
+    return sqlalchemy.Table(
+        f"{table.name}_{suffix}".lower(),
+        table.metadata,
+        *[column.copy() for column in table.columns],
+        schema=table.schema,
+    )

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -5,7 +5,7 @@ import pytest
 import sqlalchemy
 
 from dataflow.operators import db_tables
-from dataflow.utils import TableConfig
+from dataflow.utils import get_temp_table, TableConfig
 
 
 @pytest.fixture
@@ -37,7 +37,7 @@ def postgres_hook(mocker):
 
 
 def test_get_temp_table(table):
-    assert db_tables._get_temp_table(table, "temp").name == "test_table_temp"
+    assert get_temp_table(table, "temp").name == "test_table_temp"
     assert table.name == "test_table"
 
 
@@ -45,7 +45,7 @@ def test_create_temp_tables(mocker):
     mocker.patch.object(db_tables.sa, "create_engine", autospec=True)
 
     table = mock.Mock()
-    mocker.patch.object(db_tables, "_get_temp_table", autospec=True, return_value=table)
+    mocker.patch.object(db_tables, "get_temp_table", autospec=True, return_value=table)
 
     db_tables.create_temp_tables("test-db", mock.Mock(), ts_nodash="123")
 
@@ -54,7 +54,7 @@ def test_create_temp_tables(mocker):
 
 def test_insert_data_into_db(mocker, mock_db_conn, s3):
     table = mock.Mock()
-    mocker.patch.object(db_tables, "_get_temp_table", autospec=True, return_value=table)
+    mocker.patch.object(db_tables, "get_temp_table", autospec=True, return_value=table)
 
     s3.iter_keys.return_value = [
         ('1', [{"id": 1, "extra": "ignored", "data": "text"}]),
@@ -114,7 +114,7 @@ def test_insert_data_into_db_using_db_config(mocker, mock_db_conn, s3):
 
 def test_insert_data_into_db_required_field_missing(mocker, mock_db_conn, s3):
     table = mock.Mock()
-    mocker.patch.object(db_tables, "_get_temp_table", autospec=True, return_value=table)
+    mocker.patch.object(db_tables, "get_temp_table", autospec=True, return_value=table)
 
     s3.iter_keys.return_value = [('1', [{"data": "text"}])]
 
@@ -288,7 +288,7 @@ def test_drop_temp_tables(mocker, mock_db_conn):
     tables = [mock.Mock()]
     tables[0].name = "test_table"
 
-    target = mocker.patch.object(db_tables, "_get_temp_table", side_effect=tables)
+    target = mocker.patch.object(db_tables, "get_temp_table", side_effect=tables)
 
     db_tables.drop_temp_tables("test-db", mock.Mock(), ts_nodash="123")
 
@@ -302,7 +302,7 @@ def test_drop_swap_tables(mocker, mock_db_conn):
     tables = [mock.Mock()]
     tables[0].name = "test_table_swap"
 
-    target = mocker.patch.object(db_tables, "_get_temp_table", side_effect=tables)
+    target = mocker.patch.object(db_tables, "get_temp_table", side_effect=tables)
 
     db_tables.drop_swap_tables("test-db", mock.Mock(), ts_nodash="123")
 


### PR DESCRIPTION
### Description of change

This PR adds an optional overridable task to transform/manipulate data between `check-temp-table-data` task and `swap-dataset-table` task.

This is utilised within contacts pipeline to join email consent data from consent dataset obtained from Consent service and prefill that to contacts dataset. This should improve performance of queries otherwise had to resort to joining contacts dataset and consent dataset.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
