### PR TITLE
Speed up comtrade goods

### DIFF
--- a/dataflow/dags/__init__.py
+++ b/dataflow/dags/__init__.py
@@ -1,1 +1,5 @@
-from .base import _PipelineDAG, _CSVPipelineDAG, _FastPollingPipeline  # noqa
+from .base import (  # noqa
+    _PipelineDAG,
+    _CSVPipelineDAG,
+    _PandasPipelineWithPollingSupport,
+)

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -350,12 +350,17 @@ class _CSVPipelineDAG(metaclass=PipelineMeta):
         return dag
 
 
-class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
+class _PandasPipelineWithPollingSupport(SkipMixin, metaclass=PipelineMeta):
     """
-    A pipeline that continuously polls (within a given period) for updates to a dataset and then aims to process
-    and upload that data as fast as practicable, to support more time-sensitive workflows. The pipeline minimises time
-    by skipping or condensing steps that are in the standard `_PipelineDAG`, e.g. uploading data to S3 and splitting
-    steps out into separate tasks.
+    A pipeline that combines the 'fetch' and 'insert' steps of a standard pipeline, and uses pandas DataFrames to
+    efficiently insert large amounts of data to the target table.
+
+    This pipeline should currently only be used when the provided optimisation is required.
+
+    There is also support for a 'polling' step at the start of the pipeline, which will continuously check
+    (within a given period) for updates to a dataset and then aims to process and upload that data as fast as
+    practicable, to support more time-sensitive workflows. This polling step could probably be moved to the
+    standard pipeline eventually - but at the moment it is not needed there.
     """
 
     target_db: str = config.DATASETS_DB_NAME
@@ -376,6 +381,10 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
     data_getter: Callable
 
     table_config: SingleTableConfig
+
+    # Whether to use a polling task to check for new data over a long period of time, as opposed to just
+    # assuming new data is available and ingesting immediately.
+    use_polling = True
 
     # How often to poll the data source to read it's "last modified" date.
     polling_interval_in_seconds = 60
@@ -427,17 +436,20 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
             else None,
         )
 
-        _poll_for_updates = PythonOperator(
-            task_id='poll-for-new-data',
-            python_callable=poll_for_new_data,
-            op_kwargs=dict(
-                target_db=self.target_db,
-                table_config=self.table_config,
-                pipeline_instance=self,
-            ),
-            dag=dag,
-            provide_context=True,
-        )
+        if self.use_polling:
+            _poll_for_updates = PythonOperator(
+                task_id='poll-for-new-data',
+                python_callable=poll_for_new_data,
+                op_kwargs=dict(
+                    target_db=self.target_db,
+                    table_config=self.table_config,
+                    pipeline_instance=self,
+                ),
+                dag=dag,
+                provide_context=True,
+            )
+        else:
+            _poll_for_updates = None
 
         _scrape_load_and_check = PythonOperator(
             task_id='scrape-and-load-data',
@@ -492,9 +504,11 @@ class _FastPollingPipeline(SkipMixin, metaclass=PipelineMeta):
             op_args=[self.target_db, *self.table_config.tables],
         )
 
+        if _poll_for_updates:
+            _poll_for_updates >> _scrape_load_and_check
+
         (
-            _poll_for_updates
-            >> _scrape_load_and_check
+            _scrape_load_and_check
             >> _swap_dataset_tables
             >> [_drop_swap_tables, _drop_temp_tables]
         )

--- a/dataflow/dags/base.py
+++ b/dataflow/dags/base.py
@@ -9,6 +9,7 @@ from airflow.models import SkipMixin
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator, BranchPythonOperator
 from airflow.operators.sensors import ExternalTaskSensor
+from airflow.utils.helpers import chain
 
 from dataflow import config
 from dataflow.operators.csv_outputs import create_csv, create_compressed_csv
@@ -22,6 +23,7 @@ from dataflow.operators.db_tables import (
     branch_on_modified_date,
     scrape_load_and_check_data,
     poll_for_new_data,
+    create_temp_table_indexes,
 )
 from dataflow.operators.email import send_dataset_update_emails
 from dataflow.utils import TableConfig, slack_alert, SingleTableConfig
@@ -201,6 +203,16 @@ class _PipelineDAG(metaclass=PipelineMeta):
         if _transform_tables:
             _transform_tables.dag = dag
 
+        if self.table_config.indexes is not None:
+            _create_post_insert_indexes = PythonOperator(
+                task_id='create-post-insert-indexes',
+                python_callable=create_temp_table_indexes,
+                provide_context=True,
+                op_args=[self.target_db, self.table_config],
+            )
+        else:
+            _create_post_insert_indexes = None
+
         _check_tables = PythonOperator(
             task_id="check-temp-table-data",
             python_callable=check_table_data,
@@ -246,10 +258,15 @@ class _PipelineDAG(metaclass=PipelineMeta):
 
         [_fetch, _create_tables] >> _insert_into_temp_table >> _drop_temp_tables
 
+        _next_chain = [_insert_into_temp_table]
         if _transform_tables:
-            _insert_into_temp_table >> _transform_tables >> _check_tables
-        else:
-            _insert_into_temp_table >> _check_tables
+            _next_chain.append(_transform_tables)
+        if _create_post_insert_indexes:
+            _next_chain.append(_create_post_insert_indexes)
+        _next_chain.append(_check_tables)
+
+        chain(*_next_chain)
+        del _next_chain
 
         _check_tables >> _swap_dataset_tables >> _drop_swap_tables
 

--- a/dataflow/dags/comtrade_pipelines.py
+++ b/dataflow/dags/comtrade_pipelines.py
@@ -9,7 +9,7 @@ from dataflow.operators.comtrade import (
     fetch_comtrade_goods_data_frames,
     fetch_comtrade_services_data,
 )
-from dataflow.utils import TableConfig, SingleTableConfig
+from dataflow.utils import TableConfig, SingleTableConfig, LateIndex
 
 
 class ComtradeGoodsPipeline(_PandasPipelineWithPollingSupport):
@@ -56,6 +56,16 @@ class ComtradeGoodsPipeline(_PandasPipelineWithPollingSupport):
                 sa.Column('quantity_unit_code', sa.BigInteger, nullable=False),
             ),
             ('Trade Value (US$)', sa.Column('trade_value_usd', sa.Numeric)),
+        ],
+        indexes=[
+            LateIndex('classification'),
+            LateIndex('period'),
+            LateIndex('period_desc'),
+            LateIndex('year'),
+            LateIndex('aggregate_level'),
+            LateIndex('is_leaf_code'),
+            LateIndex('reporter_code'),
+            LateIndex('partner_code'),
         ],
     )
 

