### PR TITLE
feat: return to office pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-09-23
 
+### Added
+
+- New activity stream pipeline for the return-to-office service
+
 ### Changed
 
 - Fix typos in export wins derived config

--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -528,3 +528,53 @@ class GreatGovUKFormsPipeline(_ActivityStreamPipeline):
             ]
         }
     }
+
+
+class ReturnToOfficeBookingsPipeline(_ActivityStreamPipeline):
+    index = "objects"
+    table_config = TableConfig(
+        schema="dit",
+        table_name="return_to_office__bookings",
+        field_mapping=[
+            ("id", sa.Column("id", sa.Integer, primary_key=True)),
+            ("dit:ReturnToOffice:Booking:userId", sa.Column("user_id", UUID)),
+            ("dit:ReturnToOffice:Booking:userEmail", sa.Column("user_email", sa.Text)),
+            (
+                "dit:ReturnToOffice:Booking:userFullName",
+                sa.Column("user_name", sa.Text),
+            ),
+            (
+                "dit:ReturnToOffice:Booking:onBehalfOfName",
+                sa.Column("on_behalf_of_name", sa.Text),
+            ),
+            (
+                "dit:ReturnToOffice:Booking:onBehalfOfEmail",
+                sa.Column("on_behalf_of_email", sa.Text),
+            ),
+            (
+                "dit:ReturnToOffice:Booking:bookingDate",
+                sa.Column("booking_date", sa.Date),
+            ),
+            (
+                "dit:ReturnToOffice:Booking:building",
+                sa.Column("building_name", sa.Text),
+            ),
+            ("dit:ReturnToOffice:Booking:floor", sa.Column("floor_name", sa.Text)),
+            (
+                "dit:ReturnToOffice:Booking:directorate",
+                sa.Column("directorate", sa.Text),
+            ),
+            ("dit:ReturnToOffice:Booking:group", sa.Column("group", sa.Text),),
+            (
+                "dit:ReturnToOffice:Booking:businessUnit",
+                sa.Column("business_unit", sa.Text),
+            ),
+            ("dit:ReturnToOffice:Booking:created", sa.Column("created", sa.DateTime)),
+            (
+                "dit:ReturnToOffice:Booking:cancelled",
+                sa.Column("cancelled", sa.DateTime),
+            ),
+        ],
+    )
+
+    query = {"bool": {"filter": [{"term": {"type": "dit:ReturnToOffice:Booking"}}]}}

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -90,6 +90,7 @@ def test_pipelines_dags():
         'PeopleFinderPeoplePipeline',
         'RawWorldBankBoundRatePipeline',
         'RawWorldBankTariffPipeline',
+        'ReturnToOfficeBookingsPipeline',
         'StaffSSOUsersPipeline',
         'TeamsDatasetPipeline',
     }


### PR DESCRIPTION
### Description of change

Adds a new activity stream pipeline for the new return to office service

Closes: https://trello.com/c/gLLzk1Tm/888-data-pipeline-for-the-dit-desk-booking-tool

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
