### PR TITLE
fix: update field mapping for john hopkins covid query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-30
+
+### Changed
+
+- Update country code mapping for the JHU covid dataset
+
 ## 2020-09-29
 
 ### Changed

--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -203,9 +203,10 @@ class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
     query = """
     WITH unmatched_codes (country, iso2, iso3) AS (VALUES
         ('Bahamas', 'BS', 'BSS'),
-        ('Bonaire, Sint Eustatius and Saba', 'BQ', NULL),
+        ('Bonaire, Sint Eustatius and Saba', 'BQ', 'BES'),
         ('Burma', 'MM', 'MMR'),
         ('Cabo Verde', 'CV', 'CPV'),
+        ('Channel Islands', 'GB', 'GBR'),
         ('Congo (Brazzaville)', 'CG', 'COG'),
         ('Congo (Kinshasa)', 'CD', 'COD'),
         ('Cote d''Ivoire', 'CI', 'CIV'),
@@ -214,13 +215,19 @@ class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
         ('Gambia', 'GM', 'GMB'),
         ('Holy See', 'VA', 'VAT'),
         ('Korea, South', 'KR', 'KOR'),
+        ('Kosovo', 'XK', 'XKX'),
+        ('Reunion', 'RE', 'REU'),
+        ('Saint Barthelemy', 'BL', 'BLM'),
         ('Saint Kitts and Nevis', 'KN', 'KNA'),
         ('Saint Lucia', 'LC', 'LCA'),
         ('Saint Vincent and the Grenadines', 'VC', 'VCT'),
         ('Sint Maarten', 'SX', 'SXM'),
+        ('St Martin', 'MF', 'MAF'),
         ('Taiwan*', 'TW', 'TWN'),
         ('Timor-Leste', 'TL', 'TLS'),
-        ('US', 'US', 'USA')
+        ('United Kingdom', 'GB', 'GBR'),
+        ('US', 'US', 'USA'),
+        ('West Bank and Gaza', 'PS', 'PSE')
     )
     SELECT
         COALESCE(ref_countries_territories_and_regions.iso2_code, unmatched_codes.iso2) AS iso2_code,


### PR DESCRIPTION
Ensure there are no countries with empty iso 2 or 3 codes

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