--- a/dataflow/dags/comtrade_pipelines.py
+++ b/dataflow/dags/comtrade_pipelines.py
@@ -3,50 +3,38 @@
 import sqlalchemy as sa
 
 from airflow.operators.python_operator import PythonOperator
-from dataflow.dags import _PipelineDAG
+
+from dataflow.dags import _PipelineDAG, _PandasPipelineWithPollingSupport
 from dataflow.operators.comtrade import (
-    fetch_comtrade_goods_data,
+    fetch_comtrade_goods_data_frames,
     fetch_comtrade_services_data,
 )
-from dataflow.utils import TableConfig
+from dataflow.utils import TableConfig, SingleTableConfig
 
 
-class ComtradeGoodsPipeline(_PipelineDAG):
+class ComtradeGoodsPipeline(_PandasPipelineWithPollingSupport):
+    use_polling = False
+
     schedule_interval = "0 1 * * 6"  # Every Saturday morning
 
-    def get_fetch_operator(self) -> PythonOperator:
-        return PythonOperator(
-            task_id="fetch-comtrade-goods-data",
-            python_callable=fetch_comtrade_goods_data,
-            queue='high-memory-usage',
-            provide_context=True,
-            op_args=[self.table_config.table_name],  # pylint: disable=no-member
-            retries=self.fetch_retries,
-        )
+    worker_queue = 'high-memory-usage'
 
-    table_config = TableConfig(
+    table_config = SingleTableConfig(
         schema="un",
         table_name="comtrade__goods",
         field_mapping=[
-            (None, sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)),
-            (
-                'Classification',
-                sa.Column('classification', sa.String, nullable=False, index=True),
-            ),
-            (
-                'Period',
-                sa.Column('period', sa.SmallInteger, nullable=False, index=True),
-            ),
+            ('Classification', sa.Column('classification', sa.String, nullable=False)),
+            ('Year', sa.Column('year', sa.SmallInteger, nullable=False)),
+            ('Period', sa.Column('period', sa.SmallInteger, nullable=False)),
             (
                 'Period Desc.',
-                sa.Column('period_desc', sa.SmallInteger, nullable=False, index=True),
+                sa.Column('period_desc', sa.SmallInteger, nullable=False),
             ),
-            ('Year', sa.Column('year', sa.SmallInteger, nullable=False, index=True)),
             (
                 'Aggregate Level',
-                sa.Column('aggregate_level', sa.BigInteger, nullable=False, index=True),
+                sa.Column('aggregate_level', sa.BigInteger, nullable=False),
             ),
-            ('is_leaf_code_bool', sa.Column('is_leaf_code', sa.Boolean)),
+            ('Is Leaf Code', sa.Column('is_leaf_code', sa.Boolean)),
             (
                 'Trade Flow Code',
                 sa.Column('trade_flow_code', sa.BigInteger, nullable=False),
@@ -54,14 +42,11 @@ class ComtradeGoodsPipeline(_PipelineDAG):
             ('Trade Flow', sa.Column('trade_flow', sa.String, nullable=False)),
             (
                 'Reporter Code',
-                sa.Column('reporter_code', sa.BigInteger, nullable=False, index=True),
+                sa.Column('reporter_code', sa.BigInteger, nullable=False),
             ),
             ('Reporter', sa.Column('reporter', sa.String, nullable=False)),
             ('Reporter ISO', sa.Column('reporter_iso', sa.String)),
-            (
-                'Partner Code',
-                sa.Column('partner_code', sa.BigInteger, nullable=False, index=True),
-            ),
+            ('Partner Code', sa.Column('partner_code', sa.BigInteger, nullable=False)),
             ('Partner', sa.Column('partner', sa.String, nullable=False)),
             ('Partner ISO', sa.Column('partner_iso', sa.String)),
             ('Commodity Code', sa.Column('commodity_code', sa.String, nullable=False)),
@@ -72,13 +57,9 @@ class ComtradeGoodsPipeline(_PipelineDAG):
             ),
             ('Trade Value (US$)', sa.Column('trade_value_usd', sa.Numeric)),
         ],
-        transforms=[
-            lambda record, table_config, contexts: {
-                **record,
-                'is_leaf_code_bool': bool(int(record['Is Leaf Code'])),
-            }
-        ],
     )
+
+    data_getter = fetch_comtrade_goods_data_frames
 
 
 class ComtradeServicesPipeline(_PipelineDAG):

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -4,7 +4,7 @@ from airflow.operators.python_operator import PythonOperator
 import sqlalchemy as sa
 
 from dataflow.dags import _PipelineDAG
-from dataflow.dags.base import _FastPollingPipeline
+from dataflow.dags.base import _PandasPipelineWithPollingSupport
 from dataflow.operators.ons import fetch_from_ons_sparql
 from dataflow.utils import SingleTableConfig
 
@@ -23,7 +23,7 @@ class _ONSPipeline(_PipelineDAG):
         )
 
 
-class ONSUKSATradeInGoodsPollingPipeline(_FastPollingPipeline):
+class ONSUKSATradeInGoodsPollingPipeline(_PandasPipelineWithPollingSupport):
     from dataflow.ons_scripts.uk_trade_in_goods_all_countries_seasonally_adjusted.main import (
         get_current_and_next_release_date,
         get_data,
@@ -52,7 +52,9 @@ class ONSUKSATradeInGoodsPollingPipeline(_FastPollingPipeline):
     )
 
 
