### PR TITLE
Update HMRC pipelines

### DIFF
--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -61,6 +61,7 @@ class HMRCNonEUExports(_HMRCPipeline):
             (19, sa.Column("quantity_1", sa.BigInteger)),
             (20, sa.Column("quantity_2", sa.BigInteger)),
             (21, sa.Column("industrial_plant_comcode", sa.String(15))),
+            (22, sa.Column("_source_name", sa.String())),
         ],
     )
 
@@ -100,6 +101,7 @@ class HMRCNonEUImports(_HMRCPipeline):
             (23, sa.Column("value", sa.BigInteger)),
             (24, sa.Column("quantity_1", sa.BigInteger)),
             (25, sa.Column("quantity_2", sa.BigInteger)),
+            (26, sa.Column("_source_name", sa.String())),
         ],
     )
 
@@ -130,6 +132,7 @@ class HMRCEUExports(_HMRCPipeline):
             (14, sa.Column("value", sa.BigInteger)),
             (15, sa.Column("nett_mass", sa.BigInteger)),
             (16, sa.Column("supp_unit", sa.BigInteger)),
+            (17, sa.Column("_source_name", sa.String())),
         ],
     )
 
@@ -160,5 +163,6 @@ class HMRCEUImports(_HMRCPipeline):
             (14, sa.Column("value", sa.BigInteger)),
             (15, sa.Column("nett_mass", sa.BigInteger)),
             (16, sa.Column("supp_unit", sa.BigInteger)),
+            (17, sa.Column("_source_name", sa.String())),
         ],
     )

--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -32,6 +32,7 @@ class _HMRCPipeline(_PipelineDAG):
 
 class HMRCNonEUExports(_HMRCPipeline):
     base_filename = "smke19"
