### PR TITLE
feat: new derived export wins table to aid reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 2020-09-15
+## 2020-09-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-09-15
 
+### Added
+
+- Add a new derived table for reporting on export wins
+
+## 2020-09-15
+
 ### Changed
 - Use postgres's native `copy_from` rather than `DataFrame.to_sql` to load data in postgres for the "fast polling" pipelines for significant speed gains (~15x).
 

--- a/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_daily.py
@@ -6,13 +6,12 @@ from dataflow.dags.dataset_pipelines import (
     CompaniesDatasetPipeline,
     ContactsDatasetPipeline,
     EventsDatasetPipeline,
-    ExportWinsAdvisersDatasetPipeline,
-    ExportWinsBreakdownsDatasetPipeline,
-    ExportWinsHVCDatasetPipeline,
-    ExportWinsWinsDatasetPipeline,
     InteractionsDatasetPipeline,
     InvestmentProjectsDatasetPipeline,
     TeamsDatasetPipeline,
+)
+from dataflow.dags.derived_report_table_pipelines import (
+    ExportWinsDerivedReportTablePipeline,
 )
 
 
@@ -586,354 +585,98 @@ class DataHubInteractionsPreviousYearDailyCSVPipeline(_DailyCSVPipeline):
 class ExportWinsCurrentFinancialYearDailyCSVPipeline(_DailyCSVPipeline):
     """Daily updated export wins for current financial year"""
 
