### PR TITLE
feat: set default retries globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add [prometheus metrics exporter](https://github.com/uktrade/data-flow-metrics) to data-flow.
 
+### Changed
+- Set default retries across almost all DAGs at three, to (hopefully) reduce the need for manually restarting failed pipelines that are caused by transient issues.
+
 ## 2020-10-02
 
 ### Added

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -134,7 +134,7 @@ class _PipelineDAG(metaclass=PipelineMeta):
                 "depends_on_past": False,
                 "email_on_failure": False,
                 "email_on_retry": False,
-                "retries": 0,
+                "retries": 3,
                 "retry_delay": timedelta(minutes=5),
                 'catchup': self.catchup,
             },
@@ -207,7 +207,6 @@ class _PipelineDAG(metaclass=PipelineMeta):
 
         _swap_dataset_tables = PythonOperator(
             task_id="swap-dataset-table",
-            retries=2,
             python_callable=swap_dataset_tables,
             execution_timeout=timedelta(minutes=10),
             provide_context=True,
@@ -308,7 +307,7 @@ class _CSVPipelineDAG(metaclass=PipelineMeta):
                 'depends_on_past': False,
                 'email_on_failure': False,
                 'email_on_retry': False,
-                'retries': 1,
+                'retries': 3,
                 'retry_delay': timedelta(minutes=5),
                 'start_date': datetime(2019, 1, 1),
             },
@@ -434,7 +433,6 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
             ),
             dag=dag,
             provide_context=True,
-            retries=3,
         )
 
         _scrape_load_and_check = PythonOperator(
@@ -448,13 +446,11 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
             dag=dag,
             provide_context=True,
             queue=self.worker_queue,
-            retries=3,
         )
 
         _swap_dataset_tables = PythonOperator(
             task_id="swap-dataset-table",
             dag=dag,
-            retries=2,
             python_callable=swap_dataset_tables,
             execution_timeout=timedelta(minutes=10),
             provide_context=True,

--- a/dataflow/dags/csv_pipelines/csv_refresh_pipeline.py
+++ b/dataflow/dags/csv_pipelines/csv_refresh_pipeline.py
@@ -53,7 +53,7 @@ class DailyCSVRefreshPipeline(_CSVPipelineDAG):
                 'depends_on_past': False,
                 'email_on_failure': False,
                 'email_on_retry': False,
-                'retries': 1,
+                'retries': 3,
                 'retry_delay': timedelta(minutes=5),
                 'catchup': self.catchup,
                 'start_date': datetime(2019, 1, 1),

--- a/dataflow/dags/tensorflow_pipelines.py
+++ b/dataflow/dags/tensorflow_pipelines.py
@@ -23,7 +23,7 @@ class ExampleTensorflowPipeline(metaclass=PipelineMeta):
                 'depends_on_past': False,
                 'email_on_failure': False,
                 'email_on_retry': False,
-                'retries': 1,
+                'retries': 0,
                 'retry_delay': timedelta(minutes=5),
                 'start_date': datetime(2019, 1, 1),
             },


### PR DESCRIPTION
### Description of change
A lot of our pipeline failures are due to transient issues, e.g.
instances being killed+restarted, APIs having hiccups, etc. By setting
default retries to 3 for all tasks across (almost) all pipelines, we
should reduce the need for manually intervening to fix jobs that have
only more significant issues.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
