### PR TITLE
fix: pagination for sharepoint lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-14
+
+### Changed
+
+- Split the requests for sharepoint columns/data to allow for pagination  
+
 ## 2020-10-13
 
 ### Changed

--- a/dataflow/dags/sharepoint_pipelines.py
+++ b/dataflow/dags/sharepoint_pipelines.py
@@ -21,7 +21,11 @@ class _SharepointPipeline(_PipelineDAG):
             task_id='run-fetch',
             python_callable=fetch_from_sharepoint_list,
             provide_context=True,
-            op_args=[self.table_config.table_name, self.sub_site_id, self.list_id],
+            op_args=[
+                self.table_config.table_name,  # pylint: disable=no-member
+                self.sub_site_id,
+                self.list_id,
+            ],
         )
 
 
@@ -58,7 +62,10 @@ class InformationAssetRegisterPipeline(_SharepointPipeline):
                 'Is a sharing agreement in place?',
                 sa.Column('is_sharing_agreement_in_place', sa.String),
             ),
-            ('Sharing agreement link', sa.Column('sharing_agreement_link', sa.String)),
+            (
+                ('Sharing agreement link', 'Url'),
+                sa.Column('sharing_agreement_link', sa.String),
+            ),
             (
                 'Security handling classification',
                 sa.Column('security_handling_classification', sa.String),
@@ -78,7 +85,7 @@ class InformationAssetRegisterPipeline(_SharepointPipeline):
                 sa.Column('type_of_agreement_personal_data_agreement', sa.String),
             ),
             (
-                'Link to agreement for collecting personal data',
+                ('Link to agreement for collecting personal data', 'Url'),
                 sa.Column('link_to_personal_data_agreement', sa.String),
             ),
             (


### PR DESCRIPTION
There is no way to paginate graph api responses when mxing data types (fields vs columns). To fix this a sharepoint request has been broken down into two parts.

1. Fetch the column names for the list
2. Paginate through the list item data

Closes: https://trello.com/c/UOWABZY5/797-information-asset-register-shows-only-first-200-rows
