### PR TITLE
Less logging to Sentry, more retries and higher delay between them for Activity Stream sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-20
+
+### Changed
+
+- More retrying and longer waits between retries for Activity Stream pipelines
+
 ## 2020-10-16
 
 ### Added

--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -42,7 +42,7 @@ def _hawk_api_request(
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logger.error(f"Request failed: {response.text}")
+        logger.warning(f"Request failed: {response.text}")
         raise
 
     if validate_response:

--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -12,7 +12,9 @@ from mohawk.exc import HawkFail
 from dataflow.utils import S3Data, get_nested_key, logger
 
 
-@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
+@backoff.on_exception(
+    backoff.expo, requests.exceptions.RequestException, max_tries=8, factor=4
+)
 def _hawk_api_request(
     url: str,
     credentials: dict,


### PR DESCRIPTION
### Description of change

We seem to get a separate Sentry event for every Hawk failure, even if they're all raised in the same place. This avoids any Sentry event on all but the last failure.

Also increasing number of attempts and delay between them since if a pipeline fails, suspect the first thing that will be done in most cases would be to retry, so we might as well have more retrying up front.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
