### PR TITLE
Fix incorrect column name in People Finder pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-03
+
+### Changed
+
+- Fix incorrect column name in People Finder people pipeline
+
 ## 2020-09-01
 
 ### Added

--- a/dataflow/dags/people_finder_pipelines.py
+++ b/dataflow/dags/people_finder_pipelines.py
@@ -26,7 +26,7 @@ class PeopleFinderPeoplePipeline(_PipelineDAG):
             ),
             ("staff_sso_id", sa.Column("staff_sso_id", UUID)),
             ("email", sa.Column("email", sa.Text)),
-            ("contact_email", sa.Column("email", sa.Text)),
+            ("contact_email", sa.Column("contact_email", sa.Text)),
             ("full_name", sa.Column("full_name", sa.Text)),
             ("first_name", sa.Column("first_name", sa.Text)),
             ("last_name", sa.Column("last_name", sa.Text)),


### PR DESCRIPTION
The (mostly empty) `contact_email` field was overwriting the main
`email` field by accident due to a typo in the field mapping

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
