### PR TITLE
fix: ensure tensorflow worker has notifications client

### DIFF
--- a/requirements-tensorflow.txt
+++ b/requirements-tensorflow.txt
@@ -40,7 +40,7 @@ decorator==4.4.2          # via ipython, traitlets
 defusedxml==0.6.0         # via python3-openid
 dill==0.3.2               # via apache-airflow
 dnspython==2.0.0          # via email-validator
-docopt==0.6.2             # via databaker
+docopt==0.6.2             # via databaker, notifications-python-client
 docutils==0.15.2          # via botocore, python-daemon
 email-validator==1.1.1    # via apache-airflow, flask-appbuilder
 flask-admin==1.5.4        # via apache-airflow
@@ -56,7 +56,7 @@ flask-wtf==0.14.3         # via apache-airflow, flask-appbuilder
 flask==1.1.2              # via apache-airflow, flask-admin, flask-appbuilder, flask-babel, flask-caching, flask-jwt-extended, flask-login, flask-openid, flask-sqlalchemy, flask-swagger, flask-wtf
 flower==0.9.5             # via apache-airflow
 funcsigs==1.0.2           # via apache-airflow
-future==0.18.2            # via apache-airflow
+future==0.18.2            # via apache-airflow, notifications-python-client
 gast==0.3.3               # via tensorflow
 google-auth-oauthlib==0.4.1  # via tensorboard
 google-auth==1.20.1       # via google-auth-oauthlib, tensorboard
@@ -96,9 +96,11 @@ marshmallow-sqlalchemy==0.23.1  # via flask-appbuilder
 marshmallow==2.21.0       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
 messytables==0.15.1       # via gssutils, xypath
 mohawk==1.1.0             # via -r requirements.in
+monotonic==1.5            # via notifications-python-client
 msal==1.4.3               # via -r requirements.in
 msgpack==1.0.0            # via cachecontrol
 natsort==7.0.1            # via croniter
+notifications-python-client==5.7.0  # via -r requirements.in
 numpy==1.18.5             # via h5py, keras-preprocessing, opt-einsum, pandas, scipy, tensorboard, tensorflow
 oauthlib==3.1.0           # via requests-oauthlib
 opt-einsum==3.3.0         # via tensorflow
@@ -124,7 +126,7 @@ pyexcel-xls==0.5.8        # via gssutils
 pyexcel==0.6.4            # via gssutils
 pygments==2.6.1           # via apache-airflow, ipython
 pyhamcrest==2.0.2         # via databaker
-pyjwt[crypto]==1.7.1      # via -r requirements.in, flask-appbuilder, flask-jwt-extended, msal
+pyjwt[crypto]==1.7.1      # via -r requirements.in, flask-appbuilder, flask-jwt-extended, msal, notifications-python-client
 pyparsing==2.4.7          # via rdflib
 pyrsistent==0.16.0        # via jsonschema
 python-daemon==2.2.4      # via apache-airflow
@@ -141,7 +143,7 @@ rdflib-jsonld==0.5.0      # via gssutils
 rdflib==4.2.2             # via gssutils, rdflib-jsonld
 redis==3.5.3              # via -r requirements.in
 requests-oauthlib==1.3.0  # via -r requirements.in, google-auth-oauthlib
-requests==2.24.0          # via -r requirements.in, apache-airflow, cachecontrol, gssutils, messytables, msal, requests-oauthlib, slackclient, tensorboard
+requests==2.24.0          # via -r requirements.in, apache-airflow, cachecontrol, gssutils, messytables, msal, notifications-python-client, requests-oauthlib, slackclient, tensorboard
 rsa==4.6                  # via google-auth
 s3transfer==0.3.3         # via boto3
 scipy==1.4.1              # via tensorflow

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,5 @@
+# If changing requirements, both requirements.txt and
+# requirements-tensorflow.txt must be recompiled
 alembic==1.3.1
 apache-airflow[postgres,crypto,celery,s3,sentry,slack]
 backoff


### PR DESCRIPTION
### Description of change

Even though it doesn't use the notifications client, it attempts to import the code of the DAGs, and fails because it can't import it

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
