### PR TITLE
fix: remove multiprocessing for stability

### DIFF
--- a/dataflow/ons_scripts/uktradecountrybycommodity/main.py
+++ b/dataflow/ons_scripts/uktradecountrybycommodity/main.py
@@ -181,19 +181,12 @@ def get_current_and_next_release_date() -> Tuple[datetime, datetime]:
 
 
 def get_data() -> DataFrame:
-    with Pool(processes=2) as pool:
-        print('start getting', datetime.now())
-        exports = pool.apply_async(
-            process_data,
-            kwds=dict(flow_type='exports', dataset_url=EXPORTS_DATASET_URL),
-        )
-        imports = pool.apply_async(
-            process_data,
-            kwds=dict(flow_type='imports', dataset_url=IMPORTS_DATASET_URL),
-        )
-        df = pd.concat(
-            [exports.get(timeout=24 * 60 * 60), imports.get(timeout=24 * 60 * 60),]
-        ).drop_duplicates()
-        print('end getting', datetime.now(), len(df))
+    print('start getting', datetime.now())
+
+    exports = process_data(flow_type='exports', dataset_url=EXPORTS_DATASET_URL)
+    imports = process_data(flow_type='imports', dataset_url=IMPORTS_DATASET_URL)
+    df = pd.concat([exports, imports]).drop_duplicates()
+
+    print('end getting', datetime.now(), len(df))
 
     return df


### PR DESCRIPTION
### Description of change
This large ONS dataset was using multiprocessing to load/clean/transform
two ONS dataset sheets at the same time - unfortunately in testing this
has ended up with a peak memory usage that is occasionally too high,
resulting in one of the subprocesses being killed. Python doesn't detect
this very cleanly and so the main process just hangs for a while, not
recognising that the child has died.

To reduce peak memory usage and have a cleaned failure state, we'll run
the ingests sequentially rather than in parallel. This will obviously be
slower - taking roughly twice as long - however we've made significant
speed gains in other areas that more than offset the extra ~2 minutes
we'll spend from running these in sequence. In this case, the
reliability of it not crashing (or very quickly detecting and reporting
the crash) is better than a slight speedup.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
