### PR TITLE
Revert "fix: update ONS schedules for delayed data release"

### DIFF
--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -90,7 +90,7 @@ class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(_FastPollingPipelin
         get_data,
     )
 
-    schedule_interval = "0 6 * * *"
+    schedule_interval = "0 6 20-31 1,4,7,10 *"
 
     date_checker = get_current_and_next_release_date
     data_getter = get_data
@@ -124,7 +124,7 @@ class ONSUKTotalTradeAllCountriesNSAPollingPipeline(_FastPollingPipeline):
         get_data,
     )
 
-    schedule_interval = "0 6 * * *"
+    schedule_interval = "0 6 20-31 1,4,7,10 *"
 
     date_checker = get_current_and_next_release_date
     data_getter = get_data


### PR DESCRIPTION
Reverts uktrade/data-flow#403

We temporarily expanded the pipeline schedule for these ONS tasks due to delayed data releases. Now that these have both run, we can switch them back to a fortnight (ish) window every quarter.