### PR TITLE
feat: use raw copy to load data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-15
+
+### Changed
+- Use postgres's native `copy_from` rather than `DataFrame.to_sql` to load data in postgres for the "fast polling" pipelines for significant speed gains (~15x).
+
 ## 2020-09-14
 
 ### Added

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -24,7 +24,7 @@ from dataflow.operators.db_tables import (
     poll_for_new_data,
 )
 from dataflow.operators.email import send_dataset_update_emails
-from dataflow.utils import TableConfig, slack_alert
+from dataflow.utils import TableConfig, slack_alert, SingleTableConfig
 
 
 class PipelineMeta(type):
@@ -366,7 +366,7 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
     date_checker: Callable[[], Tuple[datetime, Optional[datetime]]]
     data_getter: Callable
 
-    table_config: TableConfig
+    table_config: SingleTableConfig
 
     # How often to poll the data source to read it's "last modified" date.
     polling_interval_in_seconds = 60

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
 from airflow.operators.python_operator import PythonOperator
+import sqlalchemy as sa
 
 from dataflow.dags import _PipelineDAG
 from dataflow.dags.base import _FastPollingPipeline
 from dataflow.operators.ons import fetch_from_ons_sparql
-from dataflow.utils import TableConfig
+from dataflow.utils import SingleTableConfig
 
 
 class _ONSPipeline(_PipelineDAG):
@@ -29,8 +30,20 @@ class ONSUKSATradeInGoodsPollingPipeline(_FastPollingPipeline):
 
     date_checker = get_current_and_next_release_date
     data_getter = get_data
