### PR TITLE
Update fields and exclude covid tickets in zendesk DIT pipeline

### DIFF
--- a/dataflow/config.py
+++ b/dataflow/config.py
@@ -124,6 +124,9 @@ DEFAULT_DATABASE_GRANTEES = (
 COMPANIES_HOUSE_PSC_TOTAL_FILES = int(
     os.environ.get('COMPANIES_HOUSE_PSC_TOTAL_FILES', 1)
 )
+
+ZENDESK_COVID_EMAIL_ADDRESS = os.environ.get("ZENDESK_COVID_EMAIL_ADDRESS", "")
+
 ZENDESK_CREDENTIALS = {
     'dit': {
         'url': os.environ.get("ZENDESK_DIT_URL") or "<invalid>",

--- a/dataflow/dags/zendesk_pipelines.py
+++ b/dataflow/dags/zendesk_pipelines.py
@@ -26,6 +26,22 @@ def transforms_fields_dit(record, table_config, contexts):
             "value"
         ]
 
+    if "assignee" in record:
+        return {
+            **record,
+            "assignee_id": record.get("assignee")["id"]
+            if record.get("assignee")
+            else None,
+            "group_id": record.get("group")["id"] if record.get("group") else None,
+            "organization_id": record["organization"]["id"]
+            if record.get("organization")
+            else None,
+            "solved_at": record["metric_set"]["solved_at"],
+            "full_resolution_time_in_minutes": record["metric_set"][
+                "full_resolution_time_in_minutes"
+            ]["calendar"],
+        }
+
     return record
 
 

--- a/sample.env
+++ b/sample.env
@@ -103,3 +103,5 @@ NOTIFY_TEMPLATE_ID__DATASET_UPDATED=get-from-notify
 UPDATE_EMAILS_DATA__ONSUKSATradeInGoodsPollingPipeline={"dataset_name": "My nice dataset", "dataset_url": "https://data.trade.gov.uk/dataset-1", "emails": []}
 
 COMPANIES_HOUSE_PSC_TOTAL_FILES=17
+
+ZENDESK_COVID_EMAIL_ADDRESS=get-from-vault

--- a/tests/unit/operators/test_zendesk.py
+++ b/tests/unit/operators/test_zendesk.py
@@ -60,3 +60,23 @@ def test_zendesk_fetch_daily_tickets(mocker):
         source_bucket_name="bucket",
         dest_bucket_name="bucket",
     )
+
+
+def test_remove_covid_related_tickets(mocker):
+    mocker.patch.object(
+        zendesk.config, "ZENDESK_COVID_EMAIL_ADDRESS", "covid@email.test"
+    )
+    non_covid_ticket = {
+        "id": 1,
+        "via": {"channel": "api", "source": {"from": {}, "to": {}}},
+    }
+    covid_ticket = {
+        "id": 2,
+        "via": {
+            "channel": "email",
+            "source": {"to": {"name": "test", "address": "covid@email.test"}},
+        },
+    }
+    results = [non_covid_ticket, covid_ticket, covid_ticket]
+
+    assert zendesk._remove_covid_related_tickets(results) == [non_covid_ticket]


### PR DESCRIPTION
### Description of change

This PR adds a function in the `fetch-daily-tickets` which removes tickets related to covid19 from the `DITZendeskPipeline`, as these tickets are not necessary to bring in to Data Workspace. 

It also adds logic to transform fields from the data export to match the structure of the fields from the API in the `DITZendeskTicketsPipeline`.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-flow/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
