### PR TITLE
feat: allow for setting `source_data_modified_utc` to utcnow()

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,539 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=start.sh
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=abstract-method,
+        bad-continuation,
+        consider-using-ternary,
+        duplicate-code,
+        http-response-with-content-type-json,
+        invalid-name,
+        missing-docstring,
+        no-else-raise,
+        no-else-return,
+        no-self-use,
+        protected-access,
+        redefined-outer-name,
+        too-few-public-methods,
+        too-many-ancestors,
+        too-many-ancestors,
+        too-many-arguments,
+        too-many-branches,
+        too-many-instance-attributes,
+        too-many-lines,
+        too-many-locals,
+        too-many-public-methods,
+        too-many-statements,
+        unused-argument,
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=125
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=yes
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=25
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=10
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - ONS UK SA Trade in Goods dataset to scrape/clean/transform/load directly from the ONS spreadsheet rather than their alpha API, which has been flaky. This will also use our condensed polling pipeline to load this data more quickly.
 - ONS UK Trade in goods by country and commodity dataset to a condensed polling pipeline.
 
+## 2020-09-11
+
+### Added
+
+- Allow for pipelines to specify setting `source_data_modified_utc` to run time (utc)
+
+### Changed
+
+- Update daily dataset dags to set `source_data_modified_utc` to utc now
+
 ## 2020-09-08
 
 ### Changed

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -78,6 +78,9 @@ class _PipelineDAG(metaclass=PipelineMeta):
     # exact time, NOT a range of "between now and 5 hours ago".
     dependencies_execution_delta: timedelta = timedelta(hours=0)
 
