### PR TITLE
fix: use "Bearer" instead of "Token" for JWT request header

### DIFF
--- a/dataflow/operators/common.py
+++ b/dataflow/operators/common.py
@@ -119,7 +119,7 @@ def fetch_from_jwt_api(
 ):
     auth_token = jwt.encode(payload, secret, algorithm=algorithm).decode("utf-8")
     fetch_from_api_endpoint(
-        table_name, source_url, auth_token, results_key, next_key, **kwargs
+        table_name, source_url, auth_token, results_key, next_key, 'Bearer', **kwargs
     )
 
 

--- a/tests/unit/operators/test_dataset.py
+++ b/tests/unit/operators/test_dataset.py
@@ -204,7 +204,7 @@ def test_fetch_from_jwt_api(mocker):
         'test_table', 'http://test', {"foo": "bar"}, "s3cr3t", "FAKE123"
     )
     token_api_fetch_method.assert_called_once_with(
-        'test_table', 'http://test', 'jwt-token', 'results', 'next'
+        'test_table', 'http://test', 'jwt-token', 'results', 'next', 'Bearer'
     )
 
 


### PR DESCRIPTION
### Description of change

The PeopleFinder API has changed and no longer works when "Token" is passed. As the PeopleFinder pipeline is the only one that uses JWT this change has been made to the common fetch_from_jwt_api method.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
