### PR TITLE
Update market access trade barriers endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove Data Hub's obslete field `accepts_dit_email_marketing`, using new field `email_marketing_consent` should be used instead.
+- Updated market access trade barriers endpoint and small change to the resulting table structure.
 
 ## 2020-08-05
 

--- a/dataflow/dags/market_access_pipelines.py
+++ b/dataflow/dags/market_access_pipelines.py
@@ -15,38 +15,65 @@ from dataflow.utils import TableConfig
 
 class MarketAccessTradeBarriersPipeline(_PipelineDAG):
     target_db = config.DATASETS_DB_NAME
-    source_url = f"{config.MARKET_ACCESS_BASE_URL}/barriers/dataset"
+    source_url = f"{config.MARKET_ACCESS_BASE_URL}/dataset/v1/barriers"
     start_date = datetime(2020, 3, 18)
     schedule_interval = '@daily'
 
     table_config = TableConfig(
         table_name="market_access_trade_barriers",
+        transforms=[
+            lambda record, table_config, contexts: {
+                **record,
+                'sectors': [sector['name'] for sector in record['sectors']],
+                'admin_areas': [area['name'] for area in record['admin_areas']],
+                'categories': [cat['title'] for cat in record['categories']],
+                'company_names': [company['name'] for company in record['companies']]
+                if record['companies']
+                else [],
+                'company_ids': [company['id'] for company in record['companies']]
+                if record['companies']
+                else [],
+            }
+        ],
         field_mapping=[
             ("id", sa.Column("id", UUID, primary_key=True)),
             ("code", sa.Column("code", sa.Text)),
-            ("scope", sa.Column("scope", sa.Text)),
-            ("status", sa.Column("status", sa.Text)),
-            ("barrier_title", sa.Column("barrier_title", sa.Text)),
+            (("term", "name"), sa.Column("term", sa.Text)),
+            (("status", "name"), sa.Column("status", sa.Text)),
+            (("status", "id"), sa.Column("status_id", sa.Text)),
+            ("title", sa.Column("barrier_title", sa.Text)),
             ("sectors", sa.Column("sectors", sa.ARRAY(sa.Text))),
-            ('overseas_region', sa.Column('overseas_region', sa.Text)),
-            ('country', sa.Column('country', sa.ARRAY(sa.Text))),
+            (
+                ('country', 'overseas_region', 'name'),
+                sa.Column('overseas_region', sa.Text),
+            ),
+            (('country', 'name'), sa.Column('country', sa.Text)),
             ('admin_areas', sa.Column('admin_areas', sa.ARRAY(sa.Text))),
             ('categories', sa.Column('categories', sa.ARRAY(sa.Text))),
             ('product', sa.Column('product', sa.Text)),
-            ('source', sa.Column('source', sa.Text)),
-            ('priority', sa.Column('priority', sa.Text)),
-            ('reported_on', sa.Column('reported_on', sa.DateTime)),
+            (('source', 'name'), sa.Column('source', sa.Text)),
+            (('priority', 'name'), sa.Column('priority', sa.Text)),
+            ('created_on', sa.Column('reported_on', sa.DateTime)),
             ('modified_on', sa.Column('modified_on', sa.DateTime)),
-            ('assessment_impact', sa.Column('assessment_impact', sa.Text)),
-            ('value_to_economy', sa.Column('value_to_economy', sa.BigInteger)),
-            ('import_market_size', sa.Column('import_market_size', sa.BigInteger)),
-            ('commercial_value', sa.Column('commercial_value', sa.BigInteger)),
-            ('export_value', sa.Column('export_value', sa.BigInteger)),
+            (('assessment', 'impact', 'name'), sa.Column('assessment_impact', sa.Text)),
+            (
+                ('assessment', 'value_to_economy'),
+                sa.Column('value_to_economy', sa.BigInteger),
+            ),
+            (
+                ('assessment', 'import_market_size'),
+                sa.Column('import_market_size', sa.BigInteger),
+            ),
+            (
+                ('assessment', 'commercial_value'),
+                sa.Column('commercial_value', sa.BigInteger),
+            ),
+            (('assessment', 'export_value'), sa.Column('export_value', sa.BigInteger)),
             ('team_count', sa.Column('team_count', sa.Integer)),
             ('company_names', sa.Column('company_names', sa.ARRAY(sa.Text))),
             ('company_ids', sa.Column('company_ids', sa.ARRAY(sa.Text))),
             (
-                'commercial_value_explanation',
+                ('assessment', 'commercial_value_explanation'),
                 sa.Column('commercial_value_explanation', sa.Text),
             ),
         ],


### PR DESCRIPTION
### Description of change
The market access team have released a new version of their barriers
endpoint which we should switch over to so that they can decommission
the old endpoint.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
