### PR TITLE
Add metadata table with source date tracking for ONS datasets

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,6 @@
+airflow/logs
+.cache
+.git
+.idea
+.mypy_cache
+.pytest_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-08-18
+
+### Added
+
+- Metadata table to the datasets DB under a `dataflow` schema, used to track various information related to pipeline runs/data pulled in. To begin with, we record the last modification date for ONS datasets and the timestamp when dataflow swapped temporary ingest tables with the "real" tables.
+- Updated ONS parsing pipelines to only continue if there is more recent data available, based on the source data modified timestamp stored in the metadata table.
+
 ## 2020-08-17
 
 ### Added

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: /home/vcap/app/bin/paas-wrapper.sh airflow webserver -p 8080
+web: /home/vcap/app/bin/paas-wrapper.sh alembic upgrade head && /home/vcap/app/bin/paas-wrapper.sh airflow webserver -p 8080
 worker: /home/vcap/app/bin/paas-wrapper.sh airflow worker
 high-memory-worker: /home/vcap/app/bin/paas-wrapper.sh airflow worker --queues high-memory-usage --concurrency 1
 scheduler: /home/vcap/app/bin/paas-wrapper.sh /home/vcap/app/bin/airflow-scheduler.sh

--- a/README.md
+++ b/README.md
@@ -67,3 +67,10 @@ For data import pipelines, it's important to keep the state of DB tables in mind
 * If a check or swap DB tables tasks fail then the temporary table is left in place, so (as long as there were no bugs in fetch/insert tasks that needed a new release) only the failed tasks need to be cleared for a rerun.
 
 
