### PR TITLE
Rename dnb tables and move to new dun_and_bradstreet schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-08-13
+
+### Changed
+
+- Move dun and bradstreet tables to dun_and_bradstreet schema
+- Rename dun and bradstreet tables to differentiate from global data
+
 ## 2020-08-10
 
 ### Changed

--- a/dataflow/dags/dun_and_bradstreet_pipelines.py
+++ b/dataflow/dags/dun_and_bradstreet_pipelines.py
@@ -32,7 +32,8 @@ class DNBCompanyPipeline(_DNBPipeline):
     allow_null_columns = True
     source_url = f'{config.DNB_BASE_URL}/api/workspace/companies/?page_size=1000'
     table_config = TableConfig(
-        table_name='dnb__companies',
+        schema='dun_and_bradstreet',
+        table_name='uk_companies',
         field_mapping=[
             ('last_updated', sa.Column('last_updated', sa.DateTime)),
             ('duns_number', sa.Column('duns_number', sa.Text)),
@@ -92,7 +93,8 @@ class DNBCompanyPipeline(_DNBPipeline):
             (
                 'registration_numbers',
                 TableConfig(
-                    table_name='dnb__registration_numbers',
+                    schema='dun_and_bradstreet',
+                    table_name='uk_registration_numbers',
                     transforms=[
                         lambda record, table_config, contexts: {
                             **record,
@@ -112,7 +114,8 @@ class DNBCompanyPipeline(_DNBPipeline):
             (
                 'industry_codes',
                 TableConfig(
-                    table_name='dnb__industry_codes',
+                    schema='dun_and_bradstreet',
+                    table_name='uk_industry_codes',
                     transforms=[
                         lambda record, table_config, contexts: {
                             **record,
@@ -132,7 +135,8 @@ class DNBCompanyPipeline(_DNBPipeline):
             (
                 'primary_industry_codes',
                 TableConfig(
-                    table_name='dnb__primary_industry_codes',
+                    schema='dun_and_bradstreet',
+                    table_name='uk_primary_industry_codes',
                     transforms=[
                         lambda record, table_config, contexts: {
                             **record,


### PR DESCRIPTION
### Description of change

- Rename uk dnb tables to differentiate them from the global company data
- Move uk dnb tables to the new dun_and_bradstreet schema to match global tables

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
