### PR TITLE
fix: ONSPostcodePipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-15
+
+### Changed
+
+- Update ONSPostcodesPipeline to keep data for all publication dates and add a view per publication
+
 ## 2020-10-14
 
 ### Changed


### PR DESCRIPTION
### Description of change

The ons postcode dataset now keeps track of data for different publication dates. Materialized views allow access to the data for a specefic publication date.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
