### PR TITLE
fix: correct MaxEmail event pipeline

### DIFF
--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -610,10 +610,10 @@ class MaxemailEventsPipeline(_ActivityStreamPipeline):
             },
             lambda record, table_config, contexts: {
                 **record,
-                "__bounced_reason": record["content"]
+                "__bounced_reason": record["object"]["content"]
                 if record["__type"] == "bounced"
                 else None,
-                "__clicked_url": record["url"]
+                "__clicked_url": record["object"]["url"]
                 if record["__type"] == "clicked"
                 else None,
             },


### PR DESCRIPTION
### Description of change

The URL and bounced reasons are on `object`, not on the top level

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
