### PR TITLE
test: ensure all fetch tasks have retries

### DIFF
--- a/dataflow/dags/activity_stream_pipelines.py
+++ b/dataflow/dags/activity_stream_pipelines.py
@@ -23,6 +23,7 @@ class _ActivityStreamPipeline(_PipelineDAG):
                 self.index,
                 self.query,
             ],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -81,6 +81,10 @@ class _PipelineDAG(metaclass=PipelineMeta):
     # If True, the source_data_modified_utc metadata field will be set to the swap table task run utc.
     use_utc_now_as_source_modified: bool = False
 
+    # How many times the fetch operator should be retried if it fails
+    # Needs to be added to each fetch operator implementation.
+    fetch_retries = 3
+
     def get_fetch_operator(self) -> PythonOperator:
         raise NotImplementedError(
             f"{self.__class__} needs to override get_fetch_operator"

--- a/dataflow/dags/cabinet_office_pipelines.py
+++ b/dataflow/dags/cabinet_office_pipelines.py
@@ -85,4 +85,5 @@ class CabinetOfficeGenderPayGapPipeline(_PipelineDAG):
                 self.records_start_year,
                 self.transform_dataframe,
             ],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/companies_house_pipelines.py
+++ b/dataflow/dags/companies_house_pipelines.py
@@ -143,6 +143,7 @@ class CompaniesHouseCompaniesPipeline(_PipelineDAG):
                 self.source_url,
                 self.number_of_files,
             ],
+            retries=self.fetch_retries,
         )
 
 
@@ -204,4 +205,5 @@ class CompaniesHousePeopleWithSignificantControlPipeline(_PipelineDAG):
                 self.table_config.table_name,  # pylint: disable=no-member
                 self.source_url,
             ],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/company_matching.py
+++ b/dataflow/dags/company_matching.py
@@ -65,6 +65,7 @@ class _CompanyMatchingPipeline(_PipelineDAG):
                 config.MATCHING_SERVICE_BATCH_SIZE,
                 self.update,
             ],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/comtrade_pipelines.py
+++ b/dataflow/dags/comtrade_pipelines.py
@@ -21,6 +21,7 @@ class ComtradeGoodsPipeline(_PipelineDAG):
             queue='high-memory-usage',
             provide_context=True,
             op_args=[self.table_config.table_name],  # pylint: disable=no-member
+            retries=self.fetch_retries,
         )
 
     table_config = TableConfig(
@@ -91,6 +92,7 @@ class ComtradeServicesPipeline(_PipelineDAG):
             python_callable=fetch_comtrade_services_data,
             provide_context=True,
             op_args=[self.table_config.table_name],  # pylint: disable=no-member
+            retries=self.fetch_retries,
         )
 
     table_config = TableConfig(

--- a/dataflow/dags/consent_pipelines.py
+++ b/dataflow/dags/consent_pipelines.py
@@ -25,6 +25,7 @@ class _ConsentPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -144,6 +144,7 @@ class OxfordCovid19GovernmentResponseTracker(_PipelineDAG):
                 self.table_config.table_name,  # pylint: disable=no-member
                 self.source_url,
             ],
+            retries=self.fetch_retries,
         )
 
 
@@ -192,6 +193,7 @@ class CSSECovid19TimeSeriesGlobal(_PipelineDAG):
                 self.source_urls,
                 self.transform_dataframe,
             ],
+            retries=self.fetch_retries,
         )
 
 
@@ -281,6 +283,7 @@ class CSSECovid19TimeSeriesGlobalGroupedByCountry(_PipelineDAG):
                 self.target_db,
                 self.table_config.table_name,  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
         return op
 
@@ -387,6 +390,7 @@ class GoogleCovid19MobilityReports(_PipelineDAG):
                 self.source_urls,
                 self.transform_dataframe,
             ],
+            retries=self.fetch_retries,
         )
 
 
@@ -503,4 +507,5 @@ class AppleCovid19MobilityTrendsPipeline(_PipelineDAG):
                 self.config_path,
                 self.transform_dataframe,
             ],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/dashboard_pipelines.py
+++ b/dataflow/dags/dashboard_pipelines.py
@@ -35,6 +35,7 @@ class _SQLPipelineDAG(_PipelineDAG):
                 self.target_db,
                 self.table_config.table_name,  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/data_workspace_pipelines.py
+++ b/dataflow/dags/data_workspace_pipelines.py
@@ -27,6 +27,7 @@ class _DataWorkspacePipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/dataset_pipelines.py
+++ b/dataflow/dags/dataset_pipelines.py
@@ -22,8 +22,6 @@ class _DatasetPipeline(_PipelineDAG):
     use_utc_now_as_source_modified = True
     source_url: str
 
