### PR TITLE
fix: include non-public schemas in table maintenance dag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Renamed DirectoryFormsPipeline to GreatGovUKFormsPipeline.
 
+## 2020-08-21
+
+### Changed
+
+- Update maintenance dag to include all (non user and postgres) schemas
+
 ## 2020-08-20
 
 ### Added

--- a/dataflow/dags/maintenance.py
+++ b/dataflow/dags/maintenance.py
@@ -79,7 +79,7 @@ AND schemaname NOT LIKE 'pg_%%'
             schema, table_name = table
             table_match = re.match(r"(.*)_(\d{8}t\d{6})(?:_swap)?", table_name)
             if not table_match:
-                logger.info(f"Skipping {table_name}")
+                logger.info(f"Skipping {schema}.{table_name}")
                 continue
 
             table_dt = datetime.strptime(table_match.groups()[1], "%Y%m%dt%H%M%S")


### PR DESCRIPTION
- Include schemas other than public in db cleanup task
- Excludes _user* and postgres internal schemas

### Checklist

* [x] Have tests been added to cover any changes?
* [x]  Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
