### PR TITLE
feature: contact and advisor last interaction pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-14
+
+### Added
+
+- Contact and advisor last interaction pipelines.
+
 ## 2020-09-12
 
 ### Added

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -5,6 +5,7 @@ def test_pipelines_dags():
     dagbag = DagBag('dataflow', include_examples=False)
     assert set(dagbag.dag_ids) == {
         'AdvisersDatasetPipeline',
+        'AdvisersLastInteractionPipeline',
         'AppleCovid19MobilityTrendsPipeline',
         'CSSECovid19TimeSeriesGlobal',
         'CSSECovid19TimeSeriesGlobalGroupedByCountry',
@@ -15,6 +16,7 @@ def test_pipelines_dags():
         'CompanyExportCountryHistory',
         'ConsentPipeline',
         'ContactsDatasetPipeline',
+        'ContactsLastInteractionPipeline',
         'CoronavirusInteractionsDashboardPipeline',
         'CountriesOfInterestServicePipeline',
         'DNBCompanyPipeline',


### PR DESCRIPTION
### Description of change

Finding the latest interaction date for a contact/advisor is a quite costly query and has caused some database outages recently. To remedy this we add two new pipelines to run overnight which will speed up custom queries on the site.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
