### PR TITLE
feature: preserve dependencies on swap table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Maxemail campaigns sent emails pipeline.
 
+### Changed
+
+- Preserve views/materialised views dependencies on table swap
+
 ## 2020-09-23
 
 ### Added

--- a/alembic/versions/e7b0c0fba2e3_table_deps_save_and_restore.py
+++ b/alembic/versions/e7b0c0fba2e3_table_deps_save_and_restore.py
@@ -1,0 +1,153 @@
+"""table deps save and restore
+
+Revision ID: e7b0c0fba2e3
+Revises: bf30b3dbebb4
+Create Date: 2020-09-17 14:12:32.436889
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e7b0c0fba2e3'
+down_revision = 'bf30b3dbebb4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'table_dependencies',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('view_schema', sa.Text(), nullable=False),
+        sa.Column('view_name', sa.Text(), nullable=False),
+        sa.Column('ddl_to_run', sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        schema='dataflow',
+    )
+
+    connection = op.get_bind()
+    connection.execute(
+        """
+        create or replace function dataflow.save_and_drop_dependencies(p_view_schema varchar, p_view_name varchar) returns void as
+        $$
+        declare
+          v_curr record;
+        begin
+        for v_curr in
+        (
+          select obj_schema, obj_name, obj_type from
+          (
+            with recursive recursive_deps(obj_schema, obj_name, obj_type, depth) as
+            (
+                select p_view_schema, p_view_name, null::varchar, 0
+                union
+                select dep_schema::varchar, dep_name::varchar, dep_type::varchar, recursive_deps.depth + 1 from
+                (
+                    select
+                        ref_nsp.nspname ref_schema,
+                        ref_cl.relname ref_name,
+                        rwr_cl.relkind dep_type,
+                        rwr_nsp.nspname dep_schema,
+                        rwr_cl.relname dep_name
+                    from pg_depend dep
+                    join pg_class ref_cl on dep.refobjid = ref_cl.oid
+                    join pg_namespace ref_nsp on ref_cl.relnamespace = ref_nsp.oid
+                    join pg_rewrite rwr on dep.objid = rwr.oid
+                    join pg_class rwr_cl on rwr.ev_class = rwr_cl.oid
+                    join pg_namespace rwr_nsp on rwr_cl.relnamespace = rwr_nsp.oid
+                    where dep.deptype = 'n'
+                    and dep.classid = 'pg_rewrite'::regclass
+                ) deps
+                join recursive_deps on deps.ref_schema = recursive_deps.obj_schema and deps.ref_name = recursive_deps.obj_name
+                where (deps.ref_schema != deps.dep_schema or deps.ref_name != deps.dep_name)
+            )
+            select obj_schema, obj_name, obj_type, depth
+            from recursive_deps
+            where depth > 0
+          ) t
+          group by obj_schema, obj_name, obj_type
+          order by max(depth) desc
+        ) loop
+          insert into dataflow.table_dependencies(view_schema, view_name, ddl_to_run)
+            select p_view_schema, p_view_name, 'COMMENT ON ' ||
+            case
+                when c.relkind = 'v' then 'VIEW'
+                when c.relkind = 'm' then 'MATERIALIZED VIEW'
+                else ''
+            end
+            || ' ' || n.nspname || '.' || c.relname || ' IS ''' || replace(d.description, '''', '''''') || ''';'
+            from pg_class c
+            join pg_namespace n on n.oid = c.relnamespace
+            join pg_description d on d.objoid = c.oid and d.objsubid = 0
+            where n.nspname = v_curr.obj_schema and c.relname = v_curr.obj_name and d.description is not null;
+
+          insert into dataflow.table_dependencies(view_schema, view_name, ddl_to_run)
+            select p_view_schema, p_view_name, 'COMMENT ON COLUMN ' || n.nspname || '.' || c.relname || '.' || a.attname || ' IS ''' || replace(d.description, '''', '''''') || ''';'
+            from pg_class c
+            join pg_attribute a on c.oid = a.attrelid
+            join pg_namespace n on n.oid = c.relnamespace
+            join pg_description d on d.objoid = c.oid and d.objsubid = a.attnum
+            where n.nspname = v_curr.obj_schema and c.relname = v_curr.obj_name and d.description is not null;
+
+          insert into dataflow.table_dependencies(view_schema, view_name, ddl_to_run)
+            select p_view_schema, p_view_name, 'GRANT ' || privilege_type || ' ON ' || table_schema || '.' || table_name || ' TO ' || grantee
+            from information_schema.role_table_grants
+            where table_schema = v_curr.obj_schema and table_name = v_curr.obj_name;
+
+          if v_curr.obj_type = 'v' then
+            insert into dataflow.table_dependencies(view_schema, view_name, ddl_to_run)
+                    select p_view_schema, p_view_name, 'CREATE VIEW ' || v_curr.obj_schema || '.' || v_curr.obj_name || ' AS ' || view_definition
+                    from information_schema.views
+                    where table_schema = v_curr.obj_schema and table_name = v_curr.obj_name;
+          elsif v_curr.obj_type = 'm' then
+            insert into dataflow.table_dependencies(view_schema, view_name, ddl_to_run)
+                    select p_view_schema, p_view_name, 'CREATE MATERIALIZED VIEW ' || v_curr.obj_schema || '.' || v_curr.obj_name || ' AS ' || definition
+                    from pg_matviews
+                    where schemaname = v_curr.obj_schema and matviewname = v_curr.obj_name;
+          end if;
+
+          execute 'DROP ' ||
+          case
+            when v_curr.obj_type = 'v' then 'VIEW'
+            when v_curr.obj_type = 'm' then 'MATERIALIZED VIEW'
+          end
+          || ' ' || v_curr.obj_schema || '.' || v_curr.obj_name;
+
+        end loop;
+        end;
+        $$
+        LANGUAGE plpgsql;
+
+        create or replace function dataflow.restore_dependencies(p_view_schema varchar, p_view_name varchar) returns void as
+        $$
+        declare
+          v_curr record;
+        begin
+        for v_curr in
+        (
+          select ddl_to_run
+          from dataflow.table_dependencies
+          where view_schema = p_view_schema and view_name = p_view_name
+          order by id desc
+        ) loop
+          execute v_curr.ddl_to_run;
+        end loop;
+        delete from dataflow.table_dependencies
+        where view_schema = p_view_schema and view_name = p_view_name;
+        end;
+        $$
+        LANGUAGE plpgsql;
+    """
+    )
+
+
+def downgrade():
+    op.drop_table('table_dependencies', schema='dataflow')
+    connection = op.get_bind()
+    connection.execute(
+        """
+        DROP FUNCTION dataflow.save_and_drop_dependencies, dataflow.restore_dependencies;
+    """
+    )

--- a/dataflow/models.py
+++ b/dataflow/models.py
@@ -14,3 +14,12 @@ class Metadata(Base):
     table_name = sa.Column(sa.Text, nullable=False)
     source_data_modified_utc = sa.Column(sa.DateTime, nullable=True)
     dataflow_swapped_tables_utc = sa.Column(sa.DateTime, nullable=False)
+
+
+class TableDependencies(Base):
+    __tablename__ = 'table_dependencies'
+
+    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+    view_schema = sa.Column(sa.Text, nullable=False)
+    view_name = sa.Column(sa.Text, nullable=False)
+    ddl_to_run = sa.Column(sa.Text, nullable=False)

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -417,8 +417,10 @@ def swap_dataset_tables(
 
             conn.execute(
                 """
+                SELECT dataflow.save_and_drop_dependencies('{schema}', '{target_temp_table}');
                 ALTER TABLE IF EXISTS {schema}.{target_temp_table} RENAME TO {swap_table_name};
                 ALTER TABLE {schema}.{temp_table} RENAME TO {target_temp_table};
+                SELECT dataflow.restore_dependencies('{schema}', '{target_temp_table}');
                 """.format(
                     schema=engine.dialect.identifier_preparer.quote(table.schema),
                     target_temp_table=engine.dialect.identifier_preparer.quote(

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -305,8 +305,10 @@ def test_swap_dataset_tables(
             call().fetchall(),
             call(
                 '''
+                SELECT dataflow.save_and_drop_dependencies('QUOTED<public>', 'QUOTED<test_table>');
                 ALTER TABLE IF EXISTS QUOTED<public>.QUOTED<test_table> RENAME TO QUOTED<test_table_123_swap>;
                 ALTER TABLE QUOTED<public>.QUOTED<test_table_123> RENAME TO QUOTED<test_table>;
+                SELECT dataflow.restore_dependencies('QUOTED<public>', 'QUOTED<test_table>');
                 '''
             ),
             call('GRANT SELECT ON QUOTED<public>.QUOTED<test_table> TO testuser'),


### PR DESCRIPTION
### Description of change

Support the swapping of tables with dependencies such as views or materialized views.
Before a table is swapped any dependencies are stored in the database and restored after
a successful swap.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
