### PR TITLE
feat: longer waitsm more retries, and lower log level for Activity Stream (actually this time)

### DIFF
--- a/dataflow/operators/api.py
+++ b/dataflow/operators/api.py
@@ -32,7 +32,7 @@ def _hawk_api_request(
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logger.error(f"Request failed: {response.text}")
+        logger.warning(f"Request failed: {response.text}")
         raise
 
     response_json = response.json()

--- a/dataflow/operators/api.py
+++ b/dataflow/operators/api.py
@@ -7,7 +7,9 @@ from mohawk import Sender
 from dataflow.utils import logger
 
 
-@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
+@backoff.on_exception(
+    backoff.expo, requests.exceptions.RequestException, max_tries=8, factor=4
+)
 def _hawk_api_request(
     url: str,
     method: str,


### PR DESCRIPTION
### Description of change

Increasing number of attempts and delay between them since if a pipeline fails, suspect the first thing that will be done in most cases would be to retry, so we might as well have more retrying up front.

We also seem to get a separate Sentry event for every Hawk failure, even if they're all raised in the same place. This avoids any Sentry event on all but the last failure.

This was initially attempted in 3ec893d76be97319157bae0ca3e5ac248c9cad46 and 890ff970845c97bf6de356a6dda3d790bbf6af58, but that changed the wrong `_hawk_api_request` function.

Leaving potentially merging the two functions until later.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
