### PR TITLE
adding a new pipeline for maxemail email campaign sent from activity stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-24
+
+### Added
+
+- Maxemail campaigns sent emails pipeline.
+
 ## 2020-09-23
 
 ### Added

--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -30,7 +30,7 @@ class ERPPipeline(_ActivityStreamPipeline):
     index = "objects"
     table_name = "erp_submissions"
     table_config = TableConfig(
-        table_name='erp',
+        table_name="erp",
         field_mapping=[
             ("id", sa.Column("id", sa.String, primary_key=True)),
             ("url", sa.Column("url", sa.String, primary_key=True)),
@@ -448,7 +448,7 @@ class LITECaseChangesPipeline(_ActivityStreamPipeline):
 def staff_sso_users_get_app_names(apps: JSONType) -> JSONType:
     # Happy with a runtime error if apps is is not a list, since the data would not
     # be of the expected structure
-    return [app['name'] for app in cast(List[Dict[str, str]], apps)]
+    return [app["name"] for app in cast(List[Dict[str, str]], apps)]
 
 
 class StaffSSOUsersPipeline(_ActivityStreamPipeline):
@@ -585,3 +585,22 @@ class ReturnToOfficeBookingsPipeline(_ActivityStreamPipeline):
     )
 
     query = {"bool": {"filter": [{"term": {"type": "dit:ReturnToOffice:Booking"}}]}}
+
+
+class MaxemailCampaignsSentPipeline(_ActivityStreamPipeline):
+    name = "maxemail-campaigns-sent"
+    index = "activities"
+    table_config = TableConfig(
+        schema="dit",
+        table_name="maxemail__email_campaigns_sent",
+        field_mapping=[
+            (("object", "id"), sa.Column("id", sa.String, primary_key=True)),
+            (("object", "dit:emailAddress"), sa.Column("email_address", sa.String)),
+            (("object", "attributedTo", "id"), sa.Column("campaign_id", sa.Integer)),
+            (("object", "attributedTo", "name"), sa.Column("campaign_name", sa.String)),
+            (("object", "attributedTo", "published"), sa.Column("sent", sa.DateTime)),
+            (("object", "type"), sa.Column("type", sa.ARRAY(sa.String))),
+        ],
+    )
+
+    query = {"bool": {"filter": [{"term": {"object.type": "dit:maxemail:Email"}}]}}

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -76,6 +76,7 @@ def test_pipelines_dags():
         'LITECasesPipeline',
         'Maintenance',
         'MarketAccessTradeBarriersPipeline',
+        'MaxemailCampaignsSentPipeline',
         'MinisterialInteractionsDashboardPipeline',
         'OMISDatasetPipeline',
         'ONSPostcodePipeline',


### PR DESCRIPTION
### Description of change
This PR adds a new pipeline to get data from Activity Stream's Maxemail email sent campaigns.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