+    # If True, the source_data_modified_utc metadata field will be set to the swap table task run utc.
+    use_utc_now_as_source_modified: bool = False
+
     def get_fetch_operator(self) -> PythonOperator:
         raise NotImplementedError(
             f"{self.__class__} needs to override get_fetch_operator"
@@ -209,6 +212,9 @@ class _PipelineDAG(metaclass=PipelineMeta):
             execution_timeout=timedelta(minutes=10),
             provide_context=True,
             op_args=[self.target_db, *self.table_config.tables],
+            op_kwargs={
+                'use_utc_now_as_source_modified': self.use_utc_now_as_source_modified
+            },
         )
 
         _drop_temp_tables = PythonOperator(

--- a/dataflow/dags/companies_house_pipelines.py
+++ b/dataflow/dags/companies_house_pipelines.py
@@ -9,6 +9,7 @@ from dataflow.utils import TableConfig
 class CompaniesHouseCompaniesPipeline(_PipelineDAG):
     schedule_interval = '0 0 10 * *'
     allow_null_columns = True
+    use_utc_now_as_source_modified = True
     number_of_files = 6
     source_url = 'http://download.companieshouse.gov.uk/BasicCompanyData-{file_date}-part{file_num}_{num_files}.zip'
     table_config = TableConfig(

--- a/dataflow/dags/consent_pipelines.py
+++ b/dataflow/dags/consent_pipelines.py
@@ -12,6 +12,7 @@ from dataflow.utils import TableConfig
 
 class _ConsentPipeline(_PipelineDAG):
     cascade_drop_tables = True
+    use_utc_now_as_source_modified = True
 
     source_url: str
     table_config: TableConfig

--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -15,6 +15,7 @@ from dataflow.utils import TableConfig
 class OxfordCovid19GovernmentResponseTracker(_PipelineDAG):
     source_url = 'https://oxcgrtportal.azurewebsites.net/api/CSVDownload'
     allow_null_columns = True
+    use_utc_now_as_source_modified = True
     table_config = TableConfig(
         table_name='oxford_covid19_government_response_tracker',
         field_mapping=[
@@ -144,6 +145,7 @@ class OxfordCovid19GovernmentResponseTracker(_PipelineDAG):
 class CSSECovid19TimeSeriesGlobal(_PipelineDAG):
     # Run after the daily update of data ~4am
     schedule_interval = '0 7 * * *'
+    use_utc_now_as_source_modified = True
 
     source_urls = {
         "confirmed": "https://github.com/CSSEGISandData/COVID-19/raw/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv",
@@ -190,7 +192,7 @@ class CSSECovid19TimeSeriesGlobal(_PipelineDAG):
 
 class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
     schedule_interval = '0 7 * * *'
-
+    use_utc_now_as_source_modified = True
     dependencies = [CSSECovid19TimeSeriesGlobal]
 
     query = """
@@ -268,9 +270,8 @@ class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
 
 
 class GoogleCovid19MobilityReports(_PipelineDAG):
-
     schedule_interval = '0 1 * * 0'
-
+    use_utc_now_as_source_modified = True
     source_urls = {
         'global': 'https://www.gstatic.com/covid19/mobility/Global_Mobility_Report.csv',
     }
@@ -376,6 +377,7 @@ class GoogleCovid19MobilityReports(_PipelineDAG):
 class AppleCovid19MobilityTrendsPipeline(_PipelineDAG):
     base_url = 'https://covid19-static.cdn-apple.com'
     config_path = '/covid19-mobility-data/current/v3/index.json'
+    use_utc_now_as_source_modified = True
     table_config = TableConfig(
         schema='apple',
         table_name='covid19_mobility_data',

--- a/dataflow/dags/dashboard_pipelines.py
+++ b/dataflow/dags/dashboard_pipelines.py
@@ -23,6 +23,7 @@ from dataflow.utils import TableConfig
 class _SQLPipelineDAG(_PipelineDAG):
     schedule_interval = '@daily'
     query: str
+    use_utc_now_as_source_modified = True
 
     def get_fetch_operator(self):
         return PythonOperator(

--- a/dataflow/dags/data_workspace_pipelines.py
+++ b/dataflow/dags/data_workspace_pipelines.py
@@ -14,6 +14,7 @@ from dataflow.utils import TableConfig
 class _DataWorkspacePipeline(_PipelineDAG):
     cascade_drop_tables = True
     source_url: str
+    use_utc_now_as_source_modified = True
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -17,7 +17,7 @@ from dataflow.utils import TableConfig
 
 class _DatasetPipeline(_PipelineDAG):
     cascade_drop_tables = True
-
+    use_utc_now_as_source_modified = True
     source_url: str
 
     fetch_retries = 0

--- a/dataflow/dags/dun_and_bradstreet_pipelines.py
+++ b/dataflow/dags/dun_and_bradstreet_pipelines.py
@@ -23,6 +23,7 @@ from dataflow.utils import TableConfig
 class _DNBPipeline(_PipelineDAG):
     cascade_drop_tables = True
     source_url: str
+    use_utc_now_as_source_modified = True
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/dags/export_wins_dashboard.py
+++ b/dataflow/dags/export_wins_dashboard.py
@@ -17,6 +17,7 @@ from dataflow.utils import TableConfig
 
 
 class ExportWinsDashboardPipeline(_PipelineDAG):
+    use_utc_now_as_source_modified = True
     dependencies = [
         CompaniesDatasetPipeline,
         ExportWinsAdvisersDatasetPipeline,

--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -14,6 +14,7 @@ class _HMRCPipeline(_PipelineDAG):
 
     schedule_interval = '0 5 12 * *'
     start_date = datetime(2020, 3, 11)
+    use_utc_now_as_source_modified = True
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/dags/market_access_pipelines.py
+++ b/dataflow/dags/market_access_pipelines.py
@@ -18,6 +18,7 @@ class MarketAccessTradeBarriersPipeline(_PipelineDAG):
     source_url = f"{config.MARKET_ACCESS_BASE_URL}/dataset/v1/barriers"
     start_date = datetime(2020, 3, 18)
     schedule_interval = '@daily'
+    use_utc_now_as_source_modified = True
 
     table_config = TableConfig(
         table_name="market_access_trade_barriers",

--- a/dataflow/dags/people_finder_pipelines.py
+++ b/dataflow/dags/people_finder_pipelines.py
@@ -15,6 +15,7 @@ from dataflow.utils import TableConfig
 
 class PeopleFinderPeoplePipeline(_PipelineDAG):
     schedule_interval = "@daily"
+    use_utc_now_as_source_modified = True
     path = "/api/v2/data_workspace_export"
     source_url = f"{config.PEOPLE_FINDER_BASE_URL}{path}"
     table_config = TableConfig(

--- a/dataflow/dags/sharepoint_pipelines.py
+++ b/dataflow/dags/sharepoint_pipelines.py
@@ -14,6 +14,7 @@ from dataflow.utils import TableConfig
 class _SharepointPipeline(_PipelineDAG):
     sub_site_id: Optional[str]
     list_id: Optional[str]
+    use_utc_now_as_source_modified = True
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/dags/spi_pipeline.py
+++ b/dataflow/dags/spi_pipeline.py
@@ -14,6 +14,7 @@ from dataflow.utils import TableConfig
 
 
 class DataHubSPIPipeline(_PipelineDAG):
+    use_utc_now_as_source_modified = True
     target_db = config.DATASETS_DB_NAME
     source_url = '{0}/v4/dataset/investment-projects-activity-dataset'.format(
         config.DATAHUB_BASE_URL

--- a/dataflow/dags/tariff_pipelines.py
+++ b/dataflow/dags/tariff_pipelines.py
@@ -9,6 +9,7 @@ from dataflow.utils import TableConfig
 
 
 class GlobalUKTariffPipeline(_PipelineDAG):
+    use_utc_now_as_source_modified = True
     source_url = (
         'https://www.check-future-uk-trade-tariffs.service.gov.uk/api/global-uk-tariff'
     )

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -273,6 +273,11 @@ def test_swap_dataset_tables(
     xcom_mock = mock.Mock()
     xcom_mock.xcom_pull.return_value = xcom_modified_date
 
+    mock_get_task_instance = mocker.patch(
+        'dataflow.operators.db_tables.get_task_instance'
+    )
+    mock_get_task_instance().end_date = expected_result
+
     with freezegun.freeze_time('20200202t12:00:00'):
         db_tables.swap_dataset_tables(
             "test-db",
@@ -280,6 +285,8 @@ def test_swap_dataset_tables(
             ts_nodash="123",
             task_instance=xcom_mock,
             use_utc_now_as_source_modified=use_utc_now_as_source_modified,
+            dag=mock.Mock(),
+            execution_date=datetime(2020, 2, 2, 12, 0),
         )
 
     mock_db_conn.execute.assert_has_calls(

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -389,7 +389,10 @@ def test_branch_on_modified_date(
 
 class TestPollForNewData:
     class TestPipeline(_FastPollingPipeline):
-        date_checker = lambda: (datetime.now(), datetime.now())  # noqa
+        @staticmethod
+        def date_checker():
+            return (datetime.now(), datetime.now())
+
         data_getter = mock.Mock()
         daily_end_time_utc = time(17, 0, 0)
         allow_null_columns = False
@@ -458,7 +461,10 @@ class TestPollForNewData:
 
         with freezegun.freeze_time(run_time_utc):
             db_tables.poll_for_new_data(
-                "test-db", self.TestPipeline.table_config, self.TestPipeline(), **kwargs
+                "test-db",
+                self.TestPipeline.table_config,  # pylint: disable=no-member
+                self.TestPipeline(),
+                **kwargs
             )
 
         if should_skip:
@@ -496,7 +502,10 @@ class TestPollForNewData:
 
         with freezegun.freeze_time('20200115t19:00:00'):
             db_tables.poll_for_new_data(
-                "test-db", self.TestPipeline.table_config, self.TestPipeline(), **kwargs
+                "test-db",
+                self.TestPipeline.table_config,  # pylint: disable=no-member
+                self.TestPipeline(),
+                **kwargs
             )
 
         assert len(mock_skip.call_args_list) == 1
@@ -528,7 +537,10 @@ class TestPollForNewData:
 
         with freezegun.freeze_time('20200101t12:00:00'):
             db_tables.poll_for_new_data(
-                "test-db", self.TestPipeline.table_config, self.TestPipeline(), **kwargs
+                "test-db",
+                self.TestPipeline.table_config,  # pylint: disable=no-member
+                self.TestPipeline(),
+                **kwargs
             )
 
         assert len(mock_skip.call_args_list) == 0
@@ -585,31 +597,46 @@ def test_poll_scrape_and_load_data(mocker):
     )
 
     with freezegun.freeze_time('20200101t19:00:00'):
-        db_tables.poll_scrape_and_load_data(
+        db_tables.scrape_load_and_check_data(
             "test-db",
             TestPipeline.table_config,  # pylint: disable=no-member
             TestPipeline(),
             **kwargs
         )
 
-    assert any(
-        c == mock.call('CREATE SCHEMA IF NOT EXISTS test')
-        for c in conn.execute.call_args_list
-    )
+    assert mock_create_tables.call_args_list == [
+        mock.call(
+            "test-db",
+            mock.ANY,
+            ts_nodash='123',
+            dag=mock.ANY,
+            dag_run=mock.ANY,
+            ti=mock.ANY,
+            task_instance=mock.ANY,
+        )
+    ]
     assert (
-        TestPipeline.data_getter.return_value.to_sql.call_args_list  # pylint: disable=no-member
+        TestPipeline.data_getter.return_value.to_csv.call_args_list  # pylint: disable=no-member
         == [
             mock.call(
-                name='tmp_test_table',
-                schema='test',
-                con=engine.return_value.connect.return_value.__enter__.return_value,
-                method='multi',
-                if_exists='append',
-                chunksize=10000,
+                mock_namedtempfile.name,
                 index=False,
+                header=False,
+                sep='\t',
+                na_rep=r'\N',
+                columns=["data_id"],
             )
         ]
     )
+    assert mock_cursor.copy_from.call_args_list == [
+        mock.call(
+            mock_namedtempfile,
+            '"test"."tmp_test_table"',
+            sep='\t',
+            null=r'\N',
+            columns=["db_id"],
+        )
+    ]
     assert mock_check_table_data.call_args_list == [
         mock.call(
             'test-db',

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -533,7 +533,7 @@ class TestPollForNewData:
 def test_poll_scrape_and_load_data(mocker):
     class TestPipeline(_FastPollingPipeline):
         def date_checker():
-            return datetime.now()  # noqa
+            return datetime.now()
 
         data_getter = mock.Mock()
         daily_end_time_utc = time(17, 0, 0)


### PR DESCRIPTION
- Specify at the dataset level whether to use xcom date or utcnow when setting the last modified date for a table.
- Cleanup db_tables.py to fix pylint issues

Closes: https://trello.com/c/FyJUmHp1/887-add-last-updated-metadata-to-dataset-pipelines

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
