### PR TITLE
feat: poll for ONS updates every 15 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-08-26
+
+### Changed
+
+- ONS datasets 2-4 to poll for updates every 15 minutes.
+
 ## 2020-08-25
 
 ### Added

--- a/dataflow/dags/ons_parsing_pipelines.py
+++ b/dataflow/dags/ons_parsing_pipelines.py
@@ -63,7 +63,7 @@ class _ONSParserPipeline(_PipelineDAG):
 
 class ONSUKTradeInServicesByPartnerCountryNSAPipeline(_ONSParserPipeline):
     start_date = datetime(2020, 4, 1)
-    schedule_interval = "@monthly"
+    schedule_interval = "1/15 7-17 * * *"
 
     ons_script_dir = 'uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted'
 
@@ -107,7 +107,7 @@ class ONSUKTradeInServicesByPartnerCountryNSAPipeline(_ONSParserPipeline):
 
 class ONSUKTotalTradeAllCountriesNSA(_ONSParserPipeline):
     start_date = datetime(2020, 4, 1)
-    schedule_interval = "@monthly"
+    schedule_interval = "3/15 7-17 * * *"
 
     ons_script_dir = 'uktotaltradeallcountriesnonseasonallyadjusted'
 
@@ -150,7 +150,7 @@ class ONSUKTotalTradeAllCountriesNSA(_ONSParserPipeline):
 
 class ONSUKTradeInGoodsByCountryAndCommodity(_ONSParserPipeline):
     start_date = datetime(2020, 4, 1)
-    schedule_interval = "0 0 13 * *"
+    schedule_interval = "5/15 7-17 * * *"
 
     ons_script_dir = "uktradecountrybycommodity"
 


### PR DESCRIPTION
### Description of change
Data analysts want faster access to ONS data when it's been released.
They have fairly inconsistent release schedules, so we will poll for new
releases every 15 minutes (each dataset slightly offset to reduce
concurrent load).

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
