### PR TITLE
Add country_investment_originates_from field to investment dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-01
+
+### Added
+
+- 'country_investment_originates_from' to Investment Projects dataset.
+
 ## 2020-08-26
 
 ### Changed

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -172,6 +172,10 @@ class InvestmentProjectsDatasetPipeline(_DatasetPipeline):
                 'competing_countries',
                 sa.Column('competing_countries', sa.ARRAY(sa.Text)),
             ),
+            (
+                'country_investment_originates_from__name',
+                sa.Column('country_investment_originates_from', sa.String),
+            ),
             ('created_by_id', sa.Column('created_by_id', UUID)),
             ('created_on', sa.Column('created_on', sa.DateTime)),
             (


### PR DESCRIPTION
### Description of change
The Data Hub team have added a new field to Investment Projects for `country_investment_originates_from`

https://github.com/uktrade/data-hub-api/blob/master/CHANGELOG.md#data-hub-api-3530-2020-08-17

It has been added to Data Hub investments dataset API endpoint.

This PR adds this field to `investment_projects_dataset` table.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
