### PR TITLE
build(deps): pin buildpack to one with working git

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,5 +2,5 @@
 applications:
 - name: data-flow
   buildpacks:
-   - python_buildpack
+   - https://github.com/cloudfoundry/python-buildpack.git#v1.7.15
   memory: 5gb


### PR DESCRIPTION
### Description of change

Without this change, pushing gets the following in the log (lots has been snipped out)

```
**WARNING** buildpack version changed from 1.7.15 to 1.7.19

Running command git clone -q https://github.com/GSS-Cogs/gss-utils.git /tmp/pip-req-build-o_tjldhk
ERROR: Command errored out with exit status 1:

error: invalid command 'bdist_wheel'
```
So I suspect something's up with the latest PaaS Python buildback

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