-    dependencies = [
-        ExportWinsAdvisersDatasetPipeline,
-        ExportWinsBreakdownsDatasetPipeline,
-        ExportWinsHVCDatasetPipeline,
-        ExportWinsWinsDatasetPipeline,
-    ]
+    dependencies = [ExportWinsDerivedReportTablePipeline]
 
     base_file_name = 'export-wins-current-financial-year'
     query = '''
         SELECT
-            "ID",
-            "User",
-            "Organisation or company name",
-            "Data Hub (Companies House) or CDMS reference number",
-            "Contact name",
-            "Job title",
-            "Contact email",
-            "HQ location",
-            "What kind of business deal was this win?",
-            "Summarise the support provided to help achieve this win",
-            "Overseas customer",
-            "What are the goods or services?",
-            "Date business won [MM/YY]",
-            "Country",
-            "Total expected export value",
-            "Total expected non export value",
-            "Total expected odi value",
-            "Does the expected value relate to",
-            "Sector",
-            "Prosperity Fund",
-            "HVC code (if applicable)",
-            "HVO Programme (if applicable)",
-            "An HVO specialist was involved",
-            "E-exporting programme",
-            "type of support 1",
-            "type of support 2",
-            "type of support 3",
-            "associated programme 1",
-            "associated programme 2",
-            "associated programme 3",
-            "associated programme 4",
-            "associated programme 5",
-            "I confirm that this information is complete and accurate",
-            "My line manager has confirmed the decision to record this win",
-            "Lead officer name",
-            "Lead officer email address",
-            "Secondary email address",
-            "Line manager",
-            "team type",
-            "HQ team, Region or Post",
-            "Medium-sized and high potential companies",
-            "Export experience",
-            "Created",
-            "Audit",
-            "Contributing advisors/team",
-            "Customer email sent",
-            "Customer email date",
-            "Export breakdown 1",
-            "Export breakdown 2",
-            "Export breakdown 3",
-            "Export breakdown 4",
-            "Export breakdown 5",
-            "Non-export breakdown 1",
-            "Non-export breakdown 2",
-            "Non-export breakdown 3",
-            "Non-export breakdown 4",
-            "Non-export breakdown 5",
-            "Outward Direct Investment breakdown 1",
-            "Outward Direct Investment breakdown 2",
-            "Outward Direct Investment breakdown 3",
-            "Outward Direct Investment breakdown 4",
-            "Outward Direct Investment breakdown 5",
-            "Customer response received",
-            "Date response received",
-            "Your name",
-            "Please confirm these details are correct",
-            "Other comments or changes to the win details",
-            "Securing the win overall?",
-            "Gaining access to contacts?",
-            "Getting information or improved understanding of the country?",
-            "Improving your profile or credibility in the country?",
-            "Having confidence to explore or expand in the country?",
-            "Developing or nurturing critical relationships?",
-            "Overcoming a problem in the country (eg legal, regulatory)?",
-            "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
-            "Our support was a prerequisite to generate this export value",
-            "Our support helped you achieve this win more quickly",
-            "Estimated value you would have achieved without our support?",
-            "Apart from this win, when did your company last export?",
-            "Without this win, your company might have stopped exporting",
-            "Apart from this win, you already have specific plans to export in the next 12 months",
-            "It enabled you to expand into a new market",
-            "It enabled you to increase exports as a proportion of your turnover",
-            "It enabled you to maintain or expand in an existing market",
-            "Would you be willing to be featured in marketing materials?",
-            "How did you first hear about DIT (or its predecessor, UKTI)",
-            "Other marketing source"
-        FROM (
-            WITH export_wins AS (
-                SELECT
-                    *,
-                    CASE WHEN EXTRACT('month' FROM date)::int >= 4
-                    THEN (to_char(date, 'YYYY')::int)
-                    ELSE (to_char(date + interval '-1' year, 'YYYY')::int)
-                    END as win_financial_year
-                FROM export_wins_wins_dataset
-                WHERE export_wins_wins_dataset.customer_email_date IS NOT NULL
-            ), export_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND export_wins_breakdowns_dataset.type = 'Export'
-            ), non_export_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND export_wins_breakdowns_dataset.type = 'Non-export'
-            ), odi_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND export_wins_breakdowns_dataset.type = 'Outward Direct Investment'
-            ), contributing_advisers AS (
-                SELECT win_id, STRING_AGG(CONCAT('Name: ', name, ', Team: ', team_type, ' - ', hq_team, ' - ', location), ', ') as advisers
-                FROM export_wins_advisers_dataset
-                GROUP BY 1
-            )
-            SELECT
-                CASE WHEN EXTRACT('month' FROM CURRENT_DATE)::int >= 4
-                THEN (to_char(CURRENT_DATE, 'YYYY'))
-                ELSE (to_char(CURRENT_DATE + interval '-1' year, 'YYYY'))
-                END as current_financial_year,
-                CASE WHEN EXTRACT('month' FROM export_wins.confirmation_created)::int >= 4
-                THEN (to_char(export_wins.confirmation_created, 'YYYY'))
-                ELSE (to_char(export_wins.confirmation_created + interval '-1' year, 'YYYY'))
-                END as confirmation_created_financial_year,
-                export_wins.win_financial_year,
-                export_wins.id AS "ID",
-                CONCAT(export_wins.user_name, ' <', export_wins.user_email, '>') AS "User",
-                export_wins.user_email AS "User email",
-                export_wins.company_name AS "Organisation or company name",
-                export_wins.cdms_reference AS "Data Hub (Companies House) or CDMS reference number",
-                export_wins.customer_name AS "Contact name",
-                export_wins.customer_job_title AS "Job title",
-                export_wins.customer_email_address AS "Contact email",
-                export_wins.customer_location AS "HQ location",
-                export_wins.business_type AS "What kind of business deal was this win?",
-                export_wins.description AS "Summarise the support provided to help achieve this win",
-                export_wins.name_of_customer AS "Overseas customer",
-                export_wins.name_of_export AS "What are the goods or services?",
-                to_char(export_wins.date, 'DD/MM/YYYY') AS "Date business won [MM/YY]",
-                export_wins.country AS "Country",
-                COALESCE(export_wins.total_expected_export_value, 0) AS "Total expected export value",
-                COALESCE(export_wins.total_expected_non_export_value, 0) AS "Total expected non export value",
-                COALESCE(export_wins.total_expected_odi_value, 0) AS "Total expected odi value",
-                export_wins.goods_vs_services AS "Does the expected value relate to",
-                export_wins.sector AS "Sector",
-                COALESCE(export_wins.is_prosperity_fund_related, 'False') AS "Prosperity Fund",
-                export_wins_hvc_dataset.name AS "HVC code (if applicable)",
-                export_wins.hvo_programme AS "HVO Programme (if applicable)",
-                COALESCE(export_wins.has_hvo_specialist_involvement, 'False') AS "An HVO specialist was involved",
-                COALESCE(export_wins.is_e_exported, 'False') AS "E-exporting programme",
-                export_wins.type_of_support_1 AS "type of support 1",
-                export_wins.type_of_support_2 AS "type of support 2",
-                export_wins.type_of_support_3 AS "type of support 3",
-                export_wins.associated_programme_1 AS "associated programme 1",
-                export_wins.associated_programme_2 AS "associated programme 2",
-                export_wins.associated_programme_3 AS "associated programme 3",
-                export_wins.associated_programme_4 AS "associated programme 4",
-                export_wins.associated_programme_5 AS "associated programme 5",
-                export_wins.is_personally_confirmed AS "I confirm that this information is complete and accurate",
-                export_wins.is_line_manager_confirmed AS "My line manager has confirmed the decision to record this win",
-                export_wins.lead_officer_name AS "Lead officer name",
-                export_wins.lead_officer_email_address AS "Lead officer email address",
-                export_wins.other_official_email_address AS "Secondary email address",
-                export_wins.line_manager_name AS "Line manager",
-                export_wins.team_type AS "team type",
-                export_wins.hq_team AS "HQ team, Region or Post",
-                export_wins.business_potential AS "Medium-sized and high potential companies",
-                export_wins.export_experience AS "Export experience",
-                to_char(export_wins.created, 'DD/MM/YYYY') AS "Created",
-                export_wins.audit AS "Audit",
-                contributing_advisers.advisers AS "Contributing advisors/team",
-                CASE WHEN export_wins.customer_email_date IS NOT NULL
-                THEN 'Yes'
-                ELSE 'No'
-                END AS "Customer email sent",
-                to_char(export_wins.customer_email_date, 'DD/MM/YYYY') AS "Customer email date",
-                CONCAT(win_financial_year, ': £', COALESCE(ebd1.value, 0)) AS "Export breakdown 1",
-                CONCAT(win_financial_year + 1, ': £', COALESCE(ebd2.value, 0)) AS "Export breakdown 2",
-                CONCAT(win_financial_year + 2, ': £', COALESCE(ebd3.value, 0)) "Export breakdown 3",
-                CONCAT(win_financial_year + 3, ': £', COALESCE(ebd4.value, 0)) AS "Export breakdown 4",
-                CONCAT(win_financial_year + 4, ': £', COALESCE(ebd5.value, 0)) AS "Export breakdown 5",
-                CONCAT(win_financial_year, ': £', COALESCE(nebd1.value, 0)) AS "Non-export breakdown 1",
-                CONCAT(win_financial_year + 1, ': £', COALESCE(nebd2.value, 0)) AS "Non-export breakdown 2",
-                CONCAT(win_financial_year + 2, ': £', COALESCE(nebd3.value, 0)) AS "Non-export breakdown 3",
-                CONCAT(win_financial_year + 3, ': £', COALESCE(nebd4.value, 0)) AS "Non-export breakdown 4",
-                CONCAT(win_financial_year + 4, ': £', COALESCE(nebd5.value, 0)) AS "Non-export breakdown 5",
-                CONCAT(win_financial_year, ': £', COALESCE(odibd1.value, 0)) AS "Outward Direct Investment breakdown 1",
-                CONCAT(win_financial_year + 1, ': £', COALESCE(odibd2.value, 0)) AS "Outward Direct Investment breakdown 2",
-                CONCAT(win_financial_year + 2, ': £', COALESCE(odibd3.value, 0)) AS "Outward Direct Investment breakdown 3",
-                CONCAT(win_financial_year + 3, ': £', COALESCE(odibd4.value, 0)) AS "Outward Direct Investment breakdown 4",
-                CONCAT(win_financial_year + 4, ': £', COALESCE(odibd5.value, 0)) AS "Outward Direct Investment breakdown 5",
-                CASE WHEN export_wins.confirmation_created IS NOT NULL
-                THEN 'Yes'
-                ELSE 'No'
-                END AS "Customer response received",
-                to_char(export_wins.confirmation_created, 'DD/MM/YYYY') AS "Date response received",
-                export_wins.confirmation_name AS "Your name",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "Please confirm these details are correct",
-                export_wins.confirmation_comments AS "Other comments or changes to the win details",
-                export_wins.confirmation_our_support AS "Securing the win overall?",
-                export_wins.confirmation_access_to_contacts AS "Gaining access to contacts?",
-                export_wins.confirmation_access_to_information AS "Getting information or improved understanding of the country?",
-                export_wins.confirmation_improved_profile AS "Improving your profile or credibility in the country?",
-                export_wins.confirmation_gained_confidence AS "Having confidence to explore or expand in the country?",
-                export_wins.confirmation_developed_relationships AS "Developing or nurturing critical relationships?",
-                export_wins.confirmation_overcame_problem AS "Overcoming a problem in the country (eg legal, regulatory)?",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "Our support was a prerequisite to generate this export value",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "Our support helped you achieve this win more quickly",
-                export_wins.confirmation_portion_without_help AS "Estimated value you would have achieved without our support?",
-                export_wins.confirmation_last_export AS "Apart from this win, when did your company last export?",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "Without this win, your company might have stopped exporting",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "Apart from this win, you already have specific plans to export in the next 12 months",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "It enabled you to expand into a new market",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "It enabled you to increase exports as a proportion of your turnover",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "It enabled you to maintain or expand in an existing market",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing IN (NULL, FALSE)
-                    THEN 'No'
-                END AS "Would you be willing to be featured in marketing materials?",
-                export_wins.confirmation_marketing_source AS "How did you first hear about DIT (or its predecessor, UKTI)",
-                export_wins.confirmation_other_marketing_source AS "Other marketing source"
-            FROM export_wins
-            -- Export breakdowns
-            LEFT JOIN export_breakdowns ebd1 ON (
-                export_wins.id = ebd1.win_id
-                AND ebd1.year = win_financial_year
-            )
-            LEFT JOIN export_breakdowns ebd2 ON (
-                export_wins.id = ebd2.win_id
-                AND ebd2.year = win_financial_year + 1
-            )
-            LEFT JOIN export_breakdowns ebd3 ON (
-                export_wins.id = ebd3.win_id
-                AND ebd3.year = win_financial_year + 2
-            )
-            LEFT JOIN export_breakdowns ebd4 ON (
-                export_wins.id = ebd4.win_id
-                AND ebd4.year = win_financial_year + 3
-            )
-            LEFT JOIN export_breakdowns ebd5 ON (
-                export_wins.id = ebd5.win_id
-                AND ebd5.year = win_financial_year + 4
-            )
-            -- Non export breakdowns
-            LEFT JOIN non_export_breakdowns nebd1 ON (
-                export_wins.id = nebd1.win_id
-                AND nebd1.year = win_financial_year
-            )
-            LEFT JOIN non_export_breakdowns nebd2 ON (
-                export_wins.id = nebd2.win_id
-                AND nebd2.year = win_financial_year + 1
-            )
-            LEFT JOIN non_export_breakdowns nebd3 ON (
-                export_wins.id = nebd3.win_id
-                AND nebd3.year = win_financial_year + 2
-            )
-            LEFT JOIN non_export_breakdowns nebd4 ON (
-                export_wins.id = nebd4.win_id
-                AND nebd4.year = win_financial_year + 3
-            )
-            LEFT JOIN non_export_breakdowns nebd5 ON (
-                export_wins.id = nebd5.win_id
-                AND nebd5.year = win_financial_year + 4
-            )
-            -- Outward Direct Investment breakdowns
-            LEFT JOIN odi_breakdowns odibd1 ON (
-                export_wins.id = odibd1.win_id
-                AND odibd1.year = win_financial_year
-            )
-            LEFT JOIN odi_breakdowns odibd2 ON (
-                export_wins.id = odibd2.win_id
-                AND odibd2.year = win_financial_year + 1
-            )
-            LEFT JOIN odi_breakdowns odibd3 ON (
-                export_wins.id = odibd3.win_id
-                AND odibd3.year = win_financial_year + 2
-            )
-            LEFT JOIN odi_breakdowns odibd4 ON (
-                export_wins.id = odibd4.win_id
-                AND odibd4.year = win_financial_year + 3
-            )
-            LEFT JOIN odi_breakdowns odibd5 ON (
-                export_wins.id = odibd5.win_id
-                AND odibd5.year = win_financial_year + 4
-            )
-            LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
-            LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
-            ORDER BY export_wins.confirmation_created NULLS FIRST
-        ) a
-        WHERE (confirmation_created_financial_year IS NULL OR confirmation_created_financial_year = current_financial_year)
-'''
+            id AS "ID",
+            user_name AS "User",
+            company_name AS "Organisation or company name",
+            cdms_reference AS "Data Hub (Companies House) or CDMS reference number",
+            customer_name AS "Contact name",
+            customer_job_title AS "Job title",
+            customer_email_address AS "Contact email",
+            customer_location AS "HQ location",
+            business_type AS "What kind of business deal was this win?",
+            description AS "Summarise the support provided to help achieve this win",
+            name_of_customer AS "Overseas customer",
+            name_of_export AS "What are the goods or services?",
+            date_business_won AS "Date business won [MM/YY]",
+            country AS "Country",
+            total_expected_export_value AS "Total expected export value",
+            total_expected_non_export_value AS "Total expected non export value",
+            total_expected_odi_value AS "Total expected odi value",
+            goods_vs_services AS "Does the expected value relate to",
+            sector AS "Sector",
+            prosperity_fund_related AS "Prosperity Fund",
+            hvc_code AS "HVC code (if applicable)",
+            hvo_programme AS "HVO Programme (if applicable)",
+            has_hvo_specialist_involvement AS "An HVO specialist was involved",
+            is_e_exported AS "E-exporting programme",
+            type_of_support_1 AS "type of support 1",
+            type_of_support_2 AS "type of support 2",
+            type_of_support_3 AS "type of support 3",
+            associated_programme_1 AS "associated programme 1",
+            associated_programme_2 AS "associated programme 2",
+            associated_programme_3 AS "associated programme 3",
+            associated_programme_4 AS "associated programme 4",
+            associated_programme_5 AS "associated programme 5",
+            is_personally_confirmed AS "I confirm that this information is complete and accurate",
+            is_line_manager_confirmed AS "My line manager has confirmed the decision to record this win",
+            lead_officer_name AS "Lead officer name",
+            lead_officer_email_address AS "Lead officer email address",
+            other_official_email_address AS "Secondary email address",
+            line_manager_name AS "Line manager",
+            team_type AS "team type",
+            hq_team AS "HQ team, Region or Post",
+            business_potential AS "Medium-sized and high potential companies",
+            export_experience AS "Export experience",
+            created AS "Created",
+            audit AS "Audit",
+            advisers AS "Contributing advisors/team",
+            customer_email_sent AS "Customer email sent",
+            customer_email_date AS "Customer email date",
+            export_breakdown_1 AS "Export breakdown 1",
+            export_breakdown_2 AS "Export breakdown 2",
+            export_breakdown_3 AS "Export breakdown 3",
+            export_breakdown_4 AS "Export breakdown 4",
+            export_breakdown_5 AS "Export breakdown 5",
+            non_export_breakdown_1 AS "Non-export breakdown 1",
+            non_export_breakdown_2 AS "Non-export breakdown 2",
+            non_export_breakdown_3 AS "Non-export breakdown 3",
+            non_export_breakdown_4 AS "Non-export breakdown 4",
+            non_export_breakdown_5 AS "Non-export breakdown 5",
+            odi_breakdown_1 AS "Outward Direct Investment breakdown 1",
+            odi_breakdown_2 AS "Outward Direct Investment breakdown 2",
+            odi_breakdown_3 AS "Outward Direct Investment breakdown 3",
+            odi_breakdown_4 AS "Outward Direct Investment breakdown 4",
+            odi_breakdown_5 AS "Outward Direct Investment breakdown 5",
+            customer_response_received AS "Customer response received",
+            date_response_received AS "Date response received",
+            confirmation_name AS "Your name",
+            agree_with_win AS "Please confirm these details are correct",
+            confirmation_comments AS "Other comments or changes to the win details",
+            confirmation_our_support AS "Securing the win overall?",
+            confirmation_access_to_contacts AS "Gaining access to contacts?",
+            confirmation_access_to_information AS "Getting information or improved understanding of the country?",
+            confirmation_improved_profile AS "Improving your profile or credibility in the country?",
+            confirmation_gained_confidence AS "Having confidence to explore or expand in the country?",
+            confirmation_developed_relationships AS "Developing or nurturing critical relationships?",
+            confirmation_overcame_problem AS "Overcoming a problem in the country (eg legal, regulatory)?",
+            confirmation_involved_state_enterprise AS "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
+            confirmation_interventions_were_prerequisite AS "Our support was a prerequisite to generate this export value",
+            confirmation_support_improved_speed AS "Our support helped you achieve this win more quickly",
+            confirmation_portion_without_help AS "Estimated value you would have achieved without our support?",
+            confirmation_last_export AS "Apart from this win, when did your company last export?",
+            confirmation_company_was_at_risk_of_not_exporting AS "Without this win, your company might have stopped exporting",
+            confirmation_has_explicit_export_plans AS "Apart from this win, you already have specific plans to export in the next 12 months",
+            confirmation_has_enabled_expansion_into_new_market AS "It enabled you to expand into a new market",
+            confirmation_has_increased_exports_as_percent_of_turnover AS "It enabled you to increase exports as a proportion of your turnover",
+            confirmation_has_enabled_expansion_into_existing_market AS "It enabled you to maintain or expand in an existing market",
+            confirmation_case_study_willing AS "Would you be willing to be featured in marketing materials?",
+            confirmation_marketing_source AS "How did you first hear about DIT (or its predecessor, UKTI)",
+            confirmation_other_marketing_source AS "Other marketing source"
+        FROM dit.export_wins__wins__derived
+        WHERE confirmation_created_financial_year IS NULL OR confirmation_created_financial_year = current_financial_year;
+        '''

--- a/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
+++ b/dataflow/dags/csv_pipelines/csv_pipelines_yearly.py
@@ -19,336 +19,96 @@ class ExportWinsYearlyCSVPipeline(_YearlyCSVPipeline):
 
     query = '''
         SELECT