-    fetch_retries = 3
-
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(
             task_id='run-fetch',
@@ -391,6 +389,7 @@ class ContactsDatasetPipeline(_DatasetPipeline):
                 self.target_db,
                 self.table_config.tables[0],  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
 
 
@@ -433,6 +432,7 @@ class ContactsLastInteractionPipeline(_DatasetPipeline):
                 self.target_db,
                 self.table_config.table_name,  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
         return op
 
@@ -571,6 +571,7 @@ class AdvisersLastInteractionPipeline(_DatasetPipeline):
                 self.target_db,
                 self.table_config.table_name,  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
         return op
 

--- a/dataflow/dags/derived_report_table_pipelines.py
+++ b/dataflow/dags/derived_report_table_pipelines.py
@@ -32,6 +32,7 @@ class _DerivedReportTablePipeline(_PipelineDAG):
                 self.target_db,
                 self.table_config.table_name,  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/dun_and_bradstreet_pipelines.py
+++ b/dataflow/dags/dun_and_bradstreet_pipelines.py
@@ -35,6 +35,7 @@ class _DNBPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/enquiry_mgmt_pipelines.py
+++ b/dataflow/dags/enquiry_mgmt_pipelines.py
@@ -101,4 +101,5 @@ class EnquiryMgmtEnquiriesPipeline(_PipelineDAG):
                 source_url=f"{config.ENQUIRY_MGMT_BASE_URL}/enquiries?page_size=1000&page=1",
                 hawk_credentials=config.ENQUIRY_MGMT_HAWK_CREDENTIALS,
             ),
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/export_wins_dashboard.py
+++ b/dataflow/dags/export_wins_dashboard.py
@@ -183,5 +183,6 @@ class ExportWinsDashboardPipeline(_PipelineDAG):
                 self.target_db,
                 self.table_config.table_name,  # pylint: disable=no-member
             ],
+            retries=self.fetch_retries,
         )
         return op

--- a/dataflow/dags/gateway_to_research_pipelines.py
+++ b/dataflow/dags/gateway_to_research_pipelines.py
@@ -19,6 +19,7 @@ class _GatewayToResearchPipeline(_PipelineDAG):
             python_callable=fetch_from_gtr_api,
             provide_context=True,
             op_args=[self.table_config.table_name, self.resource_type],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -26,6 +26,7 @@ class _HMRCPipeline(_PipelineDAG):
                 self.base_filename,
                 self.records_start_year,
             ],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/market_access_pipelines.py
+++ b/dataflow/dags/market_access_pipelines.py
@@ -148,4 +148,5 @@ class MarketAccessTradeBarriersPipeline(_PipelineDAG):
                 self.table_config.table.name,  # pylint: disable=no-member
                 self.source_url,
             ],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -19,6 +19,7 @@ class _ONSPipeline(_PipelineDAG):
             python_callable=fetch_from_ons_sparql,
             provide_context=True,
             op_args=[self.table_config.table_name, self.query, self.index_query],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/people_finder_pipelines.py
+++ b/dataflow/dags/people_finder_pipelines.py
@@ -117,4 +117,5 @@ class PeopleFinderPeoplePipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/sharepoint_pipelines.py
+++ b/dataflow/dags/sharepoint_pipelines.py
@@ -26,6 +26,7 @@ class _SharepointPipeline(_PipelineDAG):
                 self.sub_site_id,
                 self.list_id,
             ],
+            retries=self.fetch_retries,
         )
 
 

--- a/dataflow/dags/spi_pipeline.py
+++ b/dataflow/dags/spi_pipeline.py
@@ -78,4 +78,5 @@ class DataHubSPIPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table.name, self.source_url],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/tags_classifier_prediction_pipeline.py
+++ b/dataflow/dags/tags_classifier_prediction_pipeline.py
@@ -61,4 +61,5 @@ class TagsClassifierPredictionPipeline(_PipelineDAG):
             queue='tensorflow',
             provide_context=True,
             op_args=[self.target_db, self.query, self.table_config.table_name],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/tags_classifier_train_pipeline.py
