### PR TITLE
feat: use shared data infrastructure dev network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,3 +75,7 @@ services:
     links:
       - "data-flow-db"
       - "data-flow-redis"
+
+networks:
+  default:
+    name: data-infrastructure-shared-network

--- a/sample.env
+++ b/sample.env
@@ -44,9 +44,9 @@ AUTHBROKER_ALLOWED_DOMAINS="digital.trade.gov.uk,trade.gov.uk,mobile.ukti.gov.uk
 DATAHUB_BASE_URL=https://datahub-api-demo.london.cloudapps.digital
 FINANCIAL_YEAR_FIRST_DAY_MONTH='4-1'
 COUNTRIES_OF_INTEREST_BASE_URL=https://countries-of-interest-service-dev.london.cloudapps.digital
-DATA_STORE_SERVICE_BASE_URL=https://data-store-service-dev.london.cloudapps.digital
-DATA_STORE_SERVICE_HAWK_ID=get-from-vault
-DATA_STORE_SERVICE_HAWK_KEY=get-from-vault
+DATA_STORE_SERVICE_BASE_URL=http://dss_web:5050
+DATA_STORE_SERVICE_HAWK_ID=create-using-data-store-service-mgmt-command
+DATA_STORE_SERVICE_HAWK_KEY=create-using-data-store-service-mgmt-command
 
 AWS_DEFAULT_REGION=eu-west-2
 AWS_ACCESS_KEY_ID=get-from-cf-service-key


### PR DESCRIPTION
Used a single network for all Data Infrastructure apps/services so that
they can be linked together more easily when working locally, e.g. to
connect data-flow and data-store-service.