### PR TITLE
Change Postgres version in local docker deployment to match production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   data-flow-db:
-    image: postgres
+    image: postgres:10
     volumes:
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:


### PR DESCRIPTION
### Description of change

Use same Postgres version (v10) in local docker deployment as in the production environment.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
