### PR TITLE
feat: configure email alerts for more ONS datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Maxemail campaigns sent emails pipeline.
+- Email alerts for the remaining 3 ONS pipeline runs.
 
 ## 2020-09-23
 

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -79,6 +79,10 @@ class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(_FastPollingPipeline
     )
     worker_queue = 'high-memory-usage'
 
+    update_emails_data_environment_variable = (
+        'UPDATE_EMAILS_DATA__ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline'
+    )
+
 
 class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(_FastPollingPipeline):
     from dataflow.ons_scripts.uk_trade_in_services_service_type_by_partner_country_non_seasonally_adjusted.main import (
@@ -109,6 +113,10 @@ class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(_FastPollingPipelin
         ],
     )
 
+    update_emails_data_environment_variable = (
+        'UPDATE_EMAILS_DATA__ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline'
+    )
+
 
 class ONSUKTotalTradeAllCountriesNSAPollingPipeline(_FastPollingPipeline):
     from dataflow.ons_scripts.uk_total_trade_all_countries_non_seasonally_adjusted.main import (
@@ -136,4 +144,8 @@ class ONSUKTotalTradeAllCountriesNSAPollingPipeline(_FastPollingPipeline):
             ('unit', sa.Column('unit', sa.Text)),
             ('marker', sa.Column('marker', sa.Text)),
         ],
+    )
+
+    update_emails_data_environment_variable = (
+        'UPDATE_EMAILS_DATA__ONSUKTotalTradeAllCountriesNSAPollingPipeline'
     )

--- a/tests/unit/dags/test_ons_pipelines.py
+++ b/tests/unit/dags/test_ons_pipelines.py
@@ -18,24 +18,18 @@ class TestONSUKTradeInGoodsByCountryAndCommodity:
     def test_tasks_in_dag(self):
         dag = ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
-            with_emails=False
-        )
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)
 
 
 class TestONSUKTradeInServicesByPartnerCountryNSAPollingPipeline:
     def test_tasks_in_dag(self):
         dag = ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
-            with_emails=False
-        )
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)
 
 
 class TestONSUKTotalTradeAllCountriesNSAPollingPipeline:
     def test_tasks_in_dag(self):
         dag = ONSUKTotalTradeAllCountriesNSAPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
-            with_emails=False
-        )
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)


### PR DESCRIPTION
### Description of change
Link up more ONS pipelines with their env vars so that emails are sent
out when the pipelin runs finish.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