-            "ID",
-            "User",
-            "Organisation or company name",
-            "Data Hub (Companies House) or CDMS reference number",
-            "Contact name",
-            "Job title",
-            "Contact email",
-            "HQ location",
-            "What kind of business deal was this win?",
-            "Summarise the support provided to help achieve this win",
-            "Overseas customer",
-            "What are the goods or services?",
-            "Date business won [MM/YY]",
-            "Country",
-            "Total expected export value",
-            "Total expected non export value",
-            "Total expected odi value",
-            "Does the expected value relate to",
-            "Sector",
-            "Prosperity Fund",
-            "HVC code (if applicable)",
-            "HVO Programme (if applicable)",
-            "An HVO specialist was involved",
-            "E-exporting programme",
-            "type of support 1",
-            "type of support 2"
-            "type of support 3",
-            "associated programme 1",
-            "associated programme 2",
-            "associated programme 3",
-            "associated programme 4",
-            "associated programme 5",
-            "I confirm that this information is complete and accurate",
-            "My line manager has confirmed the decision to record this win",
-            "Lead officer name",
-            "Lead officer email address",
-            "Secondary email address",
-            "Line manager",
-            "team type",
-            "HQ team, Region or Post",
-            "Medium-sized and high potential companies",
-            "Export experience",
-            "Created",
-            "Audit",
-            "Contributing advisors/team",
-            "Customer email sent",
-            "Customer email date",
-            "Export breakdown 1",
-            "Export breakdown 2",
-            "Export breakdown 3",
-            "Export breakdown 4",
-            "Export breakdown 5",
-            "Non-export breakdown 1",
-            "Non-export breakdown 2",
-            "Non-export breakdown 3",
-            "Non-export breakdown 4",
-            "Non-export breakdown 5",
-            "Outward Direct Investment breakdown 1",
-            "Outward Direct Investment breakdown 2",
-            "Outward Direct Investment breakdown 3",
-            "Outward Direct Investment breakdown 4",
-            "Outward Direct Investment breakdown 5",
-            "Customer response received",
-            "Date response received",
-            "Your name",
-            "Please confirm these details are correct",
-            "Other comments or changes to the win details",
-            "Securing the win overall?",
-            "Gaining access to contacts?",
-            "Getting information or improved understanding of the country?",
-            "Improving your profile or credibility in the country?",
-            "Having confidence to explore or expand in the country?",
-            "Developing or nurturing critical relationships?",
-            "Overcoming a problem in the country (eg legal, regulatory)?",
-            "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
-            "Our support was a prerequisite to generate this export value",
-            "Our support helped you achieve this win more quickly",
-            "Estimated value you would have achieved without our support?",
-            "Apart from this win, when did your company last export?",
-            "Without this win, your company might have stopped exporting",
-            "Apart from this win, you already have specific plans to export in the next 12 months",
-            "It enabled you to expand into a new market",
-            "It enabled you to increase exports as a proportion of your turnover",
-            "It enabled you to maintain or expand in an existing market",
-            "Would you be willing to be featured in marketing materials?",
-            "How did you first hear about DIT (or its predecessor, UKTI)",
-            "Other marketing source"
-        FROM (
-            WITH export_wins AS (
-                SELECT *
-                FROM export_wins_wins_dataset
-                WHERE export_wins_wins_dataset.customer_email_date IS NOT NULL
-                AND date_trunc('year', export_wins_wins_dataset.confirmation_created) =  date_trunc('year', :run_date)
-            ), export_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND year >= EXTRACT(year FROM CURRENT_DATE)::int
-                AND export_wins_breakdowns_dataset.type = 'Export'
-            ), non_export_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND year >= EXTRACT(year FROM CURRENT_DATE)::int
-                AND export_wins_breakdowns_dataset.type = 'Non-export'
-            ), odi_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND year >= EXTRACT(year FROM CURRENT_DATE)::int
-                AND export_wins_breakdowns_dataset.type = 'Outward Direct Investment'
-            ), contributing_advisers AS (
-                SELECT win_id, STRING_AGG(CONCAT('Name: ', name, ', Team: ', team_type, ' - ', hq_team, ' - ', location), ', ') as advisers
-                FROM export_wins_advisers_dataset
-                GROUP  BY 1
-            )
-            SELECT
-                export_wins.id AS "ID",
-                CONCAT(export_wins.user_name, ' <', export_wins.user_email, '>') AS "User",
-                export_wins.user_email AS "User email",
-                export_wins.company_name AS "Organisation or company name",
-                export_wins.cdms_reference AS "Data Hub (Companies House) or CDMS reference number",
-                export_wins.customer_name AS "Contact name",
-                export_wins.customer_job_title AS "Job title",
-                export_wins.customer_email_address AS "Contact email",
-                export_wins.customer_location AS "HQ location",
-                export_wins.business_type AS "What kind of business deal was this win?",
-                export_wins.description AS "Summarise the support provided to help achieve this win",
-                export_wins.name_of_customer AS "Overseas customer",
-                export_wins.name_of_export AS "What are the goods or services?",
-                to_char(export_wins.date, 'DD/MM/YYYY') AS "Date business won [MM/YY]",
-                export_wins.country AS "Country",
-                COALESCE(export_wins.total_expected_export_value, 0) AS "Total expected export value",
-                COALESCE(export_wins.total_expected_non_export_value, 0) AS "Total expected non export value",
-                COALESCE(export_wins.total_expected_odi_value, 0) AS "Total expected odi value",
-                export_wins.goods_vs_services AS "Does the expected value relate to",
-                export_wins.sector AS "Sector",
-                COALESCE(export_wins.is_prosperity_fund_related, 'False') AS "Prosperity Fund",
-                export_wins_hvc_dataset.name AS "HVC code (if applicable)",
-                export_wins.hvo_programme AS "HVO Programme (if applicable)",
-                COALESCE(export_wins.has_hvo_specialist_involvement, 'False') AS "An HVO specialist was involved",
-                COALESCE(export_wins.is_e_exported, 'False') AS "E-exporting programme",
-                export_wins.type_of_support_1 AS "type of support 1",
-                export_wins.type_of_support_2 AS "type of support 2",
-                export_wins.type_of_support_3 AS "type of support 3",
-                export_wins.associated_programme_1 AS "associated programme 1",
-                export_wins.associated_programme_2 AS "associated programme 2",
-                export_wins.associated_programme_3 AS "associated programme 3",
-                export_wins.associated_programme_4 AS "associated programme 4",
-                export_wins.associated_programme_5 AS "associated programme 5",
-                export_wins.is_personally_confirmed AS "I confirm that this information is complete and accurate",
-                export_wins.is_line_manager_confirmed AS "My line manager has confirmed the decision to record this win",
-                export_wins.lead_officer_name AS "Lead officer name",
-                export_wins.lead_officer_email_address AS "Lead officer email address",
-                export_wins.other_official_email_address AS "Secondary email address",
-                export_wins.line_manager_name AS "Line manager",
-                export_wins.team_type AS "team type",
-                export_wins.hq_team AS "HQ team, Region or Post",
-                export_wins.business_potential AS "Medium-sized and high potential companies",
-                export_wins.export_experience AS "Export experience",
-                to_char(export_wins.created, 'DD/MM/YYYY') AS "Created",
-                export_wins.audit AS "Audit",
-                contributing_advisers.advisers AS "Contributing advisors/team",
-                CASE WHEN export_wins.customer_email_date IS NOT NULL
-                THEN 'Yes'
-                ELSE 'No'
-                END AS "Customer email sent",
-                to_char(export_wins.customer_email_date, 'DD/MM/YYYY') AS "Customer email date",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int, ': £', COALESCE(ebd1.value, 0)) AS "Export breakdown 1",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 1, ': £', COALESCE(ebd2.value, 0)) AS "Export breakdown 2",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 2, ': £', COALESCE(ebd3.value, 0)) "Export breakdown 3",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 3, ': £', COALESCE(ebd4.value, 0)) AS "Export breakdown 4",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 4, ': £', COALESCE(ebd5.value, 0)) AS "Export breakdown 5",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int, ': £', COALESCE(nebd1.value, 0)) AS "Non-export breakdown 1",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 1, ': £', COALESCE(nebd2.value, 0)) AS "Non-export breakdown 2",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 2, ': £', COALESCE(nebd3.value, 0)) AS "Non-export breakdown 3",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 3, ': £', COALESCE(nebd4.value, 0)) AS "Non-export breakdown 4",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 4, ': £', COALESCE(nebd5.value, 0)) AS "Non-export breakdown 5",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int, ': £', COALESCE(odibd1.value, 0)) AS "Outward Direct Investment breakdown 1",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 1, ': £', COALESCE(odibd2.value, 0)) AS "Outward Direct Investment breakdown 2",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 2, ': £', COALESCE(odibd3.value, 0)) AS "Outward Direct Investment breakdown 3",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 3, ': £', COALESCE(odibd4.value, 0)) AS "Outward Direct Investment breakdown 4",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 4, ': £', COALESCE(odibd5.value, 0)) AS "Outward Direct Investment breakdown 5",
-                CASE WHEN export_wins.confirmation_created IS NOT NULL
-                THEN 'Yes'
-                ELSE 'No'
-                END AS "Customer response received",
-                to_char(export_wins.confirmation_created, 'DD/MM/YYYY') AS "Date response received",
-                export_wins.confirmation_name AS "Your name",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win IS NULL
-                    THEN 'No'
-                END AS "Please confirm these details are correct",
-                export_wins.confirmation_comments AS "Other comments or changes to the win details",
-                export_wins.confirmation_our_support AS "Securing the win overall?",
-                export_wins.confirmation_access_to_contacts AS "Gaining access to contacts?",
-                export_wins.confirmation_access_to_information AS "Getting information or improved understanding of the country?",
-                export_wins.confirmation_improved_profile AS "Improving your profile or credibility in the country?",
-                export_wins.confirmation_gained_confidence AS "Having confidence to explore or expand in the country?",
-                export_wins.confirmation_developed_relationships AS "Developing or nurturing critical relationships?",
-                export_wins.confirmation_overcame_problem AS "Overcoming a problem in the country (eg legal, regulatory)?",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Our support was a prerequisite to generate this export value",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Our support helped you achieve this win more quickly",
-                export_wins.confirmation_portion_without_help AS "Estimated value you would have achieved without our support?",
-                export_wins.confirmation_last_export AS "Apart from this win, when did your company last export?",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Without this win, your company might have stopped exporting",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Apart from this win, you already have specific plans to export in the next 12 months",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "It enabled you to expand into a new market",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "It enabled you to increase exports as a proportion of your turnover",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "It enabled you to maintain or expand in an existing market",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Would you be willing to be featured in marketing materials?",
-                export_wins.confirmation_marketing_source AS "How did you first hear about DIT (or its predecessor, UKTI)",
-                export_wins.confirmation_other_marketing_source AS "Other marketing source"
-            FROM export_wins
-            -- Export breakdowns
-            LEFT JOIN export_breakdowns ebd1 ON (
-                export_wins.id = ebd1.win_id
-                AND ebd1.year = extract(year FROM CURRENT_DATE)::int
-            )
-            LEFT JOIN export_breakdowns ebd2 ON (
-                export_wins.id = ebd2.win_id
-                AND ebd2.year = extract(year FROM CURRENT_DATE)::int + 1
-            )
-            LEFT JOIN export_breakdowns ebd3 ON (
-                export_wins.id = ebd3.win_id
-                AND ebd3.year = extract(year FROM CURRENT_DATE)::int + 2
-            )
-            LEFT JOIN export_breakdowns ebd4 ON (
-                export_wins.id = ebd4.win_id
-                AND ebd4.year = extract(year FROM CURRENT_DATE)::int + 3
-            )
-            LEFT JOIN export_breakdowns ebd5 ON (
-                export_wins.id = ebd5.win_id
-                AND ebd5.year = extract(year FROM CURRENT_DATE)::int + 4
-            )
-            -- Non export breakdowns
-            LEFT JOIN non_export_breakdowns nebd1 ON (
-                export_wins.id = nebd1.win_id
-                AND nebd1.year = extract(year FROM CURRENT_DATE)::int
-            )
-            LEFT JOIN non_export_breakdowns nebd2 ON (
-                export_wins.id = nebd2.win_id
-                AND nebd2.year = extract(year FROM CURRENT_DATE)::int + 1
-            )
-            LEFT JOIN non_export_breakdowns nebd3 ON (
-                export_wins.id = nebd3.win_id
-                AND nebd3.year = extract(year FROM CURRENT_DATE)::int + 2
-            )
-            LEFT JOIN non_export_breakdowns nebd4 ON (
-                export_wins.id = nebd4.win_id
-                AND nebd4.year = extract(year FROM CURRENT_DATE)::int + 3
-            )
-            LEFT JOIN non_export_breakdowns nebd5 ON (
-                export_wins.id = nebd5.win_id
-                AND nebd5.year = extract(year FROM CURRENT_DATE)::int + 4
-            )
-            -- Outward Direct Investment breakdowns
-            LEFT JOIN odi_breakdowns odibd1 ON (
-                export_wins.id = odibd1.win_id
-                AND odibd1.year = extract(year FROM CURRENT_DATE)::int
-            )
-            LEFT JOIN odi_breakdowns odibd2 ON (
-                export_wins.id = odibd2.win_id
-                AND odibd2.year = extract(year FROM CURRENT_DATE)::int + 1
-            )
-            LEFT JOIN odi_breakdowns odibd3 ON (
-                export_wins.id = odibd3.win_id
-                AND odibd3.year = extract(year FROM CURRENT_DATE)::int + 2
-            )
-            LEFT JOIN odi_breakdowns odibd4 ON (
-                export_wins.id = odibd4.win_id
-                AND odibd4.year = extract(year FROM CURRENT_DATE)::int + 3
-            )
-            LEFT JOIN odi_breakdowns odibd5 ON (
-                export_wins.id = odibd5.win_id
-                AND odibd5.year = extract(year FROM CURRENT_DATE)::int + 4
-            )
-            LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
-            LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
-            ORDER BY export_wins.confirmation_created NULLS FIRST
-        ) a
-        WHERE "Please confirm these details are correct" = 'Yes'
+            id AS "ID",
+            user_name AS "User",
+            company_name AS "Organisation or company name",
+            cdms_reference AS "Data Hub (Companies House) or CDMS reference number",
+            customer_name AS "Contact name",
+            customer_job_title AS "Job title",
+            customer_email_address AS "Contact email",
+            customer_location AS "HQ location",
+            business_type AS "What kind of business deal was this win?",
+            description AS "Summarise the support provided to help achieve this win",
+            name_of_customer AS "Overseas customer",
+            name_of_export AS "What are the goods or services?",
+            date_business_won AS "Date business won [MM/YY]",
+            country AS "Country",
+            total_expected_export_value AS "Total expected export value",
+            total_expected_non_export_value AS "Total expected non export value",
+            total_expected_odi_value AS "Total expected odi value",
+            goods_vs_services AS "Does the expected value relate to",
+            sector AS "Sector",
+            prosperity_fund_related AS "Prosperity Fund",
+            hvc_code AS "HVC code (if applicable)",
+            hvo_programme AS "HVO Programme (if applicable)",
+            has_hvo_specialist_involvement AS "An HVO specialist was involved",
+            is_e_exported AS "E-exporting programme",
+            type_of_support_1 AS "type of support 1",
+            type_of_support_2 AS "type of support 2",
+            type_of_support_3 AS "type of support 3",
+            associated_programme_1 AS "associated programme 1",
+            associated_programme_2 AS "associated programme 2",
+            associated_programme_3 AS "associated programme 3",
+            associated_programme_4 AS "associated programme 4",
+            associated_programme_5 AS "associated programme 5",
+            is_personally_confirmed AS "I confirm that this information is complete and accurate",
+            is_line_manager_confirmed AS "My line manager has confirmed the decision to record this win",
+            lead_officer_name AS "Lead officer name",
+            lead_officer_email_address AS "Lead officer email address",
+            other_official_email_address AS "Secondary email address",
+            line_manager_name AS "Line manager",
+            team_type AS "team type",
+            hq_team AS "HQ team, Region or Post",
+            business_potential AS "Medium-sized and high potential companies",
+            export_experience AS "Export experience",
+            created AS "Created",
+            audit AS "Audit",
+            advisers AS "Contributing advisors/team",
+            customer_email_sent AS "Customer email sent",
+            customer_email_date AS "Customer email date",
+            export_breakdown_1 AS "Export breakdown 1",
+            export_breakdown_2 AS "Export breakdown 2",
+            export_breakdown_3 AS "Export breakdown 3",
+            export_breakdown_4 AS "Export breakdown 4",
+            export_breakdown_5 AS "Export breakdown 5",
+            non_export_breakdown_1 AS "Non-export breakdown 1",
+            non_export_breakdown_2 AS "Non-export breakdown 2",
+            non_export_breakdown_3 AS "Non-export breakdown 3",
+            non_export_breakdown_4 AS "Non-export breakdown 4",
+            non_export_breakdown_5 AS "Non-export breakdown 5",
+            odi_breakdown_1 AS "Outward Direct Investment breakdown 1",
+            odi_breakdown_2 AS "Outward Direct Investment breakdown 2",
+            odi_breakdown_3 AS "Outward Direct Investment breakdown 3",
+            odi_breakdown_4 AS "Outward Direct Investment breakdown 4",
+            odi_breakdown_5 AS "Outward Direct Investment breakdown 5",
+            customer_response_received AS "Customer response received",
+            date_response_received AS "Date response received",
+            confirmation_name AS "Your name",
+            agree_with_win AS "Please confirm these details are correct",
+            confirmation_comments AS "Other comments or changes to the win details",
+            confirmation_our_support AS "Securing the win overall?",
+            confirmation_access_to_contacts AS "Gaining access to contacts?",
+            confirmation_access_to_information AS "Getting information or improved understanding of the country?",
+            confirmation_improved_profile AS "Improving your profile or credibility in the country?",
+            confirmation_gained_confidence AS "Having confidence to explore or expand in the country?",
+            confirmation_developed_relationships AS "Developing or nurturing critical relationships?",
+            confirmation_overcame_problem AS "Overcoming a problem in the country (eg legal, regulatory)?",
+            confirmation_involved_state_enterprise AS "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
+            confirmation_interventions_were_prerequisite AS "Our support was a prerequisite to generate this export value",
+            confirmation_support_improved_speed AS "Our support helped you achieve this win more quickly",
+            confirmation_portion_without_help AS "Estimated value you would have achieved without our support?",
+            confirmation_last_export AS "Apart from this win, when did your company last export?",
+            confirmation_company_was_at_risk_of_not_exporting AS "Without this win, your company might have stopped exporting",
+            confirmation_has_explicit_export_plans AS "Apart from this win, you already have specific plans to export in the next 12 months",
+            confirmation_has_enabled_expansion_into_new_market AS "It enabled you to expand into a new market",
+            confirmation_has_increased_exports_as_percent_of_turnover AS "It enabled you to increase exports as a proportion of your turnover",
+            confirmation_has_enabled_expansion_into_existing_market AS "It enabled you to maintain or expand in an existing market",
+            confirmation_case_study_willing AS "Would you be willing to be featured in marketing materials?",
+            confirmation_marketing_source AS "How did you first hear about DIT (or its predecessor, UKTI)",
+            confirmation_other_marketing_source AS "Other marketing source"
+        FROM dit.export_wins__wins__derived
+        WHERE date_trunc('year', confirmation_created_date) = date_trunc('year', :run_date)
+        AND agree_with_win = 'Yes';
     '''
 
 
@@ -361,335 +121,95 @@ class ExportWinsByFinancialYearCSVPipeline(_YearlyCSVPipeline):
 
     query = '''
         SELECT