-class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(_FastPollingPipeline):
+class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(
+    _PandasPipelineWithPollingSupport
+):
     from dataflow.ons_scripts.uk_trade_country_by_commodity.main import (
         get_current_and_next_release_date,
         get_data,
@@ -85,7 +87,9 @@ class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(_FastPollingPipeline
     )
 
 
-class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(_FastPollingPipeline):
+class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(
+    _PandasPipelineWithPollingSupport
+):
     from dataflow.ons_scripts.uk_trade_in_services_service_type_by_partner_country_non_seasonally_adjusted.main import (
         get_current_and_next_release_date,
         get_data,
@@ -119,7 +123,7 @@ class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(_FastPollingPipelin
     )
 
 
-class ONSUKTotalTradeAllCountriesNSAPollingPipeline(_FastPollingPipeline):
+class ONSUKTotalTradeAllCountriesNSAPollingPipeline(_PandasPipelineWithPollingSupport):
     from dataflow.ons_scripts.uk_total_trade_all_countries_non_seasonally_adjusted.main import (
         get_current_and_next_release_date,
         get_data,

--- a/dataflow/ons_scripts/uk_total_trade_all_countries_non_seasonally_adjusted/main.py
+++ b/dataflow/ons_scripts/uk_total_trade_all_countries_non_seasonally_adjusted/main.py
@@ -185,7 +185,7 @@ def process_data():
 
     print(datetime.now(), f'process_data finished', len(table))
 
-    return table
+    return [table]
 
 
 def get_current_and_next_release_date() -> Tuple[datetime, Optional[datetime]]:

--- a/dataflow/ons_scripts/uk_trade_country_by_commodity/main.py
+++ b/dataflow/ons_scripts/uk_trade_country_by_commodity/main.py
@@ -184,9 +184,13 @@ def get_data() -> DataFrame:
     print('start getting', datetime.now())
 
     exports = process_data(flow_type='exports', dataset_url=EXPORTS_DATASET_URL)
+    yield exports
+    num_rows = len(exports)
+    del exports
+
     imports = process_data(flow_type='imports', dataset_url=IMPORTS_DATASET_URL)
-    df = pd.concat([exports, imports]).drop_duplicates()
+    yield imports
+    num_rows += len(imports)
+    del imports
 
-    print('end getting', datetime.now(), len(df))
-
-    return df
+    print('end getting', datetime.now(), num_rows)

--- a/dataflow/ons_scripts/uk_trade_in_goods_all_countries_seasonally_adjusted/main.py
+++ b/dataflow/ons_scripts/uk_trade_in_goods_all_countries_seasonally_adjusted/main.py
@@ -180,7 +180,7 @@ def process_data():
 
     print(datetime.now(), f'transformed and normalised data')
 
-    return table.drop_duplicates()
+    return [table.drop_duplicates()]
 
 
 def get_current_and_next_release_date() -> Tuple[datetime, datetime]:

--- a/dataflow/ons_scripts/uk_trade_in_services_service_type_by_partner_country_non_seasonally_adjusted/main.py
+++ b/dataflow/ons_scripts/uk_trade_in_services_service_type_by_partner_country_non_seasonally_adjusted/main.py
@@ -4,7 +4,7 @@ https://github.com/GSS-Cogs/family-trade/blob/fca3be954d0b4ed216a4a0989182b19a5c
 """
 
 from datetime import datetime
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 
 import gssutils
 import pandas
@@ -16,7 +16,7 @@ from gssutils import Excel
 DATASET_URL = 'https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted'
 
 
-def process_data() -> pandas.DataFrame:
+def process_data() -> List[pandas.DataFrame]:
     print(datetime.now(), 'process_data start')
 
     YEAR_RE = re.compile(r'[0-9]{4}')
@@ -171,7 +171,7 @@ def process_data() -> pandas.DataFrame:
 
     print(datetime.now(), f'process_data finished', len(new_table))
 
-    return new_table
+    return [new_table]
 
 
 def get_current_and_next_release_date() -> Tuple[datetime, Optional[datetime]]:

--- a/dataflow/operators/comtrade.py
+++ b/dataflow/operators/comtrade.py
@@ -3,43 +3,110 @@ import csv
 import io
 import json
 import zipfile
+from typing import TYPE_CHECKING, Generator
 
 import backoff
+import pandas
 import requests
 
 from dataflow import config
 from dataflow.utils import S3Data, logger
 
+if TYPE_CHECKING:
+    from dataflow.dags.comtrade_pipelines import ComtradeGoodsPipeline  # noqa
 
-def fetch_comtrade_goods_data(
-    table_name: str, ts_nodash: str, **kwargs,
-):
-    s3 = S3Data(table_name, ts_nodash)
-    expected_keys = [
-        'Classification',
-        'Year',
-        'Period',
-        'Period Desc.',
-        'Aggregate Level',
-        'Is Leaf Code',
-        'Trade Flow Code',
-        'Trade Flow',
-        'Reporter Code',
-        'Reporter',
-        'Reporter ISO',
-        'Partner Code',
-        'Partner',
-        'Partner ISO',
-        'Commodity Code',
-        'Commodity',
-        'Qty Unit Code',
-        'Qty Unit',
-        'Qty',
-        'Netweight (kg)',
-        'Trade Value (US$)',
-        'Flag',
+
+def fetch_comtrade_goods_data_frames() -> Generator[pandas.DataFrame, None, None]:
+    expected_columns_and_dtypes = {
+        'Classification': 'category',
+        'Year': 'uint16',
+        'Period': 'uint16',
+        'Period Desc.': 'uint16',
+        'Aggregate Level': 'uint8',
+        'Is Leaf Code': 'bool',
+        'Trade Flow Code': 'int',
+        'Trade Flow': 'category',
+        'Reporter Code': 'uint16',
+        'Reporter': 'category',
+        'Reporter ISO': 'category',
+        'Partner Code': 'category',
+        'Partner': 'category',
+        'Partner ISO': 'category',
+        'Commodity Code': 'category',
+        'Commodity': 'category',
+        'Qty Unit Code': 'int',
+        'Qty Unit': 'category',
+        'Qty': 'float',
+        'Trade Value (US$)': 'int64',
+    }
+
+    trade_type = 'C'
+
+    years = _get_years(trade_type)
+    zipfile_bytes_for_each_period = _get_zipfile_bytes_for_each_period(
+        trade_type, years, config.COMTRADE_TOKEN
+    )
+    csv_files_for_each_period = _get_csvfile_for_each_period(
+        zipfile_bytes_for_each_period
+    )
+    for csv_file in csv_files_for_each_period:
+        df_chunk_generator = pandas.read_csv(
+            csv_file,
+            chunksize=1_000_000,
+            dtype=expected_columns_and_dtypes,
+            usecols=[c for c in expected_columns_and_dtypes.keys()],
+        )
+        for df_chunk in df_chunk_generator:
+            yield df_chunk
+
+
+def _get_years(trade_type):
+    with _download('https://comtrade.un.org/Data/cache/years.json') as response:
+        years_objs = json.loads(response.content)
+    if years_objs['more']:
+        raise Exception('Unable to fetch all years')
+
+    years = [
+        year_obj['id']
+        for year_obj in years_objs['results']
+        if year_obj['id'].lower() != 'all'
     ]
-    _fetch(s3, 'C', expected_keys)
+
+    if trade_type == 'S':
+        # Comtrade API returns 404 for years before 2000 for services (HS) files, so we will just skip those years
+        # in this case in order to get back to a functioning pipeline.
+        years = filter(lambda o: int(o) >= 2000, years)
+    elif trade_type == 'C':
+        # Comtrade API returns 404 for years before 1988 for goods (C) files, so we will just skip those years
+        # in this case in order to get back to a functioning pipeline.
+        years = filter(lambda o: int(o) >= 1988, years)
+
+    return list(years)
+
+
+def _get_csvfile_for_each_period(data_for_each_period):
+    for zip_bytes in data_for_each_period:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+            name = archive.namelist()[0]
+            logger.info('Opening csv file %s in zip', name)
+            with archive.open(name, "r") as file:
+                yield file
+
+
+def _get_zipfile_bytes_for_each_period(trade_type, periods, comtrade_token):
+    # There is potential for a fairly "quick win" optimisation here. This comtrade API endpoint serves files quite
+    # slowly - sometimes taking 3+ minutes. Multiplied by 30+ files, this adds a non-negligible delay to the pipeline
+    # as a whole. If we could pull the next file in the background so that it's always ready as soon as the processing
+    # steps want it, we could eliminate pretty much all of the downtime (except for the first file). Scraping the API
+    # in a background thread and pushing results onto a queue with a maxsize of 1 seems like a fairly trivial
+    # candidate implementation. Not doing it yet because the current speed should be "good enough".
+    frequency = 'A'
+    classification = 'HS' if trade_type == 'C' else 'EB02'
+    for period in periods:
+        yield _download(
+            f'https://comtrade.un.org/api/get/bulk/{trade_type}/{frequency}/{period}/all/{classification}',
+            params=(('token', comtrade_token),),
+        ).content
 
 
 def fetch_comtrade_services_data(
@@ -70,25 +137,7 @@ def fetch_comtrade_services_data(
 
 
 def _fetch(s3, trade_type, expected_keys):
-    with _download('https://comtrade.un.org/Data/cache/years.json') as response:
-        years_objs = json.loads(response.content)
-    if years_objs['more']:
-        raise Exception('Unable to fetch all years')
-
-    years = [
-        year_obj['id']
-        for year_obj in years_objs['results']
-        if year_obj['id'].lower() != 'all'
-    ]
-
-    if trade_type == 'S':
-        # Comtrade API returns 404 for years before 2000 for services (HS) files, so we will just skip those years
-        # in this case in order to get back to a functioning pipeline.
-        years = filter(lambda o: int(o) >= 2000, years)
-    elif trade_type == 'C':
-        # Comtrade API returns 404 for years before 1988 for goods (C) files, so we will just skip those years
-        # in this case in order to get back to a functioning pipeline.
-        years = filter(lambda o: int(o) >= 1988, years)
+    years = _get_years(trade_type)
 
     def paginate(items, num_per_page):
         page = []

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -649,12 +649,3 @@ def scrape_load_and_check_data(
                     del data_frame
 
             logger.info("Copy complete.")
-
-    create_temp_table_indexes(target_db, table_config, **kwargs)
-
-    check_table_data(
-        target_db,
-        *table_config.tables,
-        allow_null_columns=pipeline_instance.allow_null_columns,
-        **kwargs,
-    )

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -58,6 +58,20 @@ class Transform(Protocol):
 
 
 @dataclass
+class LateIndex:
+    """Data-Flow-specific class for adding indexes to pipeline tables. These indexes are "late" because they are setup
+     *after* the data has been inserted into the table. This provides significant efficiency gains on larger datasets.
+
+    The data in this class is used to build a sqlalchemy Index instance. We don't use that class natively because it
+    expects an index name to be specified, and we want the names to be automatically generated so we can be sure
+    they will reliably fit within the 64-character Postgres identifier limit.
+    """
+
+    columns: Union[str, List[str]]
+    unique: bool = False
+
+
+@dataclass
 class TableConfig:
     """Wrapper for all the information needed to define how data (e.g. from an API) should be processed and
     ingested into a database, including which fields to pull out and any transformations to apply.
@@ -76,6 +90,14 @@ class TableConfig:
     # do not have a reference to the main record, you'll need to apply a custom transform to pull that data in.
     # See DataHubSPIPipeline for an example.
     field_mapping: FieldMapping
+
+    # Indexes to apply to the columns in the top-level table this TableConfig defines. These indexes are added *after*
+    # the data is ingested as opposed to when the table is first defined, which is more efficient. This is particularly
+    # important when ingesting large datasets.
+    #
+    # While it is possible to use `sa.Column(index=True)` in the `field_mapping` entries, this is be discouraged.
+    # There are few good reasons not to prefer using this option that applies the indexes after ingestion.
+    indexes: Optional[List[LateIndex]] = None
 
     transforms: Iterable[Transform] = tuple()
     temp_table_suffix: Optional[str] = None

--- a/dataflow/utils.py
+++ b/dataflow/utils.py
@@ -150,7 +150,7 @@ class TableConfig:
 
 class SingleTableConfig(TableConfig):
     # A TableConfig that doesn't support any nested tables, for cases where our current code doesn't support building
-    # related tables (e.g. _FastPollingPipeline).
+    # related tables (e.g. _PandasPipelineWithPollingSupport).
     field_mapping: SingleTableFieldMapping
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   data-flow-worker-tensorflow:
     build:
       context: .
-      dockerfile: Dockerfile-tensorflow
+      dockerfile: Dockerfile
     volumes:
       - .:/home/vcap/app
     env_file: .env

--- a/requirements-tensorflow-worker.txt
+++ b/requirements-tensorflow-worker.txt
@@ -117,6 +117,7 @@ prompt-toolkit==3.0.7     # via -r requirements.txt, ipython
 protobuf==3.14.0          # via tensorboard, tensorflow
 psutil==5.7.2             # via -r requirements.txt, apache-airflow
 psycopg2-binary==2.8.6    # via -r requirements.txt, apache-airflow
+git+https://github.com/psycopg/psycopg3.git@f045d822ca3c375b62657b55a6dd88daae4548a5#subdirectory=psycopg3  # via -r requirements.txt
 ptyprocess==0.6.0         # via -r requirements.txt, pexpect
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
@@ -171,7 +172,7 @@ texttable==1.6.3          # via -r requirements.txt, pyexcel
 thrift==0.13.0            # via -r requirements.txt, apache-airflow
 tornado==5.1.1            # via -r requirements.txt, apache-airflow, flower
 traitlets==5.0.4          # via -r requirements.txt, ipython
-typing-extensions==3.7.4.3  # via -r requirements.txt
+typing-extensions==3.7.4.3  # via -r requirements.txt, psycopg3
 tzlocal==1.5.1            # via -r requirements.txt, apache-airflow, pendulum
 unicodecsv==0.14.1        # via -r requirements.txt, apache-airflow
 unidecode==1.1.1          # via -r requirements.txt, gssutils

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,4 @@ zipstream
 scikit-learn==0.22.2.post1
 git+https://github.com/uktrade/data-flow-metrics.git
 splitstream==1.2.4
+git+https://github.com/psycopg/psycopg3.git@f045d822ca3c375b62657b55a6dd88daae4548a5#subdirectory=psycopg3

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,6 +105,7 @@ prometheus-client==0.8.0  # via data-flow-metrics, flower
 prompt-toolkit==3.0.7     # via ipython
 psutil==5.7.2             # via apache-airflow
 psycopg2-binary==2.8.6    # via apache-airflow
+git+https://github.com/psycopg/psycopg3.git@f045d822ca3c375b62657b55a6dd88daae4548a5#subdirectory=psycopg3  # via -r requirements.in
 ptyprocess==0.6.0         # via pexpect
 pycparser==2.20           # via cffi
 pyexcel-ezodf==0.3.4      # via pyexcel-ods3
@@ -151,7 +152,7 @@ texttable==1.6.3          # via pyexcel
 thrift==0.13.0            # via apache-airflow
 tornado==5.1.1            # via apache-airflow, flower
 traitlets==5.0.4          # via ipython
-typing-extensions==3.7.4.3  # via -r requirements.in
+typing-extensions==3.7.4.3  # via -r requirements.in, psycopg3
 tzlocal==1.5.1            # via apache-airflow, pendulum
 unicodecsv==0.14.1        # via apache-airflow
 unidecode==1.1.1          # via gssutils

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,6 @@
 from unittest import mock
 
 import pytest
-import sqlalchemy as sa
-from airflow.operators.python_operator import PythonOperator
-
-from dataflow.dags import _PipelineDAG
-from dataflow.utils import TableConfig
 
 
 @pytest.fixture
@@ -19,25 +14,3 @@ def mock_db_conn(mocker):
     engine.begin.return_value.__enter__.return_value = conn
 
     return conn
-
-
-@pytest.fixture()
-def test_dag_cls():
-    def _fetch(*args, **kwargs):
-        return
-
-    class TestDAG(_PipelineDAG):
-        table_config = TableConfig(
-            table_name="test-table",
-            field_mapping=(
-                ("id", sa.Column("id", sa.Integer, primary_key=True)),
-                ("data", sa.Column("data", sa.Integer)),
-            ),
-        )
-
-        def get_fetch_operator(self) -> PythonOperator:
-            return PythonOperator(
-                task_id="fetch-data", python_callable=_fetch, provide_context=True,
-            )
-
-    return TestDAG

--- a/tests/unit/dags/test_base.py
+++ b/tests/unit/dags/test_base.py
@@ -1,19 +1,54 @@
 from datetime import datetime
 
+import sqlalchemy as sa
+from airflow.operators.python_operator import PythonOperator
 
+from dataflow.dags import _PandasPipelineWithPollingSupport, _PipelineDAG
+from dataflow.utils import TableConfig, LateIndex
 from tests.unit.utils import get_base_dag_tasks
 
 
-def test_base_dag_tasks(test_dag_cls):
-    dag = test_dag_cls().get_dag()
+def test_base_dag_tasks():
+    class TestDAG(_PipelineDAG):
+        table_config = TableConfig(
+            table_name="test-table",
+            field_mapping=(
+                ("id", sa.Column("id", sa.Integer, primary_key=True)),
+                ("data", sa.Column("data", sa.Integer)),
+            ),
+        )
+
+        def get_fetch_operator(self):
+            return PythonOperator(
+                task_id="fetch-data",
+                python_callable=lambda: None,
+                provide_context=True,
+            )
+
+    dag = TestDAG().get_dag()
 
     assert {t.task_id for t in dag.tasks} == get_base_dag_tasks(
         with_modified_date_check=False
     )
 
 
-def test_dag_tasks_with_source_modified_data_utc_callable(test_dag_cls):
-    class ModifiedTestDAG(test_dag_cls):
+def test_dag_tasks_with_source_modified_data_utc_callable():
+    class TestDAG(_PipelineDAG):
+        table_config = TableConfig(
+            table_name="test-table",
+            field_mapping=(
+                ("id", sa.Column("id", sa.Integer, primary_key=True)),
+                ("data", sa.Column("data", sa.Integer)),
+            ),
+        )
+
+        def get_fetch_operator(self):
+            return PythonOperator(
+                task_id="fetch-data",
+                python_callable=lambda: None,
+                provide_context=True,
+            )
+
         @staticmethod
         def get_source_data_modified_utc(self) -> datetime:
             return datetime(2020, 1, 1)
@@ -21,8 +56,268 @@ def test_dag_tasks_with_source_modified_data_utc_callable(test_dag_cls):
         def get_source_data_modified_utc_callable(self):
             return self.get_source_data_modified_utc
 
-    dag = ModifiedTestDAG().get_dag()
+    dag = TestDAG().get_dag()
 
     assert {t.task_id for t in dag.tasks} == get_base_dag_tasks(
         with_modified_date_check=True
     )
+
+
+def test_pipeline_dag_task_relationships():
+    class TestDAG(_PipelineDAG):
+        table_config = TableConfig(
+            table_name="test-table",
+            field_mapping=(
+                ("id", sa.Column("id", sa.Integer, primary_key=True)),
+                ("data", sa.Column("data", sa.Integer)),
+            ),
+        )
+
+        def get_fetch_operator(self):
+            return PythonOperator(
+                task_id="fetch-data",
+                python_callable=lambda: None,
+                provide_context=True,
+            )
+
+    dag = TestDAG().get_dag()
+
+    fetch_data = dag.get_task('fetch-data')
+    create_temp_tables = dag.get_task('create-temp-tables')
+    insert_into_temp_table = dag.get_task('insert-into-temp-table')
+    drop_temp_tables = dag.get_task('drop-temp-tables')
+    check_temp_table_data = dag.get_task('check-temp-table-data')
+    swap_dataset_table = dag.get_task('swap-dataset-table')
+    drop_swap_tables = dag.get_task('drop-swap-tables')
+
+    assert len(dag.tasks) == 7
+
+    assert fetch_data.upstream_task_ids == set()
+    assert fetch_data.downstream_task_ids == {'insert-into-temp-table'}
+
+    assert create_temp_tables.upstream_task_ids == set()
+    assert create_temp_tables.downstream_task_ids == {'insert-into-temp-table'}
+
+    assert insert_into_temp_table.upstream_task_ids == {
+        'create-temp-tables',
+        'fetch-data',
+    }
+    assert insert_into_temp_table.downstream_task_ids == {
+        'check-temp-table-data',
+        'drop-temp-tables',
+    }
+
+    assert drop_temp_tables.upstream_task_ids == {'insert-into-temp-table'}
+    assert drop_temp_tables.downstream_task_ids == set()
+
+    assert check_temp_table_data.upstream_task_ids == {'insert-into-temp-table'}
+    assert check_temp_table_data.downstream_task_ids == {'swap-dataset-table'}
+
+    assert swap_dataset_table.upstream_task_ids == {'check-temp-table-data'}
+    assert swap_dataset_table.downstream_task_ids == {'drop-swap-tables'}
+
+    assert drop_swap_tables.upstream_task_ids == {'swap-dataset-table'}
+    assert drop_swap_tables.downstream_task_ids == set()
+
+    # Add a late index to the table config for the DAG, which should add a new intermediate task.
+    TestDAG.table_config.indexes = [LateIndex('data')]
+    dag = TestDAG().get_dag()
+
+    fetch_data = dag.get_task('fetch-data')
+    create_temp_tables = dag.get_task('create-temp-tables')
+    insert_into_temp_table = dag.get_task('insert-into-temp-table')
+    drop_temp_tables = dag.get_task('drop-temp-tables')
+    create_post_insert_indexes = dag.get_task('create-post-insert-indexes')
+    check_temp_table_data = dag.get_task('check-temp-table-data')
+    swap_dataset_table = dag.get_task('swap-dataset-table')
+    drop_swap_tables = dag.get_task('drop-swap-tables')
+
+    assert len(dag.tasks) == 8
+
+    assert fetch_data.upstream_task_ids == set()
+    assert fetch_data.downstream_task_ids == {'insert-into-temp-table'}
+
+    assert create_temp_tables.upstream_task_ids == set()
+    assert create_temp_tables.downstream_task_ids == {'insert-into-temp-table'}
+
+    assert insert_into_temp_table.upstream_task_ids == {
+        'create-temp-tables',
+        'fetch-data',
+    }
+    assert insert_into_temp_table.downstream_task_ids == {
+        'create-post-insert-indexes',
+        'drop-temp-tables',
+    }
+
+    assert create_post_insert_indexes.upstream_task_ids == {'insert-into-temp-table'}
+    assert create_post_insert_indexes.downstream_task_ids == {'check-temp-table-data'}
+
+    assert drop_temp_tables.upstream_task_ids == {'insert-into-temp-table'}
+    assert drop_temp_tables.downstream_task_ids == set()
+
+    assert check_temp_table_data.upstream_task_ids == {'create-post-insert-indexes'}
+    assert check_temp_table_data.downstream_task_ids == {'swap-dataset-table'}
+
+    assert swap_dataset_table.upstream_task_ids == {'check-temp-table-data'}
+    assert swap_dataset_table.downstream_task_ids == {'drop-swap-tables'}
+
+    assert drop_swap_tables.upstream_task_ids == {'swap-dataset-table'}
+    assert drop_swap_tables.downstream_task_ids == set()
+
+
+def test_pandas_dag_task_relationships():
+    class TestDAG(_PandasPipelineWithPollingSupport):
+        use_polling = False
+        data_getter = lambda: None  # noqa: E731
+        table_config = TableConfig(
+            table_name="test-table",
+            field_mapping=(
+                ("id", sa.Column("id", sa.Integer, primary_key=True)),
+                ("data", sa.Column("data", sa.Integer)),
+            ),
+        )
+
+    dag = TestDAG().get_dag()
+
+    scrape_and_load_data = dag.get_task('scrape-and-load-data')
+    check_temp_table_data = dag.get_task('check-temp-table-data')
+    swap_dataset_table = dag.get_task('swap-dataset-table')
+    drop_temp_tables = dag.get_task('drop-temp-tables')
+    drop_swap_tables = dag.get_task('drop-swap-tables')
+
+    assert len(dag.tasks) == 5
+
+    assert scrape_and_load_data.upstream_task_ids == set()
+    assert scrape_and_load_data.downstream_task_ids == {
+        'drop-temp-tables',
+        'check-temp-table-data',
+    }
+
+    assert check_temp_table_data.upstream_task_ids == {'scrape-and-load-data'}
+    assert check_temp_table_data.downstream_task_ids == {'swap-dataset-table'}
+
+    assert swap_dataset_table.upstream_task_ids == {'check-temp-table-data'}
+    assert swap_dataset_table.downstream_task_ids == {'drop-swap-tables'}
+
+    assert drop_temp_tables.upstream_task_ids == {'scrape-and-load-data'}
+    assert drop_temp_tables.downstream_task_ids == set()
+
+    assert drop_swap_tables.upstream_task_ids == {'swap-dataset-table'}
+    assert drop_swap_tables.downstream_task_ids == set()
+
+    # Add a late index to the table config for the DAG, which should add a new intermediate task.
+    TestDAG.table_config.indexes = [LateIndex('data')]
+    dag = TestDAG().get_dag()
+
+    scrape_and_load_data = dag.get_task('scrape-and-load-data')
+    check_temp_table_data = dag.get_task('check-temp-table-data')
+    create_post_insert_indexes = dag.get_task('create-post-insert-indexes')
+    swap_dataset_table = dag.get_task('swap-dataset-table')
+    drop_temp_tables = dag.get_task('drop-temp-tables')
+    drop_swap_tables = dag.get_task('drop-swap-tables')
+
+    assert len(dag.tasks) == 6
+
+    assert scrape_and_load_data.upstream_task_ids == set()
+    assert scrape_and_load_data.downstream_task_ids == {
+        'drop-temp-tables',
+        'create-post-insert-indexes',
+    }
+
+    assert check_temp_table_data.upstream_task_ids == {'create-post-insert-indexes'}
+    assert check_temp_table_data.downstream_task_ids == {'swap-dataset-table'}
+
+    assert create_post_insert_indexes.upstream_task_ids == {'scrape-and-load-data'}
+    assert create_post_insert_indexes.downstream_task_ids == {'check-temp-table-data'}
+
+    assert swap_dataset_table.upstream_task_ids == {'check-temp-table-data'}
+    assert swap_dataset_table.downstream_task_ids == {'drop-swap-tables'}
+
+    assert drop_temp_tables.upstream_task_ids == {'scrape-and-load-data'}
+    assert drop_temp_tables.downstream_task_ids == set()
+
+    assert drop_swap_tables.upstream_task_ids == {'swap-dataset-table'}
+    assert drop_swap_tables.downstream_task_ids == set()
+
+    # Enable polling on the pipeline, which should add a new task at the start of the DAG.
+    TestDAG.use_polling = True
+    dag = TestDAG().get_dag()
+
+    poll_for_new_data = dag.get_task('poll-for-new-data')
+    scrape_and_load_data = dag.get_task('scrape-and-load-data')
+    check_temp_table_data = dag.get_task('check-temp-table-data')
+    create_post_insert_indexes = dag.get_task('create-post-insert-indexes')
+    swap_dataset_table = dag.get_task('swap-dataset-table')
+    drop_temp_tables = dag.get_task('drop-temp-tables')
+    drop_swap_tables = dag.get_task('drop-swap-tables')
+
+    assert len(dag.tasks) == 7
+
+    assert poll_for_new_data.upstream_task_ids == set()
+    assert poll_for_new_data.downstream_task_ids == {'scrape-and-load-data'}
+
+    assert scrape_and_load_data.upstream_task_ids == {'poll-for-new-data'}
+    assert scrape_and_load_data.downstream_task_ids == {
+        'drop-temp-tables',
+        'create-post-insert-indexes',
+    }
+
+    assert check_temp_table_data.upstream_task_ids == {'create-post-insert-indexes'}
+    assert check_temp_table_data.downstream_task_ids == {'swap-dataset-table'}
+
+    assert create_post_insert_indexes.upstream_task_ids == {'scrape-and-load-data'}
+    assert create_post_insert_indexes.downstream_task_ids == {'check-temp-table-data'}
+
+    assert swap_dataset_table.upstream_task_ids == {'check-temp-table-data'}
+    assert swap_dataset_table.downstream_task_ids == {'drop-swap-tables'}
+
+    assert drop_temp_tables.upstream_task_ids == {'scrape-and-load-data'}
+    assert drop_temp_tables.downstream_task_ids == set()
+
+    assert drop_swap_tables.upstream_task_ids == {'swap-dataset-table'}
+    assert drop_swap_tables.downstream_task_ids == set()
+
+    # Enable email notifications on DAG completion, which adds a new task at the end.
+    TestDAG.update_emails_data_environment_variable = 'MY_ENV_VAR'
+    dag = TestDAG().get_dag()
+
+    poll_for_new_data = dag.get_task('poll-for-new-data')
+    scrape_and_load_data = dag.get_task('scrape-and-load-data')
+    check_temp_table_data = dag.get_task('check-temp-table-data')
+    create_post_insert_indexes = dag.get_task('create-post-insert-indexes')
+    swap_dataset_table = dag.get_task('swap-dataset-table')
+    send_dataset_updated_emails = dag.get_task('send-dataset-updated-emails')
+    drop_temp_tables = dag.get_task('drop-temp-tables')
+    drop_swap_tables = dag.get_task('drop-swap-tables')
+
+    assert len(dag.tasks) == 8
+
+    assert poll_for_new_data.upstream_task_ids == set()
+    assert poll_for_new_data.downstream_task_ids == {'scrape-and-load-data'}
+
+    assert scrape_and_load_data.upstream_task_ids == {'poll-for-new-data'}
+    assert scrape_and_load_data.downstream_task_ids == {
+        'drop-temp-tables',
+        'create-post-insert-indexes',
+    }
+
+    assert check_temp_table_data.upstream_task_ids == {'create-post-insert-indexes'}
+    assert check_temp_table_data.downstream_task_ids == {'swap-dataset-table'}
+
+    assert create_post_insert_indexes.upstream_task_ids == {'scrape-and-load-data'}
+    assert create_post_insert_indexes.downstream_task_ids == {'check-temp-table-data'}
+
+    assert swap_dataset_table.upstream_task_ids == {'check-temp-table-data'}
+    assert swap_dataset_table.downstream_task_ids == {
+        'drop-swap-tables',
+        'send-dataset-updated-emails',
+    }
+
+    assert drop_temp_tables.upstream_task_ids == {'scrape-and-load-data'}
+    assert drop_temp_tables.downstream_task_ids == set()
+
+    assert drop_swap_tables.upstream_task_ids == {'swap-dataset-table'}
+    assert drop_swap_tables.downstream_task_ids == set()
+
+    assert send_dataset_updated_emails.upstream_task_ids == {'swap-dataset-table'}
+    assert send_dataset_updated_emails.downstream_task_ids == set()

--- a/tests/unit/operators/test_comtrade.py
+++ b/tests/unit/operators/test_comtrade.py
@@ -2,14 +2,15 @@ import io
 import zipfile
 from unittest import mock
 
+import pandas
+
 from dataflow.operators import comtrade
 
 
 DUMMY_DATA_FILENAME = "SMKE191912.zip"
 
 
-def test_fetch_goods_from_comtrade(mocker, requests_mock):
-
+def test_fetch_goods_from_comtrade(requests_mock):
     requests_mock.get(
         "https://comtrade.un.org/Data/cache/years.json",
         json={
@@ -48,65 +49,67 @@ def test_fetch_goods_from_comtrade(mocker, requests_mock):
         content=goods_csv_2018.getvalue(),
     )
 
-    s3_mock = mock.MagicMock()
-    mocker.patch.object(comtrade, "S3Data", return_value=s3_mock, autospec=True)
+    data_frames = list(comtrade.fetch_comtrade_goods_data_frames())
 
-    comtrade.fetch_comtrade_goods_data(
-        "goods", ts_nodash="task-1",
-    )
-
-    file_1_rows = [
-        {
-            'Classification': 'S3',
-            'Year': '2008',
-            'Period': '2008',
-            'Period Desc.': '2008',
-            'Aggregate Level': '1',
-            'Is Leaf Code': '0',
-            'Trade Flow Code': '1',
-            'Trade Flow': 'Import',
-            'Reporter Code': '4',
-            'Reporter': 'Afghanistan',
-            'Reporter ISO': 'AFG',
-            'Partner Code': '0',
-            'Partner': 'World',
-            'Partner ISO': 'WLD',
-            'Commodity Code': '0',
-            'Commodity': 'Food and live animals',
-            'Qty Unit Code': '1',
-            'Qty Unit': 'No Quantity',
-            'Qty': None,
-            'Netweight (kg)': None,
-            'Trade Value (US$)': '309541080',
-            'Flag': '0',
-        },
-        {
-            'Classification': 'S3',
-            'Year': '2008',
-            'Period': '2008',
-            'Period Desc.': '2008',
-            'Aggregate Level': '1',
-            'Is Leaf Code': '0',
-            'Trade Flow Code': '2',
-            'Trade Flow': 'Export',
-            'Reporter Code': '4',
-            'Reporter': 'Afghanistan',
-            'Reporter ISO': 'AFG',
-            'Partner Code': '0',
-            'Partner': 'World',
-            'Partner ISO': 'WLD',
-            'Commodity Code': '0',
-            'Commodity': 'Food and live animals',
-            'Qty Unit Code': '1',
-            'Qty Unit': 'No Quantity',
-            'Qty': None,
-            'Netweight (kg)': None,
-            'Trade Value (US$)': '280276257',
-            'Flag': '0',
-        },
+    expected_data_frames = [
+        pandas.DataFrame(
+            [
+                {
+                    'Classification': 'S3',
+                    'Year': '2008',
+                    'Period': '2008',
+                    'Period Desc.': '2008',
+                    'Aggregate Level': '1',
+                    'Is Leaf Code': False,
+                    'Trade Flow Code': '1',
+                    'Trade Flow': 'Import',
+                    'Reporter Code': '4',
+                    'Reporter': 'Afghanistan',
+                    'Reporter ISO': 'AFG',
+                    'Partner Code': '0',
+                    'Partner': 'World',
+                    'Partner ISO': 'WLD',
+                    'Commodity Code': '0',
+                    'Commodity': 'Food and live animals',
+                    'Qty Unit Code': '1',
+                    'Qty Unit': 'No Quantity',
+                    'Qty': None,
+                    'Trade Value (US$)': '309541080',
+                }
+            ],
+        ),
+        pandas.DataFrame(
+            [
+                {
+                    'Classification': 'S3',
+                    'Year': '2008',
+                    'Period': '2008',
+                    'Period Desc.': '2008',
+                    'Aggregate Level': '1',
+                    'Is Leaf Code': False,
+                    'Trade Flow Code': '2',
+                    'Trade Flow': 'Export',
+                    'Reporter Code': '4',
+                    'Reporter': 'Afghanistan',
+                    'Reporter ISO': 'AFG',
+                    'Partner Code': '0',
+                    'Partner': 'World',
+                    'Partner ISO': 'WLD',
+                    'Commodity Code': '0',
+                    'Commodity': 'Food and live animals',
+                    'Qty Unit Code': '1',
+                    'Qty Unit': 'No Quantity',
+                    'Qty': None,
+                    'Trade Value (US$)': '280276257',
+                }
+            ]
+        ),
     ]
 
-    s3_mock.write_key.assert_has_calls([mock.call("0000000000.json", file_1_rows)])
+    assert all(
+        df.to_csv() == edf.to_csv()
+        for df, edf in zip(data_frames, expected_data_frames)
+    )
 
 
 def test_fetch_services_from_comtrade(mocker, requests_mock):

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -630,9 +630,6 @@ def test_poll_scrape_and_load_data(mocker, monkeypatch):
     )
     mock_temp_table.return_value.name = 'tmp_test_table'
     mock_temp_table.return_value.schema = 'test'
-    mock_check_table_data = mocker.patch.object(
-        db_tables, "check_table_data", autospec=True
-    )
     mocker.patch("dataflow.operators.db_tables.sleep", autospec=True)
     mock_postgres = mocker.patch(
         "dataflow.operators.db_tables.psycopg3.connect", autospec=True
@@ -668,15 +665,3 @@ def test_poll_scrape_and_load_data(mocker, monkeypatch):
         )
     ]
     assert mock_copy_write.call_args_list == [mock.call("1\t50\n2\t999\n")]
-    assert mock_check_table_data.call_args_list == [
-        mock.call(
-            'test-db',
-            mock.ANY,
-            allow_null_columns=False,
-            ts_nodash='123',
-            dag=mock.ANY,
-            dag_run=mock.ANY,
-            ti=mock.ANY,
-            task_instance=mock.ANY,
-        )
-    ]

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+from collections import defaultdict
 from glob import glob
 
 from dataflow.dags import _PipelineDAG
@@ -73,5 +74,18 @@ def get_fetch_retries_for_all_concrete_dags():
     results_dict = {}
     for dag_class in concrete_dag_classes:
         results_dict[dag_class.__name__] = dag_class().get_fetch_operator().retries
+
+    return results_dict
+
+
+def get_dags_with_non_pk_indexes_on_sqlalchemy_columns():
+    concrete_dag_classes = get_all_dag_concrete_subclasses(_PipelineDAG)
+
+    results_dict = defaultdict(list)
+    for dag_class in concrete_dag_classes:
+        for table in dag_class().table_config.tables:
+            for col in table.columns:
+                if col.index is True or col.unique is True:
+                    results_dict[dag_class.__name__].append(col.name)
 
     return results_dict

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -29,6 +29,7 @@ def get_polling_dag_tasks(with_emails=False):
     tasks = {
         "poll-for-new-data",
         "scrape-and-load-data",
+        "check-temp-table-data",
         "swap-dataset-table",
         "drop-swap-tables",
         "drop-temp-tables",


### PR DESCRIPTION
### Commit 1 - speed up comtrade goods
The goods pipeline is trying to pull in >500 million rows, so a standard
pipeline will not work as that does row-by-row inserts. We need to do
bulk inserts via postgresql copy. This patch does the following:

1) Update the "_FastPollingPipeline" to a mouthful of a
   "_PandasPipelineWithPollingSupport". This pipeline type loads
   data into pandas DataFrames and writes the csv output of this
   directly into postgres via a `copy` command. This renaming removes
   some of the vagueness of the "fast" naming and hopefully makes it
   easier to grok on sight.
2) Change the Comtrade Goods pipeline from a standard one to a Pandas
   one, and re-writes the logic to use pandas Data Frames, chunking data
   into blocks of 1 million to reduce maximum memory footprint. This
   required adapting the Pandas pipeline's main task to take a
   list/iterable of DataFrames rather than a single DataFrame, which
   further required updates to the existing ONS pipelines.
3) Disable indexing on the Comtrade Goods pipeline, which was causing
   intermittent throttling of the task. This appeared to be throttling
   on the DB side, presumably as it intermittently
   resolves/flushes/"does something" to the incoming data/indexes.
4) Update the Comtrade Goods pipeline to run weekly, starting on a
   Saturday morning, as the ingest is still expected to take multiple
   hours.