+++ b/dataflow/dags/tags_classifier_train_pipeline.py
@@ -8,7 +8,6 @@ from dataflow.operators.tags_classifier.train.train import (
 
 
 class TagsClassifierTrainPipeline(_PipelineDAG):
-
     schedule_interval = (
         None  # For now we trigger the pipeline manually when training data is uploaded
     )
@@ -33,4 +32,5 @@ class TagsClassifierTrainPipeline(_PipelineDAG):
             queue='tensorflow',
             provide_context=True,
             op_args=[self.table_config.table_name],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/tariff_pipelines.py
+++ b/dataflow/dags/tariff_pipelines.py
@@ -43,4 +43,5 @@ class GlobalUKTariffPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )

--- a/dataflow/dags/zendesk_pipelines.py
+++ b/dataflow/dags/zendesk_pipelines.py
@@ -129,6 +129,7 @@ class ZendeskDITTicketsPipeline(_PipelineDAG):
             python_callable=fetch_daily_tickets,
             provide_context=True,
             op_args=[self.table_config.schema, self.table_config.table_name, "dit"],
+            retries=self.fetch_retries,
         )
 
 
@@ -192,6 +193,7 @@ class ZendeskUKTradeTicketsPipeline(_PipelineDAG):
                 self.table_config.table_name,
                 "uktrade",
             ],
+            retries=self.fetch_retries,
         )
 
 
@@ -230,6 +232,7 @@ class ZendeskUKTRadeGroupsPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )
 
 
@@ -268,4 +271,5 @@ class ZendeskDITGroupsPipeline(_PipelineDAG):
             ),
             provide_context=True,
             op_args=[self.table_config.table_name, self.source_url],
+            retries=self.fetch_retries,
         )

--- a/tests/unit/test_dags.py
+++ b/tests/unit/test_dags.py
@@ -1,5 +1,7 @@
 from airflow.models.dagbag import DagBag
 
+from tests.unit.utils import get_fetch_retries_for_all_concrete_dags
+
 
 def test_pipelines_dags():
     dagbag = DagBag('dataflow', include_examples=False)
@@ -115,3 +117,12 @@ def test_pipelines_dags():
         'ZendeskUKTradeTicketsPipeline',
         'ZendeskUKTRadeGroupsPipeline',
     }
+
+
+def test_standard_dags_have_some_fetch_retries():
+    fetch_retries_by_dag_name = get_fetch_retries_for_all_concrete_dags()
+
+    for dag_class_name, fetch_retries in fetch_retries_by_dag_name.items():
+        assert (
+            fetch_retries > 0
+        ), f"{dag_class_name} does not have any retries configured for its fetch operator"

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,3 +1,10 @@
+import importlib
+import os
+from glob import glob
+
+from dataflow.dags import _PipelineDAG
+
+
 def get_base_dag_tasks(with_modified_date_check=False, fetch_name="fetch-data"):
     tasks = {
         fetch_name,
@@ -30,3 +37,41 @@ def get_polling_dag_tasks(with_emails=False):
         tasks.add("send-dataset-updated-emails")
 
     return tasks
+
+
+def get_all_dag_concrete_subclasses(root_class):
+    """Import all of the DAGs, find subclasses of `root_class`, and return them all.
+
+    This will result in every module in `dataflow/dags` being imported into the local namespace. If this causes issues,
+    this method could be run via multiprocessing to start up an isolated Python process.
+    """
+    for module in glob('dataflow/dags/*.py', recursive=True):
+        if module == '__init__.py' or module[-3:] != '.py':
+            continue
+        importlib.import_module(module[:-3].replace(os.path.sep, '.'))
+
+    def get_subclasses(cls):
+        classes = cls.__subclasses__()
+        for subclass in classes:
+            classes.extend(get_subclasses(subclass))
+        return classes
+
+    all_dag_classes = get_subclasses(root_class)
+    concrete_dag_classes = filter(
+        lambda c: not c.__name__.startswith('_'), all_dag_classes
+    )
+
+    return concrete_dag_classes
+
+
+def get_fetch_retries_for_all_concrete_dags():
+    """Gets all DAGs which are subclasses of `_PipelineDAG` and checks their `get_fetch_operator` tasks,
+    returning a dict with all of the DAG names correlated to the # retries configured on that task.
+    """
+    concrete_dag_classes = get_all_dag_concrete_subclasses(_PipelineDAG)
+
+    results_dict = {}
+    for dag_class in concrete_dag_classes:
+        results_dict[dag_class.__name__] = dag_class().get_fetch_operator().retries
+
+    return results_dict


### PR DESCRIPTION
### Description of change
We might want to have some tests that enforce some "basics" across all of our DAGs. Here's an example test that checks that every "standard" DAG returns a DAG task from `get_fetch_operator` with >0 retries configured so that any transient/trivial errors are automatically recovered from. This will hopefully remove a subset of a class of errors from requiring manual intervention.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