+### Managing Data-Flow migrations
+
+Data-Flow maintains some models in the `dataflow` schema of the datasets DB. At the moment this is just a `metadata` table used to associate some timestamps with tables. Migrations for this table, and future tables in the same schema, are managed using Alembic. To change the model:
+
+1) Update the model in Python
+2) Run `PYTHONPATH=. alembic revision --autogenerate -m "<short description>"`
+3) Optionally run `PYTHONPATH=. alembic upgrade head`, though this is run automatically on app startup.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,89 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+revision_environment = true
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# this is the default URI for a local/development instance via docker-compose.
+sqlalchemy.url = postgresql://root@127.0.0.1:15432/datasets
+
+version_table_schema = 'dataflow'
+version_table = 'alembic_version'
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks=black
+# black.type=console_scripts
+# black.entrypoint=black
+# black.options=-l 79
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,113 @@
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from dataflow.models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_datasets_db_url():
+    if "AIRFLOW_CONN_DATASETS_DB" in os.environ:
+        url = os.environ['AIRFLOW_CONN_DATASETS_DB']
+    else:
+        url = config.get_main_option("sqlalchemy.url")
+
+    return url
+
+
+def include_object(object, name, type_, reflected, compare_to):
+    if type_ == 'table' and object.schema != "dataflow":
+        return False
+
+    return True
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = get_datasets_db_url()
+
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        version_table_schema='dataflow',
+        include_object=include_object,
+        include_schemas=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    # https://alembic.sqlalchemy.org/en/latest/cookbook.html#don-t-generate-empty-migrations-with-autogenerate
+    def process_revision_directives(context, revision, directives):
+        if config.cmd_opts.autogenerate:
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        url=get_datasets_db_url(),
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table_schema='dataflow',
+            include_object=include_object,
+            include_schemas=True,
+            process_revision_directives=process_revision_directives,
+        )
+
+        connection.execute("CREATE SCHEMA IF NOT EXISTS dataflow")
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/bf30b3dbebb4_create_metadata_table.py
+++ b/alembic/versions/bf30b3dbebb4_create_metadata_table.py
@@ -1,0 +1,33 @@
+"""create metadata table
+
+Revision ID: bf30b3dbebb4
+Revises:
+Create Date: 2020-08-18 16:07:58.707634
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "bf30b3dbebb4"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "metadata",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("table_schema", sa.Text(), nullable=False),
+        sa.Column("table_name", sa.Text(), nullable=False),
+        sa.Column("source_data_modified_utc", sa.DateTime(), nullable=True),
+        sa.Column("dataflow_swapped_tables_utc", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        schema="dataflow",
+    )
+
+
+def downgrade():
+    op.drop_table("metadata", schema="dataflow")

--- a/dataflow/models.py
+++ b/dataflow/models.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+
+Base: Any = declarative_base(metadata=sa.MetaData(schema='dataflow'))
+
+
+class Metadata(Base):
+    __tablename__ = 'metadata'
+
+    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+    table_schema = sa.Column(sa.Text, nullable=False)
+    table_name = sa.Column(sa.Text, nullable=False)
+    source_data_modified_utc = sa.Column(sa.DateTime, nullable=True)
+    dataflow_swapped_tables_utc = sa.Column(sa.DateTime, nullable=False)

--- a/dataflow/ons_scripts/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted/UK trade in services by partner country.py
+++ b/dataflow/ons_scripts/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted/UK trade in services by partner country.py
@@ -16,10 +16,11 @@
 # UK trade in services: service type by partner country, non-seasonally adjusted
 
 # +
+import json
+
 from gssutils import *
 
-scraper = Scraper('https://www.ons.gov.uk/businessindustryandtrade/' + \
-                  'internationaltrade/datasets/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted')
+scraper = Scraper(json.load(open('info.json'))['landingPage'])
 scraper
 
 # +

--- a/dataflow/ons_scripts/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted/info.json
+++ b/dataflow/ons_scripts/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted/info.json
@@ -1,0 +1,21 @@
+{
+    "title": "UK trade in services: service type by partner country, non-seasonally adjusted",
+    "publisher": "Office for National Statistics",
+    "description": "",
+    "landingPage": "https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted",
+    "published": "2020-01-22",
+    "families": [
+        "Trade"
+    ],
+    "extract": {
+        "source": "XLS",
+        "stage": "Done"
+    },
+    "transform": {
+        "validate": false,
+        "airtable": "reczFVGkUgwXtzkoH",
+        "main_issue": 17
+    },
+    "sizingNotes": "",
+    "notes": ""
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - /bin/sh
       - -c
       - |
+          alembic upgrade head
           airflow initdb
           ./bin/airflow-scheduler.sh &
           airflow worker &

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+alembic==1.3.1
 apache-airflow[postgres,crypto,celery,s3,sentry,slack]
 backoff
 mohawk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,11 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.3.1            # via apache-airflow
+alembic==1.3.1            # via -r requirements.in, apache-airflow
 amqp==2.5.2               # via kombu
 apache-airflow[celery,crypto,postgres,s3,sentry,slack]==1.10.11  # via -r requirements.in
 apispec[yaml]==1.3.3      # via flask-appbuilder
+appnope==0.1.0            # via ipython
 argcomplete==1.11.1       # via apache-airflow
 argparse==1.4.0           # via gssutils
 attrs==19.3.0             # via apache-airflow, cattrs, jsonschema

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,11 @@
 from unittest import mock
 
 import pytest
+import sqlalchemy as sa
+from airflow.operators.python_operator import PythonOperator
+
+from dataflow.dags import _PipelineDAG
+from dataflow.utils import TableConfig
 
 
 @pytest.fixture
@@ -14,3 +19,25 @@ def mock_db_conn(mocker):
     engine.begin.return_value.__enter__.return_value = conn
 
     return conn
+
+
+@pytest.fixture()
+def test_dag_cls():
+    def _fetch(*args, **kwargs):
+        return
+
+    class TestDAG(_PipelineDAG):
+        table_config = TableConfig(
+            table_name="test-table",
+            field_mapping=(
+                ("id", sa.Column("id", sa.Integer, primary_key=True)),
+                ("data", sa.Column("data", sa.Integer)),
+            ),
+        )
+
+        def get_fetch_operator(self) -> PythonOperator:
+            return PythonOperator(
+                task_id="fetch-data", python_callable=_fetch, provide_context=True,
+            )
+
+    return TestDAG

--- a/tests/unit/dags/test_base.py
+++ b/tests/unit/dags/test_base.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from tests.unit.utils import get_base_dag_tasks
+
+
+def test_base_dag_tasks(test_dag_cls):
+    dag = test_dag_cls().get_dag()
+
+    assert [t.task_id for t in dag.tasks] == get_base_dag_tasks(
+        with_modified_date_check=False
+    )
+
+
+def test_dag_tasks_with_source_modified_data_utc_callable(test_dag_cls):
+    class ModifiedTestDAG(test_dag_cls):
+        @staticmethod
+        def get_source_data_modified_utc(self) -> datetime:
+            return datetime(2020, 1, 1)
+
+        def get_source_data_modified_utc_callable(self):
+            return self.get_source_data_modified_utc
+
+    dag = ModifiedTestDAG().get_dag()
+
+    assert [t.task_id for t in dag.tasks] == get_base_dag_tasks(
+        with_modified_date_check=True
+    )

--- a/tests/unit/dags/test_ons_parsing_pipelines.py
+++ b/tests/unit/dags/test_ons_parsing_pipelines.py
@@ -1,0 +1,33 @@
+from dataflow.dags.ons_parsing_pipelines import (
+    ONSUKTradeInServicesByPartnerCountryNSAPipeline,
+    ONSUKTotalTradeAllCountriesNSA,
+    ONSUKTradeInGoodsByCountryAndCommodity,
+)
+from tests.unit.utils import get_base_dag_tasks
+
+
+class TestONSUKTradeInServicesByPartnerCountryNSAPipeline:
+    def test_tasks_in_dag(self):
+        dag = ONSUKTradeInServicesByPartnerCountryNSAPipeline().get_dag()
+
+        assert [t.task_id for t in dag.tasks] == get_base_dag_tasks(
+            with_modified_date_check=True, fetch_name="run-ons-parser-script"
+        )
+
+
+class TestONSUKTotalTradeAllCountriesNSA:
+    def test_tasks_in_dag(self):
+        dag = ONSUKTotalTradeAllCountriesNSA().get_dag()
+
+        assert [t.task_id for t in dag.tasks] == get_base_dag_tasks(
+            with_modified_date_check=True, fetch_name="run-ons-parser-script"
+        )
+
+
+class TestONSUKTradeInGoodsByCountryAndCommodity:
+    def test_tasks_in_dag(self):
+        dag = ONSUKTradeInGoodsByCountryAndCommodity().get_dag()
+
+        assert [t.task_id for t in dag.tasks] == get_base_dag_tasks(
+            with_modified_date_check=True, fetch_name="run-ons-parser-script"
+        )

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,0 +1,25 @@
+def get_base_dag_tasks(with_modified_date_check=False, fetch_name="fetch-data"):
+    if with_modified_date_check:
+        return [
+            "get-source-modified-date",
+            "branch-on-modified-date",
+            "stop",
+            "continue",
+            fetch_name,
+            "create-temp-tables",
+            "insert-into-temp-table",
+            "drop-temp-tables",
+            "check-temp-table-data",
+            "swap-dataset-table",
+            "drop-swap-tables",
+        ]
+
+    return [
+        fetch_name,
+        "create-temp-tables",
+        "insert-into-temp-table",
+        "drop-temp-tables",
+        "check-temp-table-data",
+        "swap-dataset-table",
+        "drop-swap-tables",
+    ]


### PR DESCRIPTION
### Description of change
This adds alembic to data-flow so that it can set up and manage a
metadata table for data-flow pipelines/tables. In the beginning we will
only track the table schema, table name, source last modified date, and
pipeline table swap date. Where a pipeline does not explicitly define a
method to determine the source data modified date, we leave the
corresponding column in the metadata column empty for now. In the future
we are likely to want to fill this in. I'm choosing not to do this now
as it isn't clear on the correct timestamp to store here for real-time
systems, which most of the remaining pipelines will represent.

Note: this patch runs DB migrations as part of app startup, which isn't
best practice, though is what we generally do on our other apps at the
moment. I've made a ticket in the tech debt backlog to address this
anti-pattern.

### Outstanding questions
~The main question I have is around the content of the metadata table. The current setup has table_schema+table_name as a PK constraint, so only one row per table will be made. Future pipelines will overwrite this row. We could alternatively just maintain this as an additive table, where each (successful) pipeline run writes a new row to the table so that we maintain a more thorough record of when data has been ingested and when it's been swapped out. This probably duplicates stuff in the dataflow UI, though it feels like a more reliable record and is also immediately accessible to data workspace because of its location in the datasets DB. Which should we do?~ We are now using an additive table where each successful pipeline run adds a row to the metadata table, so in theory we will have a growing history of pipeline runs and related data.

### Example data
```
datasets=# select * from dataflow.metadata;
 id | table_schema |                 table_name                 | source_data_modified_utc | dataflow_swapped_tables_utc
----+--------------+--------------------------------------------+--------------------------+-----------------------------
  1 | public       | market_access_trade_barriers               |                          | 2020-08-18 15:24:10.014625
  2 | public       | market_access_trade_barrier_status_history |                          | 2020-08-18 15:24:10.026038
  3 | public       | market_access_trade_barriers               |                          | 2020-08-18 15:27:16.316823
  4 | public       | market_access_trade_barrier_status_history |                          | 2020-08-18 15:27:16.328207
  5 | public       | ons__uk_trade_in_services_by_country_nsa   | 2020-07-22 00:00:00      | 2020-08-18 15:27:38.753588
```

### Example first run (with source data modified date checks)
<img width="1388" alt="Screen Shot 2020-08-18 at 16 36 37" src="https://user-images.githubusercontent.com/2920760/90533904-033b6680-e171-11ea-8afe-359ba5ebdfce.png">


### Example second run (with source data modified date checks)
<img width="1374" alt="Screen Shot 2020-08-18 at 16 31 16" src="https://user-images.githubusercontent.com/2920760/90533376-4d701800-e170-11ea-89ec-1f117886bf3f.png">

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [x] Has the README been updated (if needed)?
