### PR TITLE
fix: move export wins derived to high mem queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- 
+- More export wins derived fetch task to the high mem queue
 
 ## 2020-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-02
+
+### Changed
+
+- 
+
 ## 2020-09-30
 
 ### Changed

--- a/dataflow/dags/derived_report_table_pipelines.py
+++ b/dataflow/dags/derived_report_table_pipelines.py
@@ -26,6 +26,7 @@ class _DerivedReportTablePipeline(_PipelineDAG):
             task_id='query-database',
             provide_context=True,
             python_callable=query_database,
+            queue='high-memory-usage',
             op_args=[
                 self.query,
                 self.target_db,


### PR DESCRIPTION
Fixes issue where fetch task was running out of memory