5) Change the main Pandas pipeline task to use psycopg3, an
   in-development successor to psycopg2, that simplifies "pushing" data
   into Postgres, which is what we want to do from multiple DataFrames.
   If this fails, theoretically we could still use psycopg2, but we'd
   need to write an obscure file-like object to handle our stream
   processing.
   https://www.psycopg.org/articles/2020/11/15/psycopg3-copy/

### Commit 2 - add post-insert indexing task
For larger datasets, having the index established on the column before
we start inserting data leads to significant loss of efficiency/speed.
This patch provides support for defining indexes outside of the
`sa.Column` objects in the field mapping, meaning that columns can be
initially created without columns.

If any columns are defined on `TableConfig.indexes`, then we insert
an additional task into the DAG after the insert task to create the
indexes.

For pandas pipelines, we inline the post-insert-index-creation task
straight into the fetch-and-insert combined task.

### Commit 3 - tweak pandas pipeline task flow
The pandas pipeline currently merges the tasks for fetching data,
transforming it, ingesting it, and validating it into a single task. Now
that we are also building indexes after inserting the data, it feels
reasonable to split this task and data validation out into separate
steps. This pipeline is being used for some large datasets, and if the
index creation or data validation fail for transient reasons, we don't
want to have to re-fetch and insert all of the data again as it will
introduce significant delays.

We run the "check table" and "apply post-insert indexes" tasks in
parallel to try to preserve as much "speed" across the full length of
the pipeline, which is currently being used for some time-sensitive
processing. With them parallel, we are only increasing processing time
of the pipeline by approximately the time it takes Airflow to schedule
an extra task.


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
