### PR TITLE
Retry the swap_dataset_tables task twice as this often fails

### DIFF
--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -145,6 +145,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
 
         _swap_dataset_tables = PythonOperator(
             task_id="swap-dataset-table",
+            retries=2,
             python_callable=swap_dataset_tables,
             execution_timeout=timedelta(minutes=10),
             provide_context=True,


### PR DESCRIPTION
### Description of change

The swap_dataset_tables has failed a few times recently after timing out. The reason for this is unclear but restarting the task manually seems to fix it. This PR ensures the task is retried automatically.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
