### PR TITLE
feat: avoid storing all JSON in memory when loading from S3

### DIFF
--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -1,10 +1,6 @@
-import csv
-
 import datetime
-import itertools
 import tempfile
 import warnings
-from io import StringIO
 from time import sleep
 from typing import Tuple, Dict, Optional, TYPE_CHECKING
 
@@ -225,64 +221,6 @@ def insert_data_into_db(
                     )
 
         logger.info('Page %s ingested successfully', page)
-
-    if count == 0:
-        raise MissingDataError("There are no pages of records in S3 to insert.")
-
-
-def insert_csv_data_into_db(
-    target_db: str, table_config: TableConfig, contexts: Tuple = tuple(), **kwargs,
-):
-    """Insert fetched response data into temporary DB tables.
-
-    Goes through the stored response contents and loads individual
-    records into the temporary DB table.
-
-    DB columns are populated according to the field mapping, which
-    if as list of `(response_field, column)` tuples, where field
-    can either be a string or a tuple of keys/indexes forming a
-    path for a nested value.
-
-    """
-    table_config.configure(**kwargs)
-    s3 = S3Data(table_config.table_name, kwargs["ts_nodash"])
-
-    engine = sa.create_engine(
-        'postgresql+psycopg2://',
-        creator=PostgresHook(postgres_conn_id=target_db).get_conn,
-    )
-
-    count = 0
-    done = 0
-    for page, data in s3.iter_keys(json=False):
-        logger.info('Processing page %s', page)
-        count += 1
-
-        with engine.begin() as conn:
-            reader = csv.DictReader(StringIO(data))
-
-            while True:
-                records = list(itertools.islice(reader, 10000))
-                if not records:
-                    break
-
-                logger.info("Ingesting records %s - %s ...", done, done + len(records))
-                transformed_records = []
-                for record in records:
-                    for transform in table_config.transforms:
-                        record = transform(record, table_config, contexts)  # type: ignore
-                    transformed_records.append(record)
-
-                conn.execute(
-                    table_config.temp_table.insert(),
-                    [
-                        _get_data_to_insert(table_config.columns, record)
-                        for record in transformed_records
-                    ],
-                )
-                done += len(records)
-
-        logger.info('File %s ingested successfully', page)
 
     if count == 0:
         raise MissingDataError("There are no pages of records in S3 to insert.")

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -15,6 +15,7 @@ from airflow.contrib.hooks.slack_webhook_hook import SlackWebhookHook
 from airflow.hooks.S3_hook import S3Hook
 from airflow.utils.state import State
 from cached_property import cached_property
+from splitstream import splitfile
 from typing_extensions import Protocol
 
 from dataflow import config
@@ -209,6 +210,45 @@ class S3JsonEncoder(JSONEncoder):
         super().default(o)
 
 
+def iterate_generator_immediately(generator_function):
+    """Iterates a generator function once when its called
+
+    A generator function is "lazy": it doesn't do anything until its called
+    _and then_ iterated over. Usually, this is fine. However, if on the first
+    iteration, exceptions can be raised, such as from connection errors, this
+    can be too late, and not desirable to handle this when iterating from a
+    code-structure point of view
+
+    So, we decorate the generator function, returning a regular function that
+    returns a generator. The call of the function does the first iteration, so
+    it raises exceptions as needed, caches the first item, which is then
+    yielded when the generator is subsequently iterated over.
+    """
+
+    def _regular_function(*args, **kwargs):
+
+        generator = generator_function(*args, **kwargs)
+
+        empty = False
+        try:
+            item = next(generator)
+        except StopIteration:
+            empty = True
+
+        def _generator_function():
+            nonlocal item
+            if empty:
+                return
+
+            yield item
+            for item in generator:
+                yield item
+
+        return _generator_function()
+
+    return _regular_function
+
+
 class S3Data:
     def __init__(self, table_name, ts_nodash):
         self.client = S3Hook("DEFAULT_S3")
@@ -226,9 +266,9 @@ class S3Data:
             data, self.prefix + key, bucket_name=self.bucket, replace=True, encrypt=True
         )
 
-    def iter_keys(self, json=True):
+    def iter_keys(self):
         for key in self.list_keys():
