### PR TITLE
Polling pipeline tweaks

### DIFF
--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -402,7 +402,7 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
                 "email_on_failure": False,
                 "email_on_retry": False,
                 "retries": 3,
-                "retry_delay": timedelta(minutes=5),
+                "retry_delay": timedelta(seconds=30),
                 'catchup': self.catchup,
             },
             start_date=self.start_date,

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -23,11 +23,11 @@ class _ONSPipeline(_PipelineDAG):
 
 class ONSUKSATradeInGoodsPollingPipeline(_FastPollingPipeline):
     from dataflow.ons_scripts.uk_trade_in_goods_all_countries_seasonally_adjusted.main import (
-        get_source_data_modified_date,
+        get_current_and_next_release_date,
         get_data,
     )
 
-    date_checker = get_source_data_modified_date
+    date_checker = get_current_and_next_release_date
     data_getter = get_data
     table_config = TableConfig(
         schema='ons', table_name="uk_sa_trade_in_goods", field_mapping=[],
@@ -40,11 +40,11 @@ class ONSUKSATradeInGoodsPollingPipeline(_FastPollingPipeline):
 
 class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(_FastPollingPipeline):
     from dataflow.ons_scripts.uktradecountrybycommodity.main import (
-        get_source_data_modified_date,
+        get_current_and_next_release_date,
         get_data,
     )
 
-    date_checker = get_source_data_modified_date
+    date_checker = get_current_and_next_release_date
     data_getter = get_data
     table_config = TableConfig(
         schema='ons',

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -51,4 +51,4 @@ class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(_FastPollingPipeline
         table_name='uk_trade_in_goods_by_country_and_commodity',
         field_mapping=[],
     )
-    queue = 'high-memory-usage'
+    worker_queue = 'high-memory-usage'

--- a/dataflow/ons_scripts/uk_trade_in_goods_all_countries_seasonally_adjusted/main.py
+++ b/dataflow/ons_scripts/uk_trade_in_goods_all_countries_seasonally_adjusted/main.py
@@ -10,6 +10,7 @@ import gssutils
 import pandas
 import re
 
+import requests
 
 DATASET_URL = 'https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/uktradeallcountriesseasonallyadjusted'
 
@@ -137,7 +138,7 @@ def process_data():
         print(datetime.now(), f'scrape {sheetname} - complete')
         return new_table
 
-    scraper = gssutils.Scraper(DATASET_URL)
+    scraper = gssutils.Scraper(DATASET_URL, session=requests.Session())
     tabs = {tab.name: tab for tab in scraper.distributions[0].as_databaker()}
 
     print(datetime.now(), f'spreadsheet scrape - start')
@@ -183,7 +184,7 @@ def process_data():
 
 
 def get_source_data_modified_date() -> datetime:
-    scraper = gssutils.Scraper(DATASET_URL)
+    scraper = gssutils.Scraper(DATASET_URL, session=requests.Session())
 
     return datetime(
         year=scraper.dataset.issued.year,

--- a/dataflow/ons_scripts/uk_trade_in_goods_all_countries_seasonally_adjusted/main.py
+++ b/dataflow/ons_scripts/uk_trade_in_goods_all_countries_seasonally_adjusted/main.py
@@ -4,7 +4,7 @@ https://github.com/GSS-Cogs/family-trade/blob/fca3be954d0b4ed216a4a0989182b19a5c
 """
 
 from datetime import datetime
-
+from typing import Tuple
 
 import gssutils
 import pandas
@@ -183,16 +183,19 @@ def process_data():
     return table.drop_duplicates()
 
 
-def get_source_data_modified_date() -> datetime:
+def get_current_and_next_release_date() -> Tuple[datetime, datetime]:
     scraper = gssutils.Scraper(DATASET_URL, session=requests.Session())
 
-    return datetime(
-        year=scraper.dataset.issued.year,
-        month=scraper.dataset.issued.month,
-        day=scraper.dataset.issued.day,
-        hour=0,
-        minute=0,
-        second=0,
+    return (
+        datetime(
+            year=scraper.dataset.issued.year,
+            month=scraper.dataset.issued.month,
+            day=scraper.dataset.issued.day,
+            hour=0,
+            minute=0,
+            second=0,
+        ),
+        scraper.dataset.updateDueOn,
     )
 
 

--- a/dataflow/ons_scripts/uktradecountrybycommodity/main.py
+++ b/dataflow/ons_scripts/uktradecountrybycommodity/main.py
@@ -8,6 +8,7 @@ import re
 from datetime import datetime, date
 from io import BytesIO
 from multiprocessing import Pool
+from typing import Tuple
 from zipfile import ZipFile
 
 import numpy
@@ -155,21 +156,27 @@ def process_data(flow_type, dataset_url):
     return table
 
 
-def get_source_data_modified_date() -> datetime:
+def get_current_and_next_release_date() -> Tuple[datetime, datetime]:
     exports_scraper = Scraper(EXPORTS_DATASET_URL, session=requests.Session())
     imports_scraper = Scraper(IMPORTS_DATASET_URL, session=requests.Session())
 
-    oldest_date: date = min(
+    oldest_current_release_date: date = min(
         exports_scraper.dataset.issued, imports_scraper.dataset.issued
     )
+    latest_update_date = max(
+        exports_scraper.dataset.updateDueOn, exports_scraper.dataset.updateDueOn
+    )
 
-    return datetime(
-        year=oldest_date.year,
-        month=oldest_date.month,
-        day=oldest_date.day,
-        hour=0,
-        minute=0,
-        second=0,
+    return (
+        datetime(
+            year=oldest_current_release_date.year,
+            month=oldest_current_release_date.month,
+            day=oldest_current_release_date.day,
+            hour=0,
+            minute=0,
+            second=0,
+        ),
+        latest_update_date,
     )
 
 

--- a/dataflow/ons_scripts/uktradecountrybycommodity/main.py
+++ b/dataflow/ons_scripts/uktradecountrybycommodity/main.py
@@ -11,6 +11,7 @@ from multiprocessing import Pool
 from zipfile import ZipFile
 
 import numpy
+import requests
 from gssutils import Scraper
 import pandas as pd
 from pandas import DataFrame
@@ -57,7 +58,7 @@ def process_data(flow_type, dataset_url):
             print(f"no match for {t}")
 
     print(datetime.now(), f'process_data({flow_type}, {dataset_url}) start')
-    scraper = Scraper(dataset_url)
+    scraper = Scraper(dataset_url, session=requests.Session())
     distribution = scraper.distribution(mediaType=lambda x: 'zip' in x, latest=True)
 
     with ZipFile(BytesIO(scraper.session.get(distribution.downloadURL).content)) as zip:
@@ -155,8 +156,8 @@ def process_data(flow_type, dataset_url):
 
 
 def get_source_data_modified_date() -> datetime:
-    exports_scraper = Scraper(EXPORTS_DATASET_URL)
-    imports_scraper = Scraper(IMPORTS_DATASET_URL)
+    exports_scraper = Scraper(EXPORTS_DATASET_URL, session=requests.Session())
+    imports_scraper = Scraper(IMPORTS_DATASET_URL, session=requests.Session())
 
     oldest_date: date = min(
         exports_scraper.dataset.issued, imports_scraper.dataset.issued

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -497,7 +497,7 @@ def poll_for_new_data(
     with engine.begin() as conn:
         db_data_last_modified_utc = conn.execute(
             text(
-                "SELECT MIN(source_data_modified_utc) "
+                "SELECT MAX(source_data_modified_utc) "
                 "FROM dataflow.metadata "
                 "WHERE table_schema = :schema AND table_name = :table"
             ),

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -19,7 +19,8 @@ def get_base_dag_tasks(with_modified_date_check=False, fetch_name="fetch-data"):
 
 def get_polling_dag_tasks(with_emails=False):
     tasks = {
-        "poll-scrape-and-load-data",
+        "poll-for-new-data",
+        "scrape-and-load-data",
         "swap-dataset-table",
         "drop-swap-tables",
         "drop-temp-tables",


### PR DESCRIPTION
### Description of change

#### fix: retry failed polling tasks faster


#### fix: bypass scraper caching
The gss-utils scraper, by default, implements file-based caching for
requests. When we run our polling pipeline task in air-flow, we
initialise a new scraper each time we want to check the last modified
date but it resolves to the same file cache, meaning that we don't
actually retrieve the last data every time we poll. Providing a custom
session overrides the default caching logic meaning that every poll will
check for the latest date.

#### fix: split polling loop to separate task 
We originally had the polling loop as part of the main
scrape/transform/load task in order to minimise the latency between
airflow running tasks. This feels not ideal upon further consideration:

We set the polling jobs to run fairly regularly, possibly even every
day, despite (currently) only expecting new data to be ingested once
a month or quarter. Therefore during the polling cycle, the task is
locking up a worker and not doing much work. For some of the larger
datasets, this may block an entire instance (e.g. high-memory-worker,
where we only have 1 instance and that instance only accepts 1 task). By
splitting the task out, we can run the polling cycles on
generic/lower-memory workers without blocking our high spec workers for
long times. The polling task also has significant downtime (current
default 60 seconds), so trying to optimise out the ~10 seconds or so of
latencty between two tasks doesn't feel like a significant enough win to
justify blocking those workers.


#### fix: class attribute name for worker queue


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
