### PR TITLE
feat: use less memory in Companies House pipelines

### DIFF
--- a/dataflow/operators/companies_house.py
+++ b/dataflow/operators/companies_house.py
@@ -48,7 +48,7 @@ def fetch_companies_house_companies(
         logger.info('Fetching zip file from %s', url)
         with zipfile.ZipFile(io.BytesIO(_download(url))) as archive:
             with archive.open(archive.namelist()[0], 'r') as f:
-                reader = csv.DictReader(codecs.iterdecode(f.readlines(), 'utf-8'))
+                reader = csv.DictReader(codecs.iterdecode(f, 'utf-8'))
                 if reader.fieldnames is not None:
                     reader.fieldnames = [x.strip() for x in reader.fieldnames]
                 for row in reader:
@@ -77,7 +77,7 @@ def fetch_companies_house_significant_persons(
         logger.info('Fetching zip file from %s', url)
         with zipfile.ZipFile(io.BytesIO(_download(url))) as archive:
             with archive.open(archive.namelist()[0], 'r') as f:
-                for line in f.readlines():
+                for line in f:
                     results.append(json.loads(line))
                     if len(results) >= page_size:
                         s3.write_key(f'{page:010}.json', results)


### PR DESCRIPTION
### Description of change

The result of archive.open is a ZipExtFile, and its readlines method reads all of its lines into a list.

However, ZipExtFile extends from BufferedIOBase https://github.com/python/cpython/blob/3.7/Lib/zipfile.py#L785 which extends from IOBase https://github.com/python/cpython/blob/3.7/Lib/io.py#L78 and from https://docs.python.org/3/library/io.html#io.IOBase

> IOBase (and its subclasses) supports the iterator protocol, meaning
> that an IOBase object can be iterated over yielding the lines in a
> stream.

so we can just avoid the readlines method, and use the ZipExtFile directly.

It would be great if we could avoid loading the raw zip file in memory, but AFAIK the directory for zip files is at the _end_ of the file, so I don't think it's possible to stream-download a zip while unzipping its contents.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