-            yield key, self.read_key(key, jsonify=json)
+            yield key, self.read_key(key)
 
     @backoff.on_exception(
         backoff.expo, botocore.exceptions.EndpointConnectionError, max_tries=5
@@ -239,9 +279,14 @@ class S3Data:
     @backoff.on_exception(
         backoff.expo, botocore.exceptions.EndpointConnectionError, max_tries=5
     )
-    def read_key(self, full_key, jsonify=True):
-        data = self.client.read_key(full_key, bucket_name=self.bucket)
-        return json.loads(data) if jsonify else data
+    @iterate_generator_immediately
+    def read_key(self, full_key):
+        s3_object = self.client.get_key(full_key, bucket_name=self.bucket)
+        records_bytes = splitfile(
+            s3_object.get()['Body'], format="json", startdepth=1, bufsize=65536
+        )
+        for record_bytes in records_bytes:
+            yield json.loads(record_bytes)
 
 
 class S3Upstream(S3Data):

--- a/requirements-tensorflow.txt
+++ b/requirements-tensorflow.txt
@@ -154,6 +154,7 @@ sentry-sdk==0.17.0        # via apache-airflow
 setproctitle==1.1.10      # via apache-airflow
 six==1.15.0               # via absl-py, astunparse, cryptography, flask-jwt-extended, google-auth, google-pasta, grpcio, h5py, html5lib, isodate, jsonschema, keras-preprocessing, mohawk, prison, protobuf, pyrsistent, python-dateutil, slackclient, sqlalchemy-utils, tenacity, tensorboard, tensorflow, thrift, traitlets, websocket-client
 slackclient==1.3.2        # via apache-airflow
+splitstream==1.2.4        # via -r requirements.in
 sqlalchemy-jsonfield==0.9.0  # via apache-airflow
 sqlalchemy-utils==0.36.8  # via flask-appbuilder
 sqlalchemy==1.3.19        # via alembic, apache-airflow, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-jsonfield, sqlalchemy-utils

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ git+https://github.com/GSS-Cogs/gss-utils.git@6439568a04c177a117cf8038dbee1678c9
 zipstream
 scikit-learn==0.22.2.post1
 git+https://github.com/uktrade/data-flow-metrics.git
+splitstream==1.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ html2text==2020.1.16      # via gssutils
 html5lib==1.1             # via messytables
 humanize==2.6.0           # via flower
 idna==2.10                # via email-validator, requests
+importlib-metadata==1.7.0  # via argcomplete, jsonschema, kombu
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.18.1           # via gssutils
 iso8601==0.1.12           # via apache-airflow
@@ -138,6 +139,7 @@ sentry-sdk==0.17.4        # via apache-airflow
 setproctitle==1.1.10      # via apache-airflow
 six==1.15.0               # via cryptography, flask-jwt-extended, html5lib, isodate, jsonschema, mohawk, prison, pyrsistent, python-dateutil, slackclient, sqlalchemy-utils, tenacity, thrift, websocket-client
 slackclient==1.3.2        # via apache-airflow
+splitstream==1.2.4        # via -r requirements.in
 sqlalchemy-jsonfield==0.9.0  # via apache-airflow
 sqlalchemy-utils==0.36.8  # via flask-appbuilder
 sqlalchemy==1.3.19        # via alembic, apache-airflow, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-jsonfield, sqlalchemy-utils
@@ -148,7 +150,7 @@ texttable==1.6.3          # via pyexcel
 thrift==0.13.0            # via apache-airflow
 tornado==5.1.1            # via apache-airflow, flower
 traitlets==5.0.4          # via ipython
-typing-extensions==3.7.4.3  # via -r requirements.in
+typing-extensions==3.7.4.3  # via -r requirements.in, apache-airflow
 tzlocal==1.5.1            # via apache-airflow, pendulum
 unicodecsv==0.14.1        # via apache-airflow
 unidecode==1.1.1          # via gssutils
@@ -164,6 +166,7 @@ xlrd==1.2.0               # via messytables, pyexcel-xls, xlutils
 xlutils==2.0.0            # via databaker
 xlwt==1.3.0               # via pyexcel-xls, xlutils
 xypath==1.1.1             # via databaker, gssutils
+zipp==3.4.0               # via importlib-metadata
 zipstream==1.1.4          # via -r requirements.in
 zope.deprecation==4.4.0   # via apache-airflow
 


### PR DESCRIPTION
### Description of change

In some cases, we load JSON manually into S3, and in some of those, the JSON is larger than 1GB. Before this commit, this data is loaded into memory at least twice, and most workers don't have enough memory for this.

We could bump the memory, but in general, I think we should be making small moves to reduce memory usage/support streaming, in order to support larger datasets that can't be loaded into memory on a single machine.

The use of the function insert_csv_data_into_db was removed in 2792f69f18c24e6741fea83f9bdbccab11ab28ee, and this was the only use of json=False/jsonify=False, so opting to remove the function and these attributes.

### Checklist

* [x] Have tests been added to cover any changes?

~* [ ] Has the README been updated (if needed)?~
