### PR TITLE
feat: companies house persons of control pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-26
+
+### Added
+
+- New pipeline for companies house significant persons of control 
+
 ## 2020-10-22
 
 ### Changed

--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -24,7 +24,7 @@ DATAHUB_HAWK_CREDENTIALS = {
 DATAHUB_BASE_URL = os.environ.get("DATAHUB_BASE_URL")
 EXPORT_WINS_BASE_URL = os.environ.get("EXPORT_WINS_BASE_URL")
 
-DEBUG = True if os.environ.get("DEBUG") == "True" else False
+DEBUG = os.environ.get("DEBUG") == "True"
 REDIS_URL = os.environ.get("AIRFLOW__CELERY__BROKER_URL")
 COUNTRIES_OF_INTEREST_BASE_URL = os.environ.get(
     "COUNTRIES_OF_INTEREST_BASE_URL", "localhost:5000"
@@ -119,4 +119,8 @@ DEFAULT_DATABASE_GRANTEES = (
     os.environ.get('DEFAULT_DATABASE_GRANTEES', '').split(',')
     if os.environ.get('DEFAULT_DATABASE_GRANTEES') is not None
     else []
+)
+
+COMPANIES_HOUSE_PSC_TOTAL_FILES = int(
+    os.environ.get('COMPANIES_HOUSE_PSC_TOTAL_FILES', 1)
 )

--- a/dataflow/operators/companies_house.py
+++ b/dataflow/operators/companies_house.py
@@ -1,12 +1,13 @@
 import codecs
 import csv
 import io
+import json
 import zipfile
 from datetime import datetime
-
 import backoff
 import requests
 
+from dataflow import config
 from dataflow.utils import S3Data, logger
 
 
@@ -17,7 +18,7 @@ def _download(source_url):
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logger.error(f"Request failed: {response.text}")
+        logger.error("Request failed: %s", response.text)
         raise
 
     return response.content
@@ -44,7 +45,7 @@ def fetch_companies_house_companies(
         url = source_url.format(
             file_date=publish_date, file_num=file_num, num_files=number_of_files,
         )
-        logger.info(f'Fetching zip file from {url}')
+        logger.info('Fetching zip file from %s', url)
         with zipfile.ZipFile(io.BytesIO(_download(url))) as archive:
             with archive.open(archive.namelist()[0], 'r') as f:
                 reader = csv.DictReader(codecs.iterdecode(f.readlines(), 'utf-8'))
@@ -62,3 +63,26 @@ def fetch_companies_house_companies(
         s3.write_key(f'{page:010}.json', results)
 
     logger.info('Fetching from source completed')
+
+
+def fetch_companies_house_significant_persons(
+    table_name: str, source_url: str, **kwargs,
+):
+    s3 = S3Data(table_name, kwargs['ts_nodash'])
+    page_size = 10000
+    page = 1
+    results = []
+    for file in range(1, config.COMPANIES_HOUSE_PSC_TOTAL_FILES + 1):
+        url = source_url.format(file=file, total=config.COMPANIES_HOUSE_PSC_TOTAL_FILES)
+        logger.info('Fetching zip file from %s', url)
+        with zipfile.ZipFile(io.BytesIO(_download(url))) as archive:
+            with archive.open(archive.namelist()[0], 'r') as f:
+                for line in f.readlines():
+                    results.append(json.loads(line))
+                    if len(results) >= page_size:
+                        s3.write_key(f'{page:010}.json', results)
+                        results = []
+                        page += 1
+    if results:
+        s3.write_key(f'{page:010}.json', results)
+    logger.info("Fetching from source completed")

--- a/sample.env
+++ b/sample.env
@@ -101,3 +101,5 @@ NOTIFY_API_KEY=test-key
 NOTIFY_TEMPLATE_ID__DATASET_UPDATED=get-from-notify
 
 UPDATE_EMAILS_DATA__ONSUKSATradeInGoodsPollingPipeline={"dataset_name": "My nice dataset", "dataset_url": "https://data.trade.gov.uk/dataset-1", "emails": []}
+
+COMPANIES_HOUSE_PSC_TOTAL_FILES=17

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -13,6 +13,7 @@ def test_pipelines_dags():
         'CompaniesDatasetPipeline',
         'CompaniesHouseCompaniesPipeline',
         'CompaniesHouseMatchingPipeline',
+        'CompaniesHousePeopleWithSignificantControlPipeline',
         'CompanyExportCountry',
         'CompanyExportCountryHistory',
         'ConsentPipeline',


### PR DESCRIPTION
Adds companies house "persons with significant control" pipeline. 

The data is currently comprised of ~8 million records spread across 17 files. This PR adds a new environment variable `COMPANIES_HOUSE_PSC_TOTAL_FILES` which will need to be updated if/when a new file is added.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
