### PR TITLE
fix(ci): add repo url to git checkout in ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
         checkout([
             $class: 'GitSCM',
             branches: [[name: params.GIT_COMMIT]],
+            userRemoteConfigs: [[url: 'https://github.com/uktrade/data-flow.git']]
         ])
         script {
           pullRequestNumber = sh(


### PR DESCRIPTION
### Description of change
Jenkins deployments have been broken for a few days because the `userRemoteConfigs` argument seems to now be required by gitscm checkout.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
