### PR TITLE
fix: build payload for each request

### DIFF
--- a/dataflow/dags/people_finder_pipelines.py
+++ b/dataflow/dags/people_finder_pipelines.py
@@ -110,9 +110,9 @@ class PeopleFinderPeoplePipeline(_PipelineDAG):
                 fetch_from_jwt_api,
                 secret=b64decode(str(config.PEOPLE_FINDER_PRIVATE_KEY), validate=True),
                 algorithm="RS512",
-                payload={
+                payload_builder=lambda: {
                     "fullpath": self.path,
-                    "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=60),
+                    "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=10),
                 },
             ),
             provide_context=True,


### PR DESCRIPTION
The People Finder API is authenticated using JWT, which has an expiry
time that is validated by the server. At the moment we are setting the
expiry time as 60 seconds from the start of the pipeline, and re-using
the same payload/auth token for every subsequent request, meaning that
if the pipeline takes more than a minute we start to see failures.

We should generate a new token with a short(er) expiry for each request,
so that the pipeline can take an arbitrary amount of time to run and we
won't send expired tokens.

### Description of change


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
