### PR TITLE
No explicitly bound services to support multiple environments in the same space

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,3 @@ applications:
   buildpacks:
    - python_buildpack
   memory: 5gb
-  services:
-    - data-flow-db
-    - data-flow-redis
-    - data-flow-s3


### PR DESCRIPTION
### Description of change

Both manual `cf push` and the Jenkins deployment pipeline preserve bound services. Typically also for other projects in the department, the services are not specified in the manifest.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
