### PR TITLE
fix: use company number as primary key

### DIFF
--- a/dataflow/dags/companies_house_pipelines.py
+++ b/dataflow/dags/companies_house_pipelines.py
@@ -19,7 +19,7 @@ class CompaniesHouseCompaniesPipeline(_PipelineDAG):
         schema='companieshouse',
         table_name='companies',
         field_mapping=[
-            (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
+            ('CompanyNumber', sa.Column('id', sa.String(8), primary_key=True)),
             ('CompanyName', sa.Column('company_name', sa.String)),
             ('CompanyNumber', sa.Column('company_number', sa.String)),
             ('RegAddress.CareOf', sa.Column('care_of', sa.String)),


### PR DESCRIPTION
### Description of change

Set the primary key for companies house companies to the company number rather than an auto-incrementing int. This resolves 2 issues:

1. As the companies api returns companies in alphabetical order, every time a company is added and the pipeline rerun the id for our record would change.
2. We currently have duplicate records for nearly every table in the dataset, this is due to a failure and rerunning of the dag. Were this to happen again the dag would fail.