-            "ID",
-            "User",
-            "Organisation or company name",
-            "Data Hub (Companies House) or CDMS reference number",
-            "Contact name",
-            "Job title",
-            "Contact email",
-            "HQ location",
-            "What kind of business deal was this win?",
-            "Summarise the support provided to help achieve this win",
-            "Overseas customer",
-            "What are the goods or services?",
-            "Date business won [MM/YY]",
-            "Country",
-            "Total expected export value",
-            "Total expected non export value",
-            "Total expected odi value",
-            "Does the expected value relate to",
-            "Sector",
-            "Prosperity Fund",
-            "HVC code (if applicable)",
-            "HVO Programme (if applicable)",
-            "An HVO specialist was involved",
-            "E-exporting programme",
-            "type of support 1",
-            "type of support 2"
-            "type of support 3",
-            "associated programme 1",
-            "associated programme 2",
-            "associated programme 3",
-            "associated programme 4",
-            "associated programme 5",
-            "I confirm that this information is complete and accurate",
-            "My line manager has confirmed the decision to record this win",
-            "Lead officer name",
-            "Lead officer email address",
-            "Secondary email address",
-            "Line manager",
-            "team type",
-            "HQ team, Region or Post",
-            "Medium-sized and high potential companies",
-            "Export experience",
-            "Created",
-            "Audit",
-            "Contributing advisors/team",
-            "Customer email sent",
-            "Customer email date",
-            "Export breakdown 1",
-            "Export breakdown 2",
-            "Export breakdown 3",
-            "Export breakdown 4",
-            "Export breakdown 5",
-            "Non-export breakdown 1",
-            "Non-export breakdown 2",
-            "Non-export breakdown 3",
-            "Non-export breakdown 4",
-            "Non-export breakdown 5",
-            "Outward Direct Investment breakdown 1",
-            "Outward Direct Investment breakdown 2",
-            "Outward Direct Investment breakdown 3",
-            "Outward Direct Investment breakdown 4",
-            "Outward Direct Investment breakdown 5",
-            "Customer response received",
-            "Date response received",
-            "Your name",
-            "Please confirm these details are correct",
-            "Other comments or changes to the win details",
-            "Securing the win overall?",
-            "Gaining access to contacts?",
-            "Getting information or improved understanding of the country?",
-            "Improving your profile or credibility in the country?",
-            "Having confidence to explore or expand in the country?",
-            "Developing or nurturing critical relationships?",
-            "Overcoming a problem in the country (eg legal, regulatory)?",
-            "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
-            "Our support was a prerequisite to generate this export value",
-            "Our support helped you achieve this win more quickly",
-            "Estimated value you would have achieved without our support?",
-            "Apart from this win, when did your company last export?",
-            "Without this win, your company might have stopped exporting",
-            "Apart from this win, you already have specific plans to export in the next 12 months",
-            "It enabled you to expand into a new market",
-            "It enabled you to increase exports as a proportion of your turnover",
-            "It enabled you to maintain or expand in an existing market",
-            "Would you be willing to be featured in marketing materials?",
-            "How did you first hear about DIT (or its predecessor, UKTI)",
-            "Other marketing source"
-        FROM (
-            WITH export_wins AS (
-                SELECT *
-                FROM export_wins_wins_dataset
-                WHERE export_wins_wins_dataset.customer_email_date IS NOT NULL
-                AND export_wins_wins_dataset.confirmation_created >= date_trunc('day', :run_date)
-                AND export_wins_wins_dataset.confirmation_created < date_trunc('day', :run_date) + interval '1 year'
-            ), export_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND year >= EXTRACT(year FROM CURRENT_DATE)::int
-                AND export_wins_breakdowns_dataset.type = 'Export'
-            ), non_export_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND year >= EXTRACT(year FROM CURRENT_DATE)::int
-                AND export_wins_breakdowns_dataset.type = 'Non-export'
-            ), odi_breakdowns AS (
-                SELECT win_id, year, value
-                FROM export_wins_breakdowns_dataset
-                WHERE win_id IN (select id from export_wins)
-                AND year >= EXTRACT(year FROM CURRENT_DATE)::int
-                AND export_wins_breakdowns_dataset.type = 'Outward Direct Investment'
-            ), contributing_advisers AS (
-                SELECT win_id, STRING_AGG(CONCAT('Name: ', name, ', Team: ', team_type, ' - ', hq_team, ' - ', location), ', ') as advisers
-                FROM export_wins_advisers_dataset
-                GROUP  BY 1
-            )
-            SELECT
-                export_wins.id AS "ID",
-                CONCAT(export_wins.user_name, ' <', export_wins.user_email, '>') AS "User",
-                export_wins.user_email AS "User email",
-                export_wins.company_name AS "Organisation or company name",
-                export_wins.cdms_reference AS "Data Hub (Companies House) or CDMS reference number",
-                export_wins.customer_name AS "Contact name",
-                export_wins.customer_job_title AS "Job title",
-                export_wins.customer_email_address AS "Contact email",
-                export_wins.customer_location AS "HQ location",
-                export_wins.business_type AS "What kind of business deal was this win?",
-                export_wins.description AS "Summarise the support provided to help achieve this win",
-                export_wins.name_of_customer AS "Overseas customer",
-                export_wins.name_of_export AS "What are the goods or services?",
-                to_char(export_wins.date, 'DD/MM/YYYY') AS "Date business won [MM/YY]",
-                export_wins.country AS "Country",
-                COALESCE(export_wins.total_expected_export_value, 0) AS "Total expected export value",
-                COALESCE(export_wins.total_expected_non_export_value, 0) AS "Total expected non export value",
-                COALESCE(export_wins.total_expected_odi_value, 0) AS "Total expected odi value",
-                export_wins.goods_vs_services AS "Does the expected value relate to",
-                export_wins.sector AS "Sector",
-                COALESCE(export_wins.is_prosperity_fund_related, 'False') AS "Prosperity Fund",
-                export_wins_hvc_dataset.name AS "HVC code (if applicable)",
-                export_wins.hvo_programme AS "HVO Programme (if applicable)",
-                COALESCE(export_wins.has_hvo_specialist_involvement, 'False') AS "An HVO specialist was involved",
-                COALESCE(export_wins.is_e_exported, 'False') AS "E-exporting programme",
-                export_wins.type_of_support_1 AS "type of support 1",
-                export_wins.type_of_support_2 AS "type of support 2",
-                export_wins.type_of_support_3 AS "type of support 3",
-                export_wins.associated_programme_1 AS "associated programme 1",
-                export_wins.associated_programme_2 AS "associated programme 2",
-                export_wins.associated_programme_3 AS "associated programme 3",
-                export_wins.associated_programme_4 AS "associated programme 4",
-                export_wins.associated_programme_5 AS "associated programme 5",
-                export_wins.is_personally_confirmed AS "I confirm that this information is complete and accurate",
-                export_wins.is_line_manager_confirmed AS "My line manager has confirmed the decision to record this win",
-                export_wins.lead_officer_name AS "Lead officer name",
-                export_wins.lead_officer_email_address AS "Lead officer email address",
-                export_wins.other_official_email_address AS "Secondary email address",
-                export_wins.line_manager_name AS "Line manager",
-                export_wins.team_type AS "team type",
-                export_wins.hq_team AS "HQ team, Region or Post",
-                export_wins.business_potential AS "Medium-sized and high potential companies",
-                export_wins.export_experience AS "Export experience",
-                to_char(export_wins.created, 'DD/MM/YYYY') AS "Created",
-                export_wins.audit AS "Audit",
-                contributing_advisers.advisers AS "Contributing advisors/team",
-                CASE WHEN export_wins.customer_email_date IS NOT NULL
-                THEN 'Yes'
-                ELSE 'No'
-                END AS "Customer email sent",
-                to_char(export_wins.customer_email_date, 'DD/MM/YYYY') AS "Customer email date",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int, ': £', COALESCE(ebd1.value, 0)) AS "Export breakdown 1",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 1, ': £', COALESCE(ebd2.value, 0)) AS "Export breakdown 2",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 2, ': £', COALESCE(ebd3.value, 0)) "Export breakdown 3",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 3, ': £', COALESCE(ebd4.value, 0)) AS "Export breakdown 4",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 4, ': £', COALESCE(ebd5.value, 0)) AS "Export breakdown 5",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int, ': £', COALESCE(nebd1.value, 0)) AS "Non-export breakdown 1",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 1, ': £', COALESCE(nebd2.value, 0)) AS "Non-export breakdown 2",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 2, ': £', COALESCE(nebd3.value, 0)) AS "Non-export breakdown 3",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 3, ': £', COALESCE(nebd4.value, 0)) AS "Non-export breakdown 4",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 4, ': £', COALESCE(nebd5.value, 0)) AS "Non-export breakdown 5",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int, ': £', COALESCE(odibd1.value, 0)) AS "Outward Direct Investment breakdown 1",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 1, ': £', COALESCE(odibd2.value, 0)) AS "Outward Direct Investment breakdown 2",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 2, ': £', COALESCE(odibd3.value, 0)) AS "Outward Direct Investment breakdown 3",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 3, ': £', COALESCE(odibd4.value, 0)) AS "Outward Direct Investment breakdown 4",
-                CONCAT(EXTRACT(year FROM CURRENT_DATE)::int + 4, ': £', COALESCE(odibd5.value, 0)) AS "Outward Direct Investment breakdown 5",
-                CASE WHEN export_wins.confirmation_created IS NOT NULL
-                THEN 'Yes'
-                ELSE 'No'
-                END AS "Customer response received",
-                to_char(export_wins.confirmation_created, 'DD/MM/YYYY') AS "Date response received",
-                export_wins.confirmation_name AS "Your name",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win IS NULL
-                    THEN 'No'
-                END AS "Please confirm these details are correct",
-                export_wins.confirmation_comments AS "Other comments or changes to the win details",
-                export_wins.confirmation_our_support AS "Securing the win overall?",
-                export_wins.confirmation_access_to_contacts AS "Gaining access to contacts?",
-                export_wins.confirmation_access_to_information AS "Getting information or improved understanding of the country?",
-                export_wins.confirmation_improved_profile AS "Improving your profile or credibility in the country?",
-                export_wins.confirmation_gained_confidence AS "Having confidence to explore or expand in the country?",
-                export_wins.confirmation_developed_relationships AS "Developing or nurturing critical relationships?",
-                export_wins.confirmation_overcame_problem AS "Overcoming a problem in the country (eg legal, regulatory)?",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Our support was a prerequisite to generate this export value",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Our support helped you achieve this win more quickly",
-                export_wins.confirmation_portion_without_help AS "Estimated value you would have achieved without our support?",
-                export_wins.confirmation_last_export AS "Apart from this win, when did your company last export?",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Without this win, your company might have stopped exporting",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Apart from this win, you already have specific plans to export in the next 12 months",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "It enabled you to expand into a new market",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "It enabled you to increase exports as a proportion of your turnover",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "It enabled you to maintain or expand in an existing market",
-                CASE
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing
-                    THEN 'Yes'
-                    WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing IN (FALSE, NULL)
-                    THEN 'No'
-                END AS "Would you be willing to be featured in marketing materials?",
-                export_wins.confirmation_marketing_source AS "How did you first hear about DIT (or its predecessor, UKTI)",
-                export_wins.confirmation_other_marketing_source AS "Other marketing source"
-            FROM export_wins
-            -- Export breakdowns
-            LEFT JOIN export_breakdowns ebd1 ON (
-                export_wins.id = ebd1.win_id
-                AND ebd1.year = extract(year FROM CURRENT_DATE)::int
-            )
-            LEFT JOIN export_breakdowns ebd2 ON (
-                export_wins.id = ebd2.win_id
-                AND ebd2.year = extract(year FROM CURRENT_DATE)::int + 1
-            )
-            LEFT JOIN export_breakdowns ebd3 ON (
-                export_wins.id = ebd3.win_id
-                AND ebd3.year = extract(year FROM CURRENT_DATE)::int + 2
-            )
-            LEFT JOIN export_breakdowns ebd4 ON (
-                export_wins.id = ebd4.win_id
-                AND ebd4.year = extract(year FROM CURRENT_DATE)::int + 3
-            )
-            LEFT JOIN export_breakdowns ebd5 ON (
-                export_wins.id = ebd5.win_id
-                AND ebd5.year = extract(year FROM CURRENT_DATE)::int + 4
-            )
-            -- Non export breakdowns
-            LEFT JOIN non_export_breakdowns nebd1 ON (
-                export_wins.id = nebd1.win_id
-                AND nebd1.year = extract(year FROM CURRENT_DATE)::int
-            )
-            LEFT JOIN non_export_breakdowns nebd2 ON (
-                export_wins.id = nebd2.win_id
-                AND nebd2.year = extract(year FROM CURRENT_DATE)::int + 1
-            )
-            LEFT JOIN non_export_breakdowns nebd3 ON (
-                export_wins.id = nebd3.win_id
-                AND nebd3.year = extract(year FROM CURRENT_DATE)::int + 2
-            )
-            LEFT JOIN non_export_breakdowns nebd4 ON (
-                export_wins.id = nebd4.win_id
-                AND nebd4.year = extract(year FROM CURRENT_DATE)::int + 3
-            )
-            LEFT JOIN non_export_breakdowns nebd5 ON (
-                export_wins.id = nebd5.win_id
-                AND nebd5.year = extract(year FROM CURRENT_DATE)::int + 4
-            )
-            -- Outward Direct Investment breakdowns
-            LEFT JOIN odi_breakdowns odibd1 ON (
-                export_wins.id = odibd1.win_id
-                AND odibd1.year = extract(year FROM CURRENT_DATE)::int
-            )
-            LEFT JOIN odi_breakdowns odibd2 ON (
-                export_wins.id = odibd2.win_id
-                AND odibd2.year = extract(year FROM CURRENT_DATE)::int + 1
-            )
-            LEFT JOIN odi_breakdowns odibd3 ON (
-                export_wins.id = odibd3.win_id
-                AND odibd3.year = extract(year FROM CURRENT_DATE)::int + 2
-            )
-            LEFT JOIN odi_breakdowns odibd4 ON (
-                export_wins.id = odibd4.win_id
-                AND odibd4.year = extract(year FROM CURRENT_DATE)::int + 3
-            )
-            LEFT JOIN odi_breakdowns odibd5 ON (
-                export_wins.id = odibd5.win_id
-                AND odibd5.year = extract(year FROM CURRENT_DATE)::int + 4
-            )
-            LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
-            LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
-            ORDER BY export_wins.confirmation_created NULLS FIRST
-        ) a
-        WHERE "Please confirm these details are correct" = 'Yes'
+            id AS "ID",
+            user_name AS "User",
+            company_name AS "Organisation or company name",
+            cdms_reference AS "Data Hub (Companies House) or CDMS reference number",
+            customer_name AS "Contact name",
+            customer_job_title AS "Job title",
+            customer_email_address AS "Contact email",
+            customer_location AS "HQ location",
+            business_type AS "What kind of business deal was this win?",
+            description AS "Summarise the support provided to help achieve this win",
+            name_of_customer AS "Overseas customer",
+            name_of_export AS "What are the goods or services?",
+            date_business_won AS "Date business won [MM/YY]",
+            country AS "Country",
+            total_expected_export_value AS "Total expected export value",
+            total_expected_non_export_value AS "Total expected non export value",
+            total_expected_odi_value AS "Total expected odi value",
+            goods_vs_services AS "Does the expected value relate to",
+            sector AS "Sector",
+            prosperity_fund_related AS "Prosperity Fund",
+            hvc_code AS "HVC code (if applicable)",
+            hvo_programme AS "HVO Programme (if applicable)",
+            has_hvo_specialist_involvement AS "An HVO specialist was involved",
+            is_e_exported AS "E-exporting programme",
+            type_of_support_1 AS "type of support 1",
+            type_of_support_2 AS "type of support 2",
+            type_of_support_3 AS "type of support 3",
+            associated_programme_1 AS "associated programme 1",
+            associated_programme_2 AS "associated programme 2",
+            associated_programme_3 AS "associated programme 3",
+            associated_programme_4 AS "associated programme 4",
+            associated_programme_5 AS "associated programme 5",
+            is_personally_confirmed AS "I confirm that this information is complete and accurate",
+            is_line_manager_confirmed AS "My line manager has confirmed the decision to record this win",
+            lead_officer_name AS "Lead officer name",
+            lead_officer_email_address AS "Lead officer email address",
+            other_official_email_address AS "Secondary email address",
+            line_manager_name AS "Line manager",
+            team_type AS "team type",
+            hq_team AS "HQ team, Region or Post",
+            business_potential AS "Medium-sized and high potential companies",
+            export_experience AS "Export experience",
+            created AS "Created",
+            audit AS "Audit",
+            advisers AS "Contributing advisors/team",
+            customer_email_sent AS "Customer email sent",
+            customer_email_date AS "Customer email date",
+            export_breakdown_1 AS "Export breakdown 1",
+            export_breakdown_2 AS "Export breakdown 2",
+            export_breakdown_3 AS "Export breakdown 3",
+            export_breakdown_4 AS "Export breakdown 4",
+            export_breakdown_5 AS "Export breakdown 5",
+            non_export_breakdown_1 AS "Non-export breakdown 1",
+            non_export_breakdown_2 AS "Non-export breakdown 2",
+            non_export_breakdown_3 AS "Non-export breakdown 3",
+            non_export_breakdown_4 AS "Non-export breakdown 4",
+            non_export_breakdown_5 AS "Non-export breakdown 5",
+            odi_breakdown_1 AS "Outward Direct Investment breakdown 1",
+            odi_breakdown_2 AS "Outward Direct Investment breakdown 2",
+            odi_breakdown_3 AS "Outward Direct Investment breakdown 3",
+            odi_breakdown_4 AS "Outward Direct Investment breakdown 4",
+            odi_breakdown_5 AS "Outward Direct Investment breakdown 5",
+            customer_response_received AS "Customer response received",
+            date_response_received AS "Date response received",
+            confirmation_name AS "Your name",
+            agree_with_win AS "Please confirm these details are correct",
+            confirmation_comments AS "Other comments or changes to the win details",
+            confirmation_our_support AS "Securing the win overall?",
+            confirmation_access_to_contacts AS "Gaining access to contacts?",
+            confirmation_access_to_information AS "Getting information or improved understanding of the country?",
+            confirmation_improved_profile AS "Improving your profile or credibility in the country?",
+            confirmation_gained_confidence AS "Having confidence to explore or expand in the country?",
+            confirmation_developed_relationships AS "Developing or nurturing critical relationships?",
+            confirmation_overcame_problem AS "Overcoming a problem in the country (eg legal, regulatory)?",
+            confirmation_involved_state_enterprise AS "The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)",
+            confirmation_interventions_were_prerequisite AS "Our support was a prerequisite to generate this export value",
+            confirmation_support_improved_speed AS "Our support helped you achieve this win more quickly",
+            confirmation_portion_without_help AS "Estimated value you would have achieved without our support?",
+            confirmation_last_export AS "Apart from this win, when did your company last export?",
+            confirmation_company_was_at_risk_of_not_exporting AS "Without this win, your company might have stopped exporting",
+            confirmation_has_explicit_export_plans AS "Apart from this win, you already have specific plans to export in the next 12 months",
+            confirmation_has_enabled_expansion_into_new_market AS "It enabled you to expand into a new market",
+            confirmation_has_increased_exports_as_percent_of_turnover AS "It enabled you to increase exports as a proportion of your turnover",
+            confirmation_has_enabled_expansion_into_existing_market AS "It enabled you to maintain or expand in an existing market",
+            confirmation_case_study_willing AS "Would you be willing to be featured in marketing materials?",
+            confirmation_marketing_source AS "How did you first hear about DIT (or its predecessor, UKTI)",
+            confirmation_other_marketing_source AS "Other marketing source"
+        FROM dit.export_wins__wins__derived
+        WHERE confirmation_created_date >= date_trunc('day', :run_date)
+        AND confirmation_created_date < date_trunc('day', :run_date) + interval '1 year'
+        AND agree_with_win = 'Yes';
     '''

--- a/dataflow/dags/derived_report_table_pipelines.py
+++ b/dataflow/dags/derived_report_table_pipelines.py
@@ -111,6 +111,7 @@ class ExportWinsDerivedReportTablePipeline(_DerivedReportTablePipeline):
             ('export_experience', sa.Column('export_experience', sa.Text)),
             ('created', sa.Column('created', sa.Text)),
             ('audit', sa.Column('audit', sa.Text)),
+            ('advisers', sa.Column('advisers', sa.Text)),
             ('customer_email_sent', sa.Column('customer_email_sent', sa.Text)),
             ('customer_email_date', sa.Column('customer_email_date', sa.Text)),
             ('export_breakdown_1', sa.Column('export_breakdown_1', sa.Text)),

--- a/dataflow/dags/derived_report_table_pipelines.py
+++ b/dataflow/dags/derived_report_table_pipelines.py
@@ -1,0 +1,496 @@
+"""Airflow Pipeline DAGs that create derived tables to simplify reporting on data workspace"""
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from airflow.operators.python_operator import PythonOperator
+
+from dataflow.dags.base import _PipelineDAG
+from dataflow.dags.dataset_pipelines import (
+    ExportWinsAdvisersDatasetPipeline,
+    ExportWinsBreakdownsDatasetPipeline,
+    ExportWinsHVCDatasetPipeline,
+    ExportWinsWinsDatasetPipeline,
+)
+from dataflow.operators.db_tables import query_database
+from dataflow.utils import TableConfig
+
+
+class _DerivedReportTablePipeline(_PipelineDAG):
+    schedule_interval = '@daily'
+    query: str
+
+    def get_fetch_operator(self):
+        return PythonOperator(
+            task_id='query-database',
+            provide_context=True,
+            python_callable=query_database,
+            op_args=[
+                self.query,
+                self.target_db,
+                self.table_config.table_name,  # pylint: disable=no-member
+            ],
+        )
+
+
+class ExportWinsDerivedReportTablePipeline(_DerivedReportTablePipeline):
+    dependencies = [
+        ExportWinsAdvisersDatasetPipeline,
+        ExportWinsBreakdownsDatasetPipeline,
+        ExportWinsHVCDatasetPipeline,
+        ExportWinsWinsDatasetPipeline,
+    ]
+    start_date = datetime(2020, 9, 16)
+    table_config = TableConfig(
+        schema='dit',
+        table_name='export_wins__wins__derived',
+        field_mapping=[
+            ('id', sa.Column('id', UUID, primary_key=True)),
+            ('user_name', sa.Column('user_name', sa.Text)),
+            ('user_email', sa.Column('user_email', sa.Text)),
+            ('company_name', sa.Column('company_name', sa.Text)),
+            ('cdms_reference', sa.Column('cdms_reference', sa.Text)),
+            ('customer_name', sa.Column('customer_name', sa.Text)),
+            ('customer_job_title', sa.Column('customer_job_title', sa.Text)),
+            ('customer_email_address', sa.Column('customer_email_address', sa.Text)),
+            ('customer_location', sa.Column('customer_location', sa.Text)),
+            ('business_type', sa.Column('business_type', sa.Text)),
+            ('description', sa.Column('description', sa.Text)),
+            ('name_of_customer', sa.Column('name_of_customer', sa.Text)),
+            ('name_of_export', sa.Column('name_of_export', sa.Text)),
+            ('date_business_won', sa.Column('date_business_won', sa.Text)),
+            ('country', sa.Column('country', sa.Text)),
+            (
+                'total_expected_export_value',
+                sa.Column('total_expected_export_value', sa.BigInteger),
+            ),
+            (
+                'total_expected_non_export_value',
+                sa.Column('total_expected_non_export_value', sa.BigInteger),
+            ),
+            (
+                'total_expected_odi_value',
+                sa.Column('total_expected_odi_value', sa.BigInteger),
+            ),
+            ('goods_vs_services', sa.Column('goods_vs_services', sa.Text)),
+            ('sector', sa.Column('sector', sa.Text)),
+            ('prosperity_fund_related', sa.Column('prosperity_fund_related', sa.Text)),
+            ('hvc_code', sa.Column('hvc_code', sa.Text)),
+            ('hvo_programme', sa.Column('hvo_programme', sa.Text)),
+            (
+                'has_hvo_specialist_involvement',
+                sa.Column('has_hvo_specialist_involvement', sa.Text),
+            ),
+            ('is_e_exported', sa.Column('is_e_exported', sa.Text)),
+            ('type_of_support_1', sa.Column('type_of_support_1', sa.Text)),
+            ('type_of_support_2', sa.Column('type_of_support_2', sa.Text)),
+            ('type_of_support_3', sa.Column('type_of_support_3', sa.Text)),
+            ('associated_programme_1', sa.Column('associated_programme_1', sa.Text)),
+            ('associated_programme_2', sa.Column('associated_programme_2', sa.Text)),
+            ('associated_programme_3', sa.Column('associated_programme_3', sa.Text)),
+            ('associated_programme_4', sa.Column('associated_programme_4', sa.Text)),
+            ('associated_programme_5', sa.Column('associated_programme_5', sa.Text)),
+            ('is_personally_confirmed', sa.Column('is_personally_confirmed', sa.Text)),
+            (
+                'is_line_manager_confirmed',
+                sa.Column('is_line_manager_confirmed', sa.Text),
+            ),
+            ('lead_officer_name', sa.Column('lead_officer_name', sa.Text)),
+            (
+                'lead_officer_email_address',
+                sa.Column('lead_officer_email_address', sa.Text),
+            ),
+            (
+                'other_official_email_address',
+                sa.Column('other_official_email_address', sa.Text),
+            ),
+            ('line_manager_name', sa.Column('line_manager_name', sa.Text)),
+            ('team_type', sa.Column('team_type', sa.Text)),
+            ('hq_team', sa.Column('hq_team', sa.Text)),
+            ('business_potential', sa.Column('business_potential', sa.Text)),
+            ('export_experience', sa.Column('export_experience', sa.Text)),
+            ('created', sa.Column('created', sa.Text)),
+            ('audit', sa.Column('audit', sa.Text)),
+            ('customer_email_sent', sa.Column('customer_email_sent', sa.Text)),
+            ('customer_email_date', sa.Column('customer_email_date', sa.Text)),
+            ('export_breakdown_1', sa.Column('export_breakdown_1', sa.Text)),
+            ('export_breakdown_2', sa.Column('export_breakdown_2', sa.Text)),
+            ('export_breakdown_3', sa.Column('export_breakdown_3', sa.Text)),
+            ('export_breakdown_4', sa.Column('export_breakdown_4', sa.Text)),
+            ('export_breakdown_5', sa.Column('export_breakdown_5', sa.Text)),
+            ('non_export_breakdown_1', sa.Column('non_export_breakdown_1', sa.Text)),
+            ('non_export_breakdown_2', sa.Column('non_export_breakdown_2', sa.Text)),
+            ('non_export_breakdown_3', sa.Column('non_export_breakdown_3', sa.Text)),
+            ('non_export_breakdown_4', sa.Column('non_export_breakdown_4', sa.Text)),
+            ('non_export_breakdown_5', sa.Column('non_export_breakdown_5', sa.Text)),
+            ('odi_breakdown_1', sa.Column('odi_breakdown_1', sa.Text)),
+            ('odi_breakdown_2', sa.Column('odi_breakdown_2', sa.Text)),
+            ('odi_breakdown_3', sa.Column('odi_breakdown_3', sa.Text)),
+            ('odi_breakdown_4', sa.Column('odi_breakdown_4', sa.Text)),
+            ('odi_breakdown_5', sa.Column('odi_breakdown_5', sa.Text)),
+            (
+                'customer_response_received',
+                sa.Column('customer_response_received', sa.Text),
+            ),
+            ('date_response_received', sa.Column('date_response_received', sa.Text)),
+            ('confirmation_name', sa.Column('confirmation_name', sa.Text)),
+            ('agree_with_win', sa.Column('agree_with_win', sa.Text)),
+            ('confirmation_comments', sa.Column('confirmation_comments', sa.Text)),
+            (
+                'confirmation_our_support',
+                sa.Column('confirmation_our_support', sa.Text),
+            ),
+            (
+                'confirmation_access_to_contacts',
+                sa.Column('confirmation_access_to_contacts', sa.Text),
+            ),
+            (
+                'confirmation_access_to_information',
+                sa.Column('confirmation_access_to_information', sa.Text),
+            ),
+            (
+                'confirmation_improved_profile',
+                sa.Column('confirmation_improved_profile', sa.Text),
+            ),
+            (
+                'confirmation_gained_confidence',
+                sa.Column('confirmation_gained_confidence', sa.Text),
+            ),
+            (
+                'confirmation_developed_relationships',
+                sa.Column('confirmation_developed_relationships', sa.Text),
+            ),
+            (
+                'confirmation_overcame_problem',
+                sa.Column('confirmation_overcame_problem', sa.Text),
+            ),
+            (
+                'confirmation_involved_state_enterprise',
+                sa.Column('confirmation_involved_state_enterprise', sa.Text),
+            ),
+            (
+                'confirmation_interventions_were_prerequisite',
+                sa.Column('confirmation_interventions_were_prerequisite', sa.Text),
+            ),
+            (
+                'confirmation_support_improved_speed',
+                sa.Column('confirmation_support_improved_speed', sa.Text),
+            ),
+            (
+                'confirmation_portion_without_help',
+                sa.Column('confirmation_portion_without_help', sa.Text),
+            ),
+            (
+                'confirmation_last_export',
+                sa.Column('confirmation_last_export', sa.Text),
+            ),
+            (
+                'confirmation_company_was_at_risk_of_not_exporting',
+                sa.Column('confirmation_company_was_at_risk_of_not_exporting', sa.Text),
+            ),
+            (
+                'confirmation_has_explicit_export_plans',
+                sa.Column('confirmation_has_explicit_export_plans', sa.Text),
+            ),
+            (
+                'confirmation_has_enabled_expansion_into_new_market',
+                sa.Column(
+                    'confirmation_has_enabled_expansion_into_new_market', sa.Text
+                ),
+            ),
+            (
+                'confirmation_has_increased_exports_as_percent_of_turnover',
+                sa.Column(
+                    'confirmation_has_increased_exports_as_percent_of_turnover', sa.Text
+                ),
+            ),
+            (
+                'confirmation_has_enabled_expansion_into_existing_market',
+                sa.Column(
+                    'confirmation_has_enabled_expansion_into_existing_market', sa.Text
+                ),
+            ),
+            (
+                'confirmation_case_study_willing',
+                sa.Column('confirmation_case_study_willing', sa.Text),
+            ),
+            (
+                'confirmation_marketing_source',
+                sa.Column('confirmation_marketing_source', sa.Text),
+            ),
+            (
+                'confirmation_other_marketing_source',
+                sa.Column('confirmation_other_marketing_source', sa.Text),
+            ),
+            # Filtering columns
+            ('country_code', sa.Column('country_code', sa.Text)),
+            ('win_date,', sa.Column('win_date', sa.Date)),
+            ('win_financial_year', sa.Column('win_financial_year', sa.Integer)),
+            (
+                'confirmation_created_date,',
+                sa.Column('confirmation_created_date', sa.Date),
+            ),
+            (
+                'confirmation_created_financial_year',
+                sa.Column('confirmation_created_financial_year', sa.Integer),
+            ),
+            ('current_financial_year', sa.Column('current_financial_year', sa.Integer)),
+        ],
+    )
+    query = '''
+        WITH export_wins AS (
+            SELECT
+                *,
+                CASE
+                    WHEN EXTRACT('month' FROM date)::int >= 4
+                    THEN (to_char(date, 'YYYY')::int)
+                    ELSE (to_char(date + interval '-1' year, 'YYYY')::int)
+                END as win_financial_year
+            FROM export_wins_wins_dataset
+            WHERE export_wins_wins_dataset.customer_email_date IS NOT NULL
+        ), export_breakdowns AS (
+            SELECT win_id, year, value
+            FROM export_wins_breakdowns_dataset
+            WHERE win_id IN (select id from export_wins)
+            AND export_wins_breakdowns_dataset.type = 'Export'
+        ), non_export_breakdowns AS (
+            SELECT win_id, year, value
+            FROM export_wins_breakdowns_dataset
+            WHERE win_id IN (select id from export_wins)
+            AND export_wins_breakdowns_dataset.type = 'Non-export'
+        ), odi_breakdowns AS (
+            SELECT win_id, year, value
+            FROM export_wins_breakdowns_dataset
+            WHERE win_id IN (select id from export_wins)
+            AND export_wins_breakdowns_dataset.type = 'Outward Direct Investment'
+        ), contributing_advisers AS (
+            SELECT win_id, STRING_AGG(CONCAT('Name: ', name, ', Team: ', team_type, ' - ', hq_team, ' - ', location), ', ') as advisers
+            FROM export_wins_advisers_dataset
+            GROUP BY 1
+        )
+        SELECT
+            export_wins.id,
+            CONCAT(export_wins.user_name, ' <', export_wins.user_email, '>') AS user_name,
+            export_wins.user_email,
+            export_wins.company_name,
+            export_wins.cdms_reference,
+            export_wins.customer_name,
+            export_wins.customer_job_title,
+            export_wins.customer_email_address,
+            export_wins.customer_location,
+            export_wins.business_type,
+            export_wins.description,
+            export_wins.name_of_customer,
+            export_wins.name_of_export,
+            to_char(export_wins.date, 'DD/MM/YYYY') AS date_business_won,
+            export_wins.country,
+            COALESCE(export_wins.total_expected_export_value, 0) AS total_expected_export_value,
+            COALESCE(export_wins.total_expected_non_export_value, 0) AS total_expected_non_export_value,
+            COALESCE(export_wins.total_expected_odi_value, 0) AS total_expected_odi_value,
+            export_wins.goods_vs_services,
+            export_wins.sector,
+            COALESCE(export_wins.is_prosperity_fund_related, 'False') AS prosperity_fund_related,
+            export_wins_hvc_dataset.name AS hvc_code,
+            export_wins.hvo_programme,
+            COALESCE(export_wins.has_hvo_specialist_involvement, 'False') AS has_hvo_specialist_involvement,
+            COALESCE(export_wins.is_e_exported, 'False') AS is_e_exported,
+            export_wins.type_of_support_1,
+            export_wins.type_of_support_2,
+            export_wins.type_of_support_3,
+            export_wins.associated_programme_1,
+            export_wins.associated_programme_2,
+            export_wins.associated_programme_3,
+            export_wins.associated_programme_4,
+            export_wins.associated_programme_5,
+            export_wins.is_personally_confirmed,
+            export_wins.is_line_manager_confirmed,
+            export_wins.lead_officer_name,
+            export_wins.lead_officer_email_address,
+            export_wins.other_official_email_address,
+            export_wins.line_manager_name,
+            export_wins.team_type,
+            export_wins.hq_team,
+            export_wins.business_potential,
+            export_wins.export_experience,
+            to_char(export_wins.created, 'DD/MM/YYYY') AS created,
+            export_wins.audit,
+            contributing_advisers.advisers,
+            CASE WHEN export_wins.customer_email_date IS NOT NULL
+            THEN 'Yes'
+            ELSE 'No'
+            END AS customer_email_sent,
+            to_char(export_wins.customer_email_date, 'DD/MM/YYYY') AS customer_email_date,
+            CONCAT(win_financial_year, ': £', COALESCE(ebd1.value, 0)) AS export_breakdown_1,
+            CONCAT(win_financial_year + 1, ': £', COALESCE(ebd2.value, 0)) AS export_breakdown_2,
+            CONCAT(win_financial_year + 2, ': £', COALESCE(ebd3.value, 0)) AS export_breakdown_3,
+            CONCAT(win_financial_year + 3, ': £', COALESCE(ebd4.value, 0)) AS export_breakdown_4,
+            CONCAT(win_financial_year + 4, ': £', COALESCE(ebd5.value, 0)) AS export_breakdown_5,
+            CONCAT(win_financial_year, ': £', COALESCE(nebd1.value, 0)) AS non_export_breakdown_1,
+            CONCAT(win_financial_year + 1, ': £', COALESCE(nebd2.value, 0)) AS non_export_breakdown_2,
+            CONCAT(win_financial_year + 2, ': £', COALESCE(nebd3.value, 0)) AS non_export_breakdown_3,
+            CONCAT(win_financial_year + 3, ': £', COALESCE(nebd4.value, 0)) AS non_export_breakdown_4,
+            CONCAT(win_financial_year + 4, ': £', COALESCE(nebd5.value, 0)) AS non_export_breakdown_5,
+            CONCAT(win_financial_year, ': £', COALESCE(odibd1.value, 0)) AS odi_breakdown_1,
+            CONCAT(win_financial_year + 1, ': £', COALESCE(odibd2.value, 0)) AS odi_breakdown_2,
+            CONCAT(win_financial_year + 2, ': £', COALESCE(odibd3.value, 0)) AS odi_breakdown_3,
+            CONCAT(win_financial_year + 3, ': £', COALESCE(odibd4.value, 0)) AS odi_breakdown_4,
+            CONCAT(win_financial_year + 4, ': £', COALESCE(odibd5.value, 0)) AS odi_breakdown_5,
+            CASE WHEN export_wins.confirmation_created IS NOT NULL
+            THEN 'Yes'
+            ELSE 'No'
+            END AS customer_response_received,
+            to_char(export_wins.confirmation_created, 'DD/MM/YYYY') AS date_response_received,
+            export_wins.confirmation_name,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_agree_with_win
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS agree_with_win,
+            export_wins.confirmation_comments,
+            export_wins.confirmation_our_support,
+            export_wins.confirmation_access_to_contacts,
+            export_wins.confirmation_access_to_information,
+            export_wins.confirmation_improved_profile,
+            export_wins.confirmation_gained_confidence,
+            export_wins.confirmation_developed_relationships,
+            export_wins.confirmation_overcame_problem,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_involved_state_enterprise
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_involved_state_enterprise,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_interventions_were_prerequisite
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_interventions_were_prerequisite,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_support_improved_speed
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_support_improved_speed,
+            export_wins.confirmation_portion_without_help,
+            export_wins.confirmation_last_export,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_company_was_at_risk_of_not_exporting
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_company_was_at_risk_of_not_exporting,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_explicit_export_plans
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_has_explicit_export_plans,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_new_market
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_has_enabled_expansion_into_new_market,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_increased_exports_as_percent_of_turnover
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_has_increased_exports_as_percent_of_turnover,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_has_enabled_expansion_into_existing_market
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_has_enabled_expansion_into_existing_market,
+            CASE
+                WHEN export_wins.confirmation_created IS NOT NULL AND export_wins.confirmation_case_study_willing
+                THEN 'Yes'
+                WHEN export_wins.confirmation_created IS NOT NULL
+                THEN 'No'
+            END AS confirmation_case_study_willing,
+            export_wins.confirmation_marketing_source,
+            export_wins.confirmation_other_marketing_source,
+
+            -- Used for filtering only
+            export_wins.country_code,
+            export_wins.date as win_date,
+            export_wins.win_financial_year,
+            export_wins.confirmation_created as confirmation_created_date,
+            CASE
+                WHEN EXTRACT('month' FROM export_wins.confirmation_created)::int >= 4
+                THEN (to_char(export_wins.confirmation_created, 'YYYY')::int)
+                ELSE (to_char(export_wins.confirmation_created + interval '-1' year, 'YYYY')::int)
+            END as confirmation_created_financial_year,
+            CASE
+                WHEN EXTRACT('month' FROM CURRENT_DATE)::int >= 4
+                THEN (to_char(CURRENT_DATE, 'YYYY')::int)
+                ELSE (to_char(CURRENT_DATE + interval '-1' year, 'YYYY')::int)
+            END as current_financial_year
+        FROM export_wins
+        LEFT JOIN export_breakdowns ebd1 ON (
+            export_wins.id = ebd1.win_id
+            AND ebd1.year = win_financial_year
+        )
+        LEFT JOIN export_breakdowns ebd2 ON (
+            export_wins.id = ebd2.win_id
+            AND ebd2.year = win_financial_year + 1
+        )
+        LEFT JOIN export_breakdowns ebd3 ON (
+            export_wins.id = ebd3.win_id
+            AND ebd3.year = win_financial_year + 2
+        )
+        LEFT JOIN export_breakdowns ebd4 ON (
+            export_wins.id = ebd4.win_id
+            AND ebd4.year = win_financial_year + 3
+        )
+        LEFT JOIN export_breakdowns ebd5 ON (
+            export_wins.id = ebd5.win_id
+            AND ebd5.year = win_financial_year + 4
+        )
+        LEFT JOIN non_export_breakdowns nebd1 ON (
+            export_wins.id = nebd1.win_id
+            AND nebd1.year = win_financial_year
+        )
+        LEFT JOIN non_export_breakdowns nebd2 ON (
+            export_wins.id = nebd2.win_id
+            AND nebd2.year = win_financial_year + 1
+        )
+        LEFT JOIN non_export_breakdowns nebd3 ON (
+            export_wins.id = nebd3.win_id
+            AND nebd3.year = win_financial_year + 2
+        )
+        LEFT JOIN non_export_breakdowns nebd4 ON (
+            export_wins.id = nebd4.win_id
+            AND nebd4.year = win_financial_year + 3
+        )
+        LEFT JOIN non_export_breakdowns nebd5 ON (
+            export_wins.id = nebd5.win_id
+            AND nebd5.year = win_financial_year + 4
+        )
+        LEFT JOIN odi_breakdowns odibd1 ON (
+            export_wins.id = odibd1.win_id
+            AND odibd1.year = win_financial_year
+        )
+        LEFT JOIN odi_breakdowns odibd2 ON (
+            export_wins.id = odibd2.win_id
+            AND odibd2.year = win_financial_year + 1
+        )
+        LEFT JOIN odi_breakdowns odibd3 ON (
+            export_wins.id = odibd3.win_id
+            AND odibd3.year = win_financial_year + 2
+        )
+        LEFT JOIN odi_breakdowns odibd4 ON (
+            export_wins.id = odibd4.win_id
+            AND odibd4.year = win_financial_year + 3
+        )
+        LEFT JOIN odi_breakdowns odibd5 ON (
+            export_wins.id = odibd5.win_id
+            AND odibd5.year = win_financial_year + 4
+        )
+        LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
+        LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
+        ORDER BY export_wins.confirmation_created NULLS FIRST
+    '''

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -51,6 +51,7 @@ def test_pipelines_dags():
         'ExportWinsByFinancialYearCSVPipeline',
         'ExportWinsCurrentFinancialYearDailyCSVPipeline',
         'ExportWinsDashboardPipeline',
+        'ExportWinsDerivedReportTablePipeline',
         'ExportWinsHVCDatasetPipeline',
         'ExportWinsMatchingPipeline',
         'ExportWinsWinsDatasetPipeline',


### PR DESCRIPTION
There are currently 156 queries on data workspace that produce the same report based on a few variables (region, sector, financial year). If a change needs to be made to the query someone has to go through and update every one of those manually.

This PR

- Adds a new derived table that handles much of the logic of our existing queries and provides a simpler way for data managers to write these reports.
- Updates the export wins csv pipelines to use the new table


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
