### PR TITLE
feature: HMRC Exporters Matching Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - HMRC Exporters matching pipeline
 
+### Changed
+
+- Support Array types in DSSGenericPipeline
+
 ## 2020-09-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix typos in export wins derived config
 
+## 2020-09-22
+
+### Added
+
+- HMRC Exporters matching pipeline
+
 ## 2020-09-21
 
 ### Changed

--- a/dataflow/dags/company_matching.py
+++ b/dataflow/dags/company_matching.py
@@ -171,3 +171,22 @@ class DSSHMRCFieldForceMatchingPipeline(_DSSGenericMatchingPipeline):
         FROM "{schema_name}"."{controller_table_name}"
         ORDER BY id asc, entry_last_modified::timestamp desc
     """
+
+
+class DSSHMRCExportersMatchingPipeline(_DSSGenericMatchingPipeline):
+    schema_name = 'hmrc'
+    controller_table_name = 'exporters'
+    table_name = 'exporters_match_ids'
+    company_match_query = f"""
+        SELECT distinct on (id)
+            id as id,
+            company_name as company_name,
+            null as contact_email,
+            null as cdms_ref,
+            postcode as postcode,
+            null as companies_house_id,
+            'hmrc.exporters' as source,
+            datetime::timestamp as datetime
+        FROM "{schema_name}"."{controller_table_name}"
+        ORDER BY id asc, datetime::timestamp desc
+    """

--- a/dataflow/operators/dss_generic.py
+++ b/dataflow/operators/dss_generic.py
@@ -65,7 +65,10 @@ def get_table_config(**context):
             'NUMERIC': sa.Numeric,
         }
         try:
-            sa_data_type = mapping[data_type]
+            if data_type.endswith('[]'):
+                sa_data_type = sa.ARRAY(mapping[data_type[:-2]])
+            else:
+                sa_data_type = mapping[data_type]
         except KeyError:
             raise ValueError(f'data type {data_type} not supported')
         return sa.Column(column_name, sa_data_type)

--- a/tests/unit/operators/test_dss_generic.py
+++ b/tests/unit/operators/test_dss_generic.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from sqlalchemy import Column, Integer, Text, DateTime
+from sqlalchemy import ARRAY, Column, Integer, Text, DateTime
 
 import dataflow
 from dataflow.operators import dss_generic
@@ -15,6 +15,9 @@ def test_get_table_config(mocker):
             {'name': 'batch_ref', 'type': 'TEXT'},
             {'name': 'status', 'type': 'TEXT'},
             {'name': 'start_date', 'type': 'TIMESTAMP WITHOUT TIME ZONE'},
+            {'name': 'int_list', 'type': 'INTEGER[]'},
+            {'name': 'text_list', 'type': 'TEXT[]'},
+            {'name': 'timestamp_list', 'type': 'TIMESTAMP WITHOUT TIME ZONE[]'},
         ],
     }
     config = {
@@ -28,7 +31,7 @@ def test_get_table_config(mocker):
     assert table_config.schema == 'test_org'
 
     field_mapping_types = [field[1].type for field in table_config.field_mapping]
-    expected_field_mapping_types = [Integer] + [Text] * 2 + [DateTime]
+    expected_field_mapping_types = [Integer] + [Text] * 2 + [DateTime] + [ARRAY] * 3
 
     for i, type in enumerate(field_mapping_types):
         expected_type = expected_field_mapping_types[i]

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -23,6 +23,7 @@ def test_pipelines_dags():
         'DNBGlobalCompanyUpdatePipeline',
         'DSSGenericPipeline',
         'DSSHMRCFieldForceMatchingPipeline',
+        'DSSHMRCExportersMatchingPipeline',
         'DailyCSVRefreshPipeline',
         'DataHubCompanyReferralsDatasetPipeline',
         'DataHubExportClientSurveyStaticCSVPipeline',


### PR DESCRIPTION
The dataset will be processed by the DSSGenericPipeline. At the end of the processing the matching pipeline is triggered to get match_ids for the data.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
