### PR TITLE
Account for 'organization' being an int or dict

### DIFF
--- a/dataflow/dags/zendesk_pipelines.py
+++ b/dataflow/dags/zendesk_pipelines.py
@@ -59,6 +59,7 @@ def transforms_fields_uktrade(record, table_config, contexts):
         field for field in record["custom_fields"] if field["id"] == 31281329
     )
     if "requester" in record:
+        org = record['organization']
         return {
             **record,
             "submitter_id": record["submitter"]["id"],
@@ -70,9 +71,7 @@ def transforms_fields_uktrade(record, table_config, contexts):
             "collaborator_ids": [
                 collaborator["id"] for collaborator in record["collaborator"]
             ],
-            "organization_id": record["organization"]["id"]
-            if record.get("organization")
-            else None,
+            "organization_id": org['id'] if isinstance(org, dict) else org,
             "service": service["value"],
             "solved_at": record["metric_set"]["solved_at"],
             "full_resolution_time_in_minutes": record["metric_set"][


### PR DESCRIPTION
### Description of change

This PR fixes a bug occurring in production when processing the `uktrade_zendesk_past_tickets` file. 

Previously I had thought that if there was a value for the `organization` key in a ticket, it would be a dict with an `id` key, however it turns out there are two tickets for which organization is an int. This PR adds logic to be able to handle both cases.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
