### PR TITLE
fix: update lite pipelines to match data standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-22
+
+### Changed
+
+- Rename and move LITE to tables to dit schema 
+
 ## 2020-10-21
 
 ### Changed

--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -416,7 +416,8 @@ class LITECasesPipeline(_ActivityStreamPipeline):
     name = "lite-cases"
     index = "activities"
     table_config = TableConfig(
-        table_name="lite_cases",
+        schema='dit',
+        table_name="lite__cases",
         field_mapping=[
             (("object", "id"), sa.Column("id", sa.String, primary_key=True)),
             (("object", "dit:caseOfficer"), sa.Column("case_officer", sa.String)),
@@ -434,7 +435,8 @@ class LITECaseChangesPipeline(_ActivityStreamPipeline):
     name = "lite-case-changes"
     index = "activities"
     table_config = TableConfig(
-        table_name="lite_case_changes",
+        schema='dit',
+        table_name="lite__case_changes",
         field_mapping=[
             (("object", "id"), sa.Column("id", sa.String, primary_key=True)),
             (("object", "dit:from"), sa.Column("case_from", sa.JSON)),


### PR DESCRIPTION
Rename lite to match naming conventions before we turn them on on prod