-    table_config = TableConfig(
-        schema='ons', table_name="uk_sa_trade_in_goods", field_mapping=[],
+    table_config = SingleTableConfig(
+        schema='ons',
+        table_name="uk_sa_trade_in_goods",
+        field_mapping=[
+            ('ons_iso_alpha_2_code', sa.Column('ons_iso_alpha_2_code', sa.Text)),
+            ('ons_region_name', sa.Column('ons_region_name', sa.Text)),
+            ('period', sa.Column('period', sa.Text)),
+            ('period_type', sa.Column('period_type', sa.Text)),
+            ('direction', sa.Column('direction', sa.Text)),
+            ('measure_type', sa.Column('measure_type', sa.Text)),
+            ('value', sa.Column('value', sa.Numeric)),
+            ('unit', sa.Column('unit', sa.Text)),
+            ('marker', sa.Column('marker', sa.Text)),
+        ],
     )
 
     update_emails_data_environment_variable = (
@@ -46,9 +59,22 @@ class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(_FastPollingPipeline
 
     date_checker = get_current_and_next_release_date
     data_getter = get_data
-    table_config = TableConfig(
+    table_config = SingleTableConfig(
         schema='ons',
         table_name='uk_trade_in_goods_by_country_and_commodity',
-        field_mapping=[],
+        field_mapping=[
+            ('ons_iso_alpha_2_code', sa.Column('ons_iso_alpha_2_code', sa.Text)),
+            ('ons_region_name', sa.Column('ons_region_name', sa.Text)),
+            ('period', sa.Column('period', sa.Text)),
+            ('period_type', sa.Column('period_type', sa.Text)),
+            ('direction', sa.Column('direction', sa.Text)),
+            ('product_code', sa.Column('product_code', sa.Text)),
+            ('product_name', sa.Column('product_name', sa.Text)),
+            ('seasonal_adjustment', sa.Column('seasonal_adjustment', sa.Text)),
+            ('measure_type', sa.Column('measure_type', sa.Text)),
+            ('total', sa.Column('total', sa.Numeric)),
+            ('unit', sa.Column('unit', sa.Text)),
+            ('marker', sa.Column('marker', sa.Text)),
+        ],
     )
     worker_queue = 'high-memory-usage'

--- a/dataflow/ons_scripts/uktradecountrybycommodity/main.py
+++ b/dataflow/ons_scripts/uktradecountrybycommodity/main.py
@@ -181,19 +181,12 @@ def get_current_and_next_release_date() -> Tuple[datetime, datetime]:
 
 
 def get_data() -> DataFrame:
-    with Pool(processes=2) as pool:
-        print('start getting', datetime.now())
-        exports = pool.apply_async(
-            process_data,
-            kwds=dict(flow_type='exports', dataset_url=EXPORTS_DATASET_URL),
-        )
-        imports = pool.apply_async(
-            process_data,
-            kwds=dict(flow_type='imports', dataset_url=IMPORTS_DATASET_URL),
-        )
-        df = pd.concat(
-            [exports.get(timeout=24 * 60 * 60), imports.get(timeout=24 * 60 * 60),]
-        ).drop_duplicates()
-        print('end getting', datetime.now(), len(df))
+    print('start getting', datetime.now())
+
+    exports = process_data(flow_type='exports', dataset_url=EXPORTS_DATASET_URL)
+    imports = process_data(flow_type='imports', dataset_url=IMPORTS_DATASET_URL)
+    df = pd.concat([exports, imports]).drop_duplicates()
+
+    print('end getting', datetime.now(), len(df))
 
     return df

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -147,6 +147,12 @@ class TableConfig:
                 related_table.configure(**kwargs)
 
 
+class SingleTableConfig(TableConfig):
+    # A TableConfig that doesn't support any nested tables, for cases where our current code doesn't support building
+    # related tables (e.g. _FastPollingPipeline).
+    field_mapping: SingleTableFieldMapping
+
+
 def slack_alert(context, success=False):
     if not config.SLACK_TOKEN:
         logger.info("No Slack token, skipping Slack notification")
@@ -268,4 +274,5 @@ def get_temp_table(table, suffix):
         table.metadata,
         *[column.copy() for column in table.columns],
         schema=table.schema,
+        keep_existing=True,
     )

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -9,7 +9,7 @@ import sqlalchemy
 from dataflow.dags import _FastPollingPipeline
 from dataflow.operators import db_tables
 from dataflow.operators.db_tables import branch_on_modified_date
-from dataflow.utils import get_temp_table, TableConfig
+from dataflow.utils import get_temp_table, TableConfig, SingleTableConfig
 
 
 @pytest.fixture
@@ -373,7 +373,7 @@ class TestPollForNewData:
         data_getter = mock.Mock()
         daily_end_time_utc = time(17, 0, 0)
         allow_null_columns = False
-        table_config = TableConfig(
+        table_config = SingleTableConfig(
             schema='test', table_name="test_table", field_mapping=[],
         )
 
@@ -524,12 +524,15 @@ def test_poll_scrape_and_load_data(mocker):
         daily_end_time_utc = time(17, 0, 0)
         allow_null_columns = False
         table_config = TableConfig(
-            schema='test', table_name="test_table", field_mapping=[],
+            schema='test',
+            table_name="test_table",
+            field_mapping=[("data_id", sqlalchemy.Column("db_id", sqlalchemy.Integer))],
         )
 
     table = mock.Mock()
-    engine = mocker.patch.object(db_tables.sa, "create_engine", autospec=True)
-    conn = engine.return_value.begin.return_value.__enter__.return_value
+    mock_create_tables = mocker.patch.object(
+        db_tables, "create_temp_tables", autospec=True
+    )
     mock_temp_table = mocker.patch.object(
         db_tables, "get_temp_table", autospec=True, return_value=table
     )
@@ -539,6 +542,16 @@ def test_poll_scrape_and_load_data(mocker):
         db_tables, "check_table_data", autospec=True
     )
     mocker.patch("dataflow.operators.db_tables.sleep", autospec=True)
+    mock_postgres = mocker.patch(
+        "dataflow.operators.db_tables.PostgresHook", autospec=True
+    )
+    mock_conn = mock_postgres.return_value.get_conn.return_value.__enter__.return_value
+    mock_cursor = mock_conn.cursor.return_value.__enter__.return_value
+    mock_tempfile = mocker.patch("dataflow.operators.db_tables.tempfile", autospec=True)
+    mock_namedtempfile = (
+        mock_tempfile.NamedTemporaryFile.return_value.__enter__.return_value
+    )
+    mock_namedtempfile.name = "tmp_file"
 
     kwargs = dict(
         ts_nodash='123',
@@ -553,19 +566,34 @@ def test_poll_scrape_and_load_data(mocker):
             "test-db", TestPipeline.table_config, TestPipeline(), **kwargs
         )
 
-    assert any(
-        c == mock.call('CREATE SCHEMA IF NOT EXISTS test')
-        for c in conn.execute.call_args_list
-    )
-    assert TestPipeline.data_getter.return_value.to_sql.call_args_list == [
+    assert mock_create_tables.call_args_list == [
         mock.call(
-            name='tmp_test_table',
-            schema='test',
-            con=engine.return_value.connect.return_value.__enter__.return_value,
-            method='multi',
-            if_exists='append',
-            chunksize=10000,
+            "test-db",
+            mock.ANY,
+            ts_nodash='123',
+            dag=mock.ANY,
+            dag_run=mock.ANY,
+            ti=mock.ANY,
+            task_instance=mock.ANY,
+        )
+    ]
+    assert TestPipeline.data_getter.return_value.to_csv.call_args_list == [
+        mock.call(
+            mock_namedtempfile.name,
             index=False,
+            header=False,
+            sep='\t',
+            na_rep=r'\N',
+            columns=["data_id"],
+        )
+    ]
+    assert mock_cursor.copy_from.call_args_list == [
+        mock.call(
+            mock_namedtempfile,
+            '"test"."tmp_test_table"',
+            sep='\t',
+            null=r'\N',
+            columns=["db_id"],
         )
     ]
     assert mock_check_table_data.call_args_list == [


### PR DESCRIPTION
### Description of change
Rather than using pandas.DataFrame.to_sql to load data from the
dataframe to the DB, we instead rely on Postgres's native copy_from
functionality to provide a significant increase in data load times. In
order to do this we need to define the table ourselves, and this
actually brings us more in line with the standard pipeline where we now
declare our table columns in a (Single)TableConfig object up front, and
manipulate the resulting data into the table using source/target field
names.

#### Change 2
This large ONS dataset was using multiprocessing to load/clean/transform
two ONS dataset sheets at the same time - unfortunately in testing this
has ended up with a peak memory usage that is occasionally too high,
resulting in one of the subprocesses being killed. Python doesn't detect
this very cleanly and so the main process just hangs for a while, not
recognising that the child has died.

To reduce peak memory usage and have a cleaned failure state, we'll run
the ingests sequentially rather than in parallel. This will obviously be
slower - taking roughly twice as long - however we've made significant
speed gains in other areas that more than offset the extra ~2 minutes
we'll spend from running these in sequence. In this case, the
reliability of it not crashing (or very quickly detecting and reporting
the crash) is better than a slight speedup.

#### Before
<img width="303" alt="Screen Shot 2020-09-15 at 11 55 28" src="https://user-images.githubusercontent.com/2920760/93205205-53492100-f74f-11ea-9625-1ae5ac76ca55.png">

#### After
<img width="311" alt="Screen Shot 2020-09-16 at 09 17 50" src="https://user-images.githubusercontent.com/2920760/93311132-821dd080-f7fd-11ea-982f-b0d98338d2df.png">


The breakdown of the task is roughly: 2x 2 minutes 30 seconds to load and transform the data from 2 sources, 1 minute to write the data to disk, and 1 minute to send and load the data in the DB.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