+    records_start_year = 2009
     table_config = TableConfig(
         schema="hmrc",
         table_name="non_eu_exports",
@@ -66,6 +67,7 @@ class HMRCNonEUExports(_HMRCPipeline):
 
 class HMRCNonEUImports(_HMRCPipeline):
     base_filename = "smki19"
+    records_start_year = 2009
     table_config = TableConfig(
         schema="hmrc",
         table_name="non_eu_imports",
@@ -104,6 +106,7 @@ class HMRCNonEUImports(_HMRCPipeline):
 
 class HMRCEUExports(_HMRCPipeline):
     base_filename = "smkx46"
+    records_start_year = 2009
     table_config = TableConfig(
         schema="hmrc",
         table_name="eu_exports",
@@ -133,6 +136,7 @@ class HMRCEUExports(_HMRCPipeline):
 
 class HMRCEUImports(_HMRCPipeline):
     base_filename = "smkm46"
+    records_start_year = 2009
     table_config = TableConfig(
         schema="hmrc",
         table_name="eu_imports",

--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -15,6 +15,7 @@ class _HMRCPipeline(_PipelineDAG):
     schedule_interval = '0 5 12 * *'
     start_date = datetime(2020, 3, 11)
     use_utc_now_as_source_modified = True
+    num_csv_fields: int
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(
@@ -25,6 +26,7 @@ class _HMRCPipeline(_PipelineDAG):
                 self.table_config.table_name,  # pylint: disable=no-member
                 self.base_filename,
                 self.records_start_year,
+                self.num_csv_fields,
             ],
             retries=self.fetch_retries,
         )
@@ -33,6 +35,7 @@ class _HMRCPipeline(_PipelineDAG):
 class HMRCNonEUExports(_HMRCPipeline):
     base_filename = "smke19"
     records_start_year = 2009
+    num_csv_fields = 22
     table_config = TableConfig(
         schema="hmrc",
         table_name="non_eu_exports",
@@ -69,6 +72,7 @@ class HMRCNonEUExports(_HMRCPipeline):
 class HMRCNonEUImports(_HMRCPipeline):
     base_filename = "smki19"
     records_start_year = 2009
+    num_csv_fields = 26
     table_config = TableConfig(
         schema="hmrc",
         table_name="non_eu_imports",
@@ -109,6 +113,7 @@ class HMRCNonEUImports(_HMRCPipeline):
 class HMRCEUExports(_HMRCPipeline):
     base_filename = "smkx46"
     records_start_year = 2009
+    num_csv_fields = 17
     table_config = TableConfig(
         schema="hmrc",
         table_name="eu_exports",
@@ -140,6 +145,7 @@ class HMRCEUExports(_HMRCPipeline):
 class HMRCEUImports(_HMRCPipeline):
     base_filename = "smkm46"
     records_start_year = 2009
+    num_csv_fields = 17
     table_config = TableConfig(
         schema="hmrc",
         table_name="eu_imports",

--- a/dataflow/operators/hmrc.py
+++ b/dataflow/operators/hmrc.py
@@ -74,12 +74,6 @@ def fetch_hmrc_trade_data(
                     f"/{base_filename}_{year}archive.zip",
                 )
             )
-            yield from nested_files_from_zip(
-                get_file_linked_from(
-                    config.HMRC_UKTRADEINFO_ARCHIVE_URL,
-                    f"/{base_filename}_{year}archive_juldec.zip",
-                )
-            )
 
         if latest_file_date.month > 1:
             yield from nested_files_from_zip(

--- a/dataflow/operators/hmrc.py
+++ b/dataflow/operators/hmrc.py
@@ -16,6 +16,7 @@ def fetch_hmrc_trade_data(
     table_name: str,
     base_filename: str,
     records_start_year: int,
+    num_expected_fields: int,
     num_per_page: int = 10000,
     **kwargs,
 ):
@@ -94,7 +95,16 @@ def fetch_hmrc_trade_data(
         for file, source_name in files:
             logger.info('Parsing file %s', file)
             for line in _without_first_and_last(file):
-                yield line.strip().decode('utf-8').split("|") + [source_name]
+                data = line.strip().decode('utf-8').split("|")
+                if len(data) == num_expected_fields:
+                    yield line.strip().decode('utf-8').split("|") + [source_name]
+                else:
+                    logger.warn(
+                        "Ignoring row with %s fields instead of expected %s: %s",
+                        len(data),
+                        num_expected_fields,
+                        line,
+                    )
 
     def paginate(lines):
         page = []

--- a/tests/unit/operators/test_hmrc.py
+++ b/tests/unit/operators/test_hmrc.py
@@ -93,6 +93,7 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
         "non-eu-exports",
         "smke19",
         records_start_year,
+        22,
         num_per_page=4,
         ts_nodash="task-1",
         run_date=run_date,

--- a/tests/unit/operators/test_hmrc.py
+++ b/tests/unit/operators/test_hmrc.py
@@ -25,7 +25,6 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
     html_archive = (
         '<a href="http://test/a/unrelated.zip"></a>'
         '<a href="http://test/b/smke19_2019archive.zip"></a>'
-        '<a href="http://test/c/smke19_2019archive_juldec.zip"></a>'
         '<a href="http://test/d/unrelated.zip"></a>'
     )
 
@@ -75,9 +74,6 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
     requests_mock.get("http://test/latest", content=html_latest.encode())
 
     requests_mock.get("http://test/b/smke19_2019archive.zip", content=file3.getvalue())
-    requests_mock.get(
-        "http://test/c/smke19_2019archive_juldec.zip", content=file3.getvalue()
-    )
     requests_mock.get("http://test/f/smke192002.zip", content=file1.getvalue())
     requests_mock.get("http://test/g/smke19_2020archive.zip", content=file3.getvalue())
 
@@ -206,7 +202,6 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
         [
             mock.call("0000000000.json", file_1_rows + file_2_rows),
             mock.call("0000000001.json", file_1_rows + file_2_rows),
-            mock.call("0000000002.json", file_1_rows + file_2_rows),
-            mock.call("0000000003.json", file_1_rows),
+            mock.call("0000000002.json", file_1_rows),
         ]
     )

--- a/tests/unit/operators/test_hmrc.py
+++ b/tests/unit/operators/test_hmrc.py
@@ -122,6 +122,7 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
             "+0000000000500",
             "+0000000000001",
             "000000000000000",
+            "dummy_export_data",
         ],
         [
             "010121000",
@@ -146,6 +147,7 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
             "+0000000000500",
             "+0000000000001",
             "000000000000000",
+            "dummy_export_data",
         ],
         [
             "010121000",
@@ -170,6 +172,7 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
             "+0000000000500",
             "+0000000000001",
             "000000000000000",
+            "dummy_export_data",
         ],
     ]
     file_2_rows = [
@@ -196,6 +199,7 @@ def test_fetch_from_uktradeinfo(mocker, requests_mock):
             "+0000000000500",
             "+0000000000001",
             "000000000000000",
+            "dummy_export_data",
         ]
     ]
     s3_mock.write_key.assert_has_calls(


### PR DESCRIPTION
### Description of change
* Pull data from as far back as their records go (generally 2009).
* Add a new column including the name of the file the row has come from
* Check for "latest" files within the last two months. Running them today, the latest data is from October but the pipelines only look at November.


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
