### PR TITLE
removing campaign id for now until Activity Stream side is fixed

### DIFF
--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -596,7 +596,6 @@ class MaxemailCampaignsSentPipeline(_ActivityStreamPipeline):
         field_mapping=[
             (("object", "id"), sa.Column("id", sa.String, primary_key=True)),
             (("object", "dit:emailAddress"), sa.Column("email_address", sa.String)),
-            (("object", "attributedTo", "id"), sa.Column("campaign_id", sa.Integer)),
             (("object", "attributedTo", "name"), sa.Column("campaign_name", sa.String)),
             (("object", "attributedTo", "published"), sa.Column("sent", sa.DateTime)),
             (("object", "type"), sa.Column("type", sa.ARRAY(sa.String))),


### PR DESCRIPTION
### Description of change
campaign id is not properly formatted in Activity Stream feed. Removing it for now, will be added back once it is fixed.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
