### PR TITLE
fix: covid and export wins pipeline cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Run the google covid pipeline daily 
 - Allow null columns on the derived export wins pipeline
+- Use the high memory queue for the google covid dataset fetch operation
 
 ## 2020-09-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Run the google covid pipeline daily 
+- Allow null columns on the derived export wins pipeline
 
 ## 2020-09-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-21
+
+### Changed
+
+- Run the google covid pipeline daily 
+
 ## 2020-09-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Run the google covid pipeline daily 
 - Allow null columns on the derived export wins pipeline
 - Use the high memory queue for the google covid dataset fetch operation
+- Add region name and region code fields to oxford covid dataset
 
 ## 2020-09-18
 

--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -365,6 +365,7 @@ class GoogleCovid19MobilityReports(_PipelineDAG):
             task_id='run-fetch',
             python_callable=fetch_mapped_hosted_csvs,
             provide_context=True,
+            queue='high-memory-usage',
             op_args=[
                 self.table_config.table_name,
                 self.source_urls,

--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -21,6 +21,8 @@ class OxfordCovid19GovernmentResponseTracker(_PipelineDAG):
         field_mapping=[
             ('CountryName', sa.Column('country_name', sa.String)),
             ('CountryCode', sa.Column('country_code', sa.String)),
+            ('RegionName', sa.Column('region_name', sa.String)),
+            ('RegionCode', sa.Column('region_code', sa.String)),
             ('Date', sa.Column('date', sa.Numeric)),
             ('C1_School closing', sa.Column('c1_school_closing', sa.Numeric)),
             ('C1_Flag', sa.Column('c1_flag', sa.Numeric)),
@@ -138,7 +140,10 @@ class OxfordCovid19GovernmentResponseTracker(_PipelineDAG):
             task_id='run-fetch',
             python_callable=partial(fetch_from_hosted_csv, allow_empty_strings=False),
             provide_context=True,
-            op_args=[self.table_config.table_name, self.source_url],
+            op_args=[
+                self.table_config.table_name,  # pylint: disable=no-member
+                self.source_url,
+            ],
         )
 
 
@@ -146,11 +151,11 @@ class CSSECovid19TimeSeriesGlobal(_PipelineDAG):
     # Run after the daily update of data ~4am
     schedule_interval = '0 7 * * *'
     use_utc_now_as_source_modified = True
-
+    _endpoint = "https://github.com/CSSEGISandData/COVID-19/raw/master/csse_covid_19_data/csse_covid_19_time_series"
     source_urls = {
-        "confirmed": "https://github.com/CSSEGISandData/COVID-19/raw/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv",
-        "recovered": "https://github.com/CSSEGISandData/COVID-19/raw/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv",
-        "deaths": "https://github.com/CSSEGISandData/COVID-19/raw/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv",
+        "confirmed": f"{_endpoint}/time_series_covid19_confirmed_global.csv",
+        "recovered": f"{_endpoint}/time_series_covid19_recovered_global.csv",
+        "deaths": f"{_endpoint}/time_series_covid19_deaths_global.csv",
     }
 
     table_config = TableConfig(
@@ -183,7 +188,7 @@ class CSSECovid19TimeSeriesGlobal(_PipelineDAG):
             python_callable=fetch_mapped_hosted_csvs,
             provide_context=True,
             op_args=[
-                self.table_config.table_name,
+                self.table_config.table_name,  # pylint: disable=no-member
                 self.source_urls,
                 self.transform_dataframe,
             ],
@@ -264,7 +269,11 @@ class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
             task_id='query-database',
             provide_context=True,
             python_callable=query_database,
-            op_args=[self.query, self.target_db, self.table_config.table_name],
+            op_args=[
+                self.query,
+                self.target_db,
+                self.table_config.table_name,  # pylint: disable=no-member
+            ],
         )
         return op
 
@@ -367,7 +376,7 @@ class GoogleCovid19MobilityReports(_PipelineDAG):
             provide_context=True,
             queue='high-memory-usage',
             op_args=[
-                self.table_config.table_name,
+                self.table_config.table_name,  # pylint: disable=no-member
                 self.source_urls,
                 self.transform_dataframe,
             ],
@@ -482,7 +491,7 @@ class AppleCovid19MobilityTrendsPipeline(_PipelineDAG):
             provide_context=True,
             python_callable=fetch_apple_mobility_data,
             op_args=[
-                self.table_config.table_name,
+                self.table_config.table_name,  # pylint: disable=no-member
                 self.base_url,
                 self.config_path,
                 self.transform_dataframe,

--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -270,7 +270,6 @@ class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
 
 
 class GoogleCovid19MobilityReports(_PipelineDAG):
-    schedule_interval = '0 1 * * 0'
     use_utc_now_as_source_modified = True
     source_urls = {
         'global': 'https://www.gstatic.com/covid19/mobility/Global_Mobility_Report.csv',

--- a/dataflow/dags/derived_report_table_pipelines.py
+++ b/dataflow/dags/derived_report_table_pipelines.py
@@ -19,6 +19,7 @@ from dataflow.utils import TableConfig
 class _DerivedReportTablePipeline(_PipelineDAG):
     schedule_interval = '@daily'
     query: str
+    allow_null_columns = True
 
     def get_fetch_operator(self):
         return PythonOperator(


### PR DESCRIPTION
A few small fixes to some pipeline issues encountered over the last few days.

- Run the google covid pipeline daily 
- Allow null columns on the derived export wins pipeline
- Use the high memory queue for the google covid dataset fetch operation
- Add region name and region code fields to oxford covid dataset
