### PR TITLE
feature: update matching service company data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix typos in export wins derived config
 - Fix incorrect field type bug in return to office pipeline
 - Add correct id field to return to office pipeline
+- Use matching service update endpoint for some matching pipeline 
 
 ## 2020-09-22
 

--- a/dataflow/dags/company_matching.py
+++ b/dataflow/dags/company_matching.py
@@ -39,6 +39,7 @@ class _CompanyMatchingPipeline(_PipelineDAG):
 
     company_match_query: str
     controller_pipeline: Union[Type[_PipelineDAG], Type[DSSGenericPipeline]]
+    update: bool = False
 
     @property
     def table_name(self):
@@ -58,11 +59,13 @@ class _CompanyMatchingPipeline(_PipelineDAG):
                 self.table_config.table_name,
                 self.company_match_query,
                 config.MATCHING_SERVICE_BATCH_SIZE,
+                self.update,
             ],
         )
 
 
 class DataHubMatchingPipeline(_CompanyMatchingPipeline):
+    update = True
     controller_pipeline = CompaniesDatasetPipeline
     dependencies = [CompaniesDatasetPipeline, ContactsDatasetPipeline]
     company_match_query = f"""
@@ -83,6 +86,7 @@ class DataHubMatchingPipeline(_CompanyMatchingPipeline):
 
 
 class ExportWinsMatchingPipeline(_CompanyMatchingPipeline):
+    update = True
     controller_pipeline = ExportWinsWinsDatasetPipeline
     dependencies = [ExportWinsWinsDatasetPipeline]
     company_match_query = f"""
@@ -120,6 +124,7 @@ class GreatGOVUKExportOpportunityEnquiriesMatchingPipeline(_CompanyMatchingPipel
 
 
 class CompaniesHouseMatchingPipeline(_CompanyMatchingPipeline):
+    update = True
     controller_pipeline = CompaniesHouseCompaniesPipeline
     dependencies = [CompaniesHouseCompaniesPipeline]
     company_match_query = f"""


### PR DESCRIPTION
### Description of change

Some of the datasets in data-flow pipelines should use the update endpoint in the matching service rather then the match endpoint to keep the matching backend up to date with the latest company information.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
