### PR TITLE
Add zendesk groups pipelines

### DIFF
--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -1,7 +1,7 @@
 import codecs
 import csv
 from contextlib import closing
-from typing import Optional, Union
+from typing import Mapping, Optional, Union
 
 import backoff
 import jwt
@@ -129,6 +129,8 @@ def fetch_from_api_endpoint(
     auth_token: Optional[str] = None,
     results_key: Optional[str] = "results",
     next_key: Optional[str] = "next",
+    auth_type: Optional[str] = "Token",
+    extra_headers: Optional[Mapping] = None,
     **kwargs,
 ):
     s3 = S3Data(table_name, kwargs["ts_nodash"])
@@ -138,7 +140,12 @@ def fetch_from_api_endpoint(
     while True:
         response = requests.get(
             source_url,
-            headers={'Authorization': f'Token {auth_token}'} if auth_token else None,
+            headers={
+                'Authorization': f'{auth_type} {auth_token}',
+                **(extra_headers or {}),
+            }
+            if auth_token
+            else None,
         )
 
         try:

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -99,5 +99,7 @@ def test_pipelines_dags():
         'TagsClassifierPipeline',
         'TeamsDatasetPipeline',
         'ZendeskDITTicketsPipeline',
+        'ZendeskDITGroupsPipeline',
         'ZendeskUKTradeTicketsPipeline',
+        'ZendeskUKTRadeGroupsPipeline',
     }


### PR DESCRIPTION
### Description of change

This PR adds two pipelines which bring in groups data from zendesk on a weekly basis. These tables can then be joined with the zendesk tickets tables to get information about the groups within DIT who are handling tickets. 

As the zendesk API requires a `basic` auth token and a specific content type, this PR also adds two new optional arguments to `fetch_from_api_endpoint` operator which allow for specifying the auth type and any additional headers.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
