### PR TITLE
fix: ignore unarchived_* fields for now

### DIFF
--- a/dataflow/dags/market_access_pipelines.py
+++ b/dataflow/dags/market_access_pipelines.py
@@ -82,8 +82,9 @@ class MarketAccessTradeBarriersPipeline(_PipelineDAG):
             (("archived_reason", "name"), sa.Column("archived_reason", sa.Text)),
             ("archived_explanation", sa.Column("archived_explanation", sa.Text)),
             (("unarchived_by", "name"), sa.Column("unarchived_by", sa.Text)),
-            ("unarchived_on", sa.Column("unarchived_on", sa.DateTime)),
-            ("unarchived_reason", sa.Column("unarchived_reason", sa.Text)),
+            # `unarchived_` fields are currently NULL everywhere, so we can't pull them in yet ...
+            # ("unarchived_on", sa.Column("unarchived_on", sa.DateTime)),
+            # ("unarchived_reason", sa.Column("unarchived_reason", sa.Text)),
             (
                 "status_history",
                 TableConfig(


### PR DESCRIPTION
### Description of change
We tried to pull these in but they're null everywhere, which the
pipeline then rejects. So let's not grab these for now.
