### PR TITLE
feature: zendesk pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-28
+
+### Added
+
+- Pipeline for DIT zendesk tickets (ZendeskDITTradeTicketsPipeline)
+- Pipeline for UKTrade zendesk tickets (ZendeskUKTradeTicketsPipeline)
+
 ## 2020-10-26
 
 ### Added
 
-- New pipeline for companies house significant persons of control 
+- New pipeline for companies house significant persons of control
 
 ## 2020-10-22
 

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -124,3 +124,10 @@ DEFAULT_DATABASE_GRANTEES = (
 COMPANIES_HOUSE_PSC_TOTAL_FILES = int(
     os.environ.get('COMPANIES_HOUSE_PSC_TOTAL_FILES', 1)
 )
+ZENDESK_CREDENTIALS = {
+    'uktrade': {
+        'url': os.environ.get("ZENDESK_UKTRADE_URL") or "<invalid>",
+        'email': os.environ.get("ZENDESK_UKTRADE_EMAIL") or "<invalid>",
+        'secret': os.environ.get("ZENDESK_UKTRADE_SECRET") or "<invalid>",
+    },
+}

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -125,6 +125,11 @@ COMPANIES_HOUSE_PSC_TOTAL_FILES = int(
     os.environ.get('COMPANIES_HOUSE_PSC_TOTAL_FILES', 1)
 )
 ZENDESK_CREDENTIALS = {
+    'dit': {
+        'url': os.environ.get("ZENDESK_DIT_URL") or "<invalid>",
+        'email': os.environ.get("ZENDESK_DIT_EMAIL") or "<invalid>",
+        'secret': os.environ.get("ZENDESK_DIT_SECRET") or "<invalid>",
+    },
     'uktrade': {
         'url': os.environ.get("ZENDESK_UKTRADE_URL") or "<invalid>",
         'email': os.environ.get("ZENDESK_UKTRADE_EMAIL") or "<invalid>",

--- a/dataflow/dags/zendesk_pipelines.py
+++ b/dataflow/dags/zendesk_pipelines.py
@@ -1,0 +1,94 @@
+import sqlalchemy as sa
+from airflow.operators.python_operator import PythonOperator
+
+from dataflow.dags import _PipelineDAG
+from dataflow.operators.zendesk import fetch_daily_tickets
+from dataflow.utils import TableConfig
+
+FIELD_MAPPING = [
+    ("id", sa.Column("id", sa.BigInteger, primary_key=True)),
+    ("external_id", sa.Column("external_id", sa.BigInteger)),
+    ("via", sa.Column("via", sa.JSON)),
+    ("created_at", sa.Column("created_at", sa.DateTime)),
+    ("updated_at", sa.Column("updated_at", sa.DateTime)),
+    ("subject", sa.Column("subject", sa.String)),
+    ("description", sa.Column("description", sa.String)),
+    ("service", sa.Column("service", sa.String)),
+    ("priority", sa.Column("priority", sa.String)),
+    ("status", sa.Column("status", sa.String)),
+    ("recipient", sa.Column("recipient", sa.String)),
+    ("requester_id", sa.Column("requester_id", sa.BigInteger)),
+    ("submitter_id", sa.Column("submitter_id", sa.BigInteger)),
+    ("assignee_id", sa.Column("assignee_id", sa.BigInteger)),
+    ("organization_id", sa.Column("organization_id", sa.BigInteger)),
+    ("group_id", sa.Column("group_id", sa.BigInteger)),
+    ("collaborator_ids", sa.Column("collaborator_ids", sa.ARRAY(sa.BigInteger))),
+    ("follower_ids", sa.Column("follower_ids", sa.ARRAY(sa.BigInteger))),
+    ("email_cc_ids", sa.Column("email_cc_ids", sa.ARRAY(sa.BigInteger))),
+    ("has_incidents", sa.Column("has_incidents", sa.Boolean)),
+    ("is_public", sa.Column("is_public", sa.Boolean)),
+    ("due_at", sa.Column("due_at", sa.DateTime)),
+    ("tags", sa.Column("tags", sa.ARRAY(sa.String))),
+    ("satisfaction_rating", sa.Column("satisfaction_rating", sa.JSON)),
+    (
+        "sharing_agreement_ids",
+        sa.Column("sharing_agreement_ids", sa.ARRAY(sa.BigInteger)),
+    ),
+    ("brand_id", sa.Column("brand_id", sa.BigInteger)),
+    ("allow_channelback", sa.Column("allow_channelback", sa.Boolean)),
+    ("allow_attachments", sa.Column("allow_attachments", sa.Boolean)),
+]
+
+
+def field_transformation(record, table_config, contexts):
+    """
+    Transform data export fields to match those of the Zendesk API.
+    Get custom service field value.
+    """
+
+    service = next(
+        field for field in record["custom_fields"] if field["id"] == 31281329
+    )
+    if "requester" in record:
+        return {
+            **record,
+            "submitter_id": record["submitter"]["id"],
+            "requester_id": record["requester"]["id"],
+            "assignee_id": record.get("assignee")["id"]
+            if record.get("assignee")
+            else None,
+            "group_id": record.get("group")["id"] if record.get("group") else None,
+            "collaborator_ids": [
+                collaborator["id"] for collaborator in record["collaborator"]
+            ],
+            "organization_id": record["organization"]["id"]
+            if record.get("organization")
+            else None,
+            "service": service["value"],
+        }
+    else:
+        return {**record, "service": service["value"]}
+
+
+class ZendeskUKTradeTicketsPipeline(_PipelineDAG):
+    schedule_interval = "@daily"
+    allow_null_columns = True
+    use_utc_now_as_source_modified = True
+    table_config = TableConfig(
+        schema="zendesk",
+        table_name="uktrade_tickets",
+        transforms=[field_transformation],
+        field_mapping=FIELD_MAPPING,
+    )
+
+    def get_fetch_operator(self) -> PythonOperator:
+        return PythonOperator(
+            task_id="fetch-daily-tickets",
+            python_callable=fetch_daily_tickets,
+            provide_context=True,
+            op_args=[
+                self.table_config.schema,
+                self.table_config.table_name,
+                "uktrade",
+            ],
+        )

--- a/dataflow/dags/zendesk_pipelines.py
+++ b/dataflow/dags/zendesk_pipelines.py
@@ -10,7 +10,12 @@ FIELD_MAPPING = [
     ("external_id", sa.Column("external_id", sa.BigInteger)),
     ("via", sa.Column("via", sa.JSON)),
     ("created_at", sa.Column("created_at", sa.DateTime)),
+    ("solved_at", sa.Column("solved_at", sa.DateTime)),
     ("updated_at", sa.Column("updated_at", sa.DateTime)),
+    (
+        "full_resolution_time_in_minutes",
+        sa.Column("full_resolution_time_in_minutes", sa.Integer),
+    ),
     ("subject", sa.Column("subject", sa.String)),
     ("description", sa.Column("description", sa.String)),
     ("service", sa.Column("service", sa.String)),
@@ -65,6 +70,10 @@ def field_transformation(record, table_config, contexts):
             if record.get("organization")
             else None,
             "service": service["value"],
+            "solved_at": record["metric_set"]["solved_at"],
+            "full_resolution_time_in_minutes": record["metric_set"][
+                "full_resolution_time_in_minutes"
+            ]["calendar"],
         }
     else:
         return {**record, "service": service["value"]}

--- a/dataflow/operators/zendesk.py
+++ b/dataflow/operators/zendesk.py
@@ -1,0 +1,65 @@
+import base64
+import itertools
+from datetime import timedelta
+
+import backoff
+import requests
+
+from dataflow import config
+from dataflow.utils import S3Data, S3Upstream, logger
+
+
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
+def _query(url, account):
+    email = config.ZENDESK_CREDENTIALS[account]["email"]
+    secret = config.ZENDESK_CREDENTIALS[account]["secret"]
+    token = base64.b64encode(f"{email}/token:{secret}".encode()).decode()
+    response = requests.get(
+        url=url,
+        headers={"Authorization": f"Basic {token}", "Content-Type": "application/json"},
+    )
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        logger.exception(f"Request failed: {response.text}")
+        raise
+    return response.json()
+
+
+def fetch_daily_tickets(
+    schema_name: str, table_name: str, account: str, **kwargs,
+):
+    """
+    Download zendesk json data and reformat it for ingestion into table
+    """
+
+    today = kwargs["execution_date"]
+    yesterday = (today - timedelta(days=1)).strftime("%Y%m%d")
+    logger.info(f"Fetching data from source for day '{yesterday}' on '{today}'")
+
+    results = []
+    query = f"type:ticket updated:{yesterday} status:closed"
+    base_url = config.ZENDESK_CREDENTIALS[account]["url"]
+
+    for page in itertools.count(1):
+        url = f"{base_url}/search.json?query={query}&sort_by=created_at&sort_order=asc&page={page}"
+        data = _query(url=url, account=account)
+        results.extend(data["results"])
+        if not data["next_page"]:
+            break
+        if page >= 11:
+            raise Exception("Too many iterations")
+
+    s3upstream = S3Upstream(f"{schema_name}_{table_name}")
+    s3upstream.write_key(f"{yesterday}.json", results, jsonify=True)
+    logger.info("Fetching from source completed")
+
+    s3data = S3Data(table_name, kwargs["ts_nodash"])
+    for source in s3upstream.list_keys():
+        s3data.client.copy_object(
+            source_bucket_key=source,
+            dest_bucket_key=source.replace(s3upstream.prefix, s3data.prefix),
+            source_bucket_name=s3data.bucket,
+            dest_bucket_name=s3data.bucket,
+        )
+    logger.info("Copy from upstream completed")

--- a/tests/unit/operators/test_zendesk.py
+++ b/tests/unit/operators/test_zendesk.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from unittest import mock
+
+import pytest
+import requests
+
+from dataflow.operators import zendesk
+
+ZENDESK_CREDENTIALS = {
+    "test": {"url": "local.host", "email": "EMAIL", "secret": "SECRET"}
+}
+
+
+def test_query_fail(mocker, requests_mock):
+    url = "http://local.host/404"
+    mocker.patch("time.sleep")
+    mocker.patch.object(zendesk.config, "ZENDESK_CREDENTIALS", ZENDESK_CREDENTIALS)
+    requests_mock.get(url, status_code=404)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        zendesk._query(url, "test")
+
+
+def test_zendesk_fetch_daily_tickets(mocker):
+    fn = "file-name"
+    s3_data = mock.Mock(bucket="bucket", prefix="prefix-data")
+    s3_upstream = mock.Mock(
+        bucket="bucket",
+        prefix="prefix-upstream",
+        list_keys=lambda: [f"{s3_upstream.prefix}/{fn}"],
+    )
+
+    query = mock.Mock(on_exception=mock.Mock())
+    data = [{"results": [{"a": 1}], "count": 1, "next_page": None}]
+
+    mocker.patch.object(zendesk.config, "ZENDESK_CREDENTIALS", ZENDESK_CREDENTIALS)
+    mocker.patch.object(zendesk, "S3Data", return_value=s3_data, autospec=True)
+    mocker.patch.object(zendesk, "S3Upstream", return_value=s3_upstream, autospec=True)
+    mocker.patch.object(
+        zendesk, "_query", return_value=query, side_effect=data, autospec=True
+    )
+
+    zendesk.fetch_daily_tickets(
+        schema_name="schema",
+        table_name="test-table",
+        account="test",
+        execution_date=datetime(2000, 12, 23, 0, 11, 22),
+        ts_nodash="20001223T001122",
+    )
+    assert s3_upstream.write_key.call_args == mock.call(
+        "20001222.json", [{"a": 1}], jsonify=True
+    )
+    assert s3_data.client.copy_object.call_args == mock.call(
+        source_bucket_key=f"{s3_upstream.prefix}/{fn}",
+        dest_bucket_key=f"{s3_data.prefix}/{fn}",
+        source_bucket_name="bucket",
+        dest_bucket_name="bucket",
+    )

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -98,5 +98,6 @@ def test_pipelines_dags():
         'StaffSSOUsersPipeline',
         'TagsClassifierPipeline',
         'TeamsDatasetPipeline',
+        'ZendeskDITTicketsPipeline',
         'ZendeskUKTradeTicketsPipeline',
     }

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -98,4 +98,5 @@ def test_pipelines_dags():
         'StaffSSOUsersPipeline',
         'TagsClassifierPipeline',
         'TeamsDatasetPipeline',
+        'ZendeskUKTradeTicketsPipeline',
     }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -166,6 +166,21 @@ def test_s3_data_list_keys_retries_requests(mocker):
     assert s3.list_keys() == []
 
 
+@pytest.mark.parametrize(
+    "table_name, extra_path, expected",
+    [
+        ("table", None, "upstream/table/"),
+        ("table", "", "upstream/table/"),
+        ("table", "path", "upstream/table/path/"),
+        ("table", "path/", "upstream/table/path/"),
+        ("table", "/", "upstream/table//"),
+    ],
+)
+def test_s3_upstream(table_name, extra_path, expected):
+    s3 = utils.S3Upstream(table_name=table_name, extra_path=extra_path)
+    assert s3.prefix == expected
+
+
 class TestTableConfig:
     def test_columns_property_only_returns_immediate_columns(self):
         id_col = ("id", Column("id", Integer))


### PR DESCRIPTION
### Description of change
Two new zendesk pipelines were added for storing zendesk tickets for `DIT` and `UKTRADE` zendesk account.

#### Details
- new schema `zendesk` in `datasets` database
- new tables in database `datasets` on `zendesk` schema 
  - `dit_tickets`
  - `uktrade_tickets`
- adding new directory in bucket named `upstream` for persistent storage of files
- files in `import-data` can be deleted after few days

#### Process
- at least once a day each pipeline is executed
- task fetches daily tickets data from zendesk API
- daily data is stored in `upstream` directory ie `upstream/zendesk_<table_name>/20201122.json`
- all files in directory `upstream/zendesk_<table_name>/` are copied to `import-data/<table_name>/<ts_nohash>/`
- these files are processed into a `datasets` table as in any other pipeline

#### Configuration
This variables have to be added to configuration
- `ZENDESK_DIT_URL`
- `ZENDESK_DIT_EMAIL`
- `ZENDESK_DIT_SECRET`
- `ZENDESK_UKTRADE_URL`
- `ZENDESK_UKTRADE_EMAIL`
- `ZENDESK_UKTRADE_SECRET`


Please, comment on decisions made regarding new schema, pipeline and table names, s3 directory structures etc. as well as on other common issues.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
