### PR TITLE
fix: migrate export wins dependent pipelines

### DIFF
--- a/dataflow/dags/derived_report_table_pipelines.py
+++ b/dataflow/dags/derived_report_table_pipelines.py
@@ -250,26 +250,26 @@ class ExportWinsDerivedReportTablePipeline(_DerivedReportTablePipeline):
                     THEN (to_char(date, 'YYYY')::int)
                     ELSE (to_char(date + interval '-1' year, 'YYYY')::int)
                 END as win_financial_year
-            FROM export_wins_wins_dataset
-            WHERE export_wins_wins_dataset.customer_email_date IS NOT NULL
+            FROM dit.export_wins__wins_dataset
+            WHERE export_wins__wins_dataset.customer_email_date IS NOT NULL
         ), export_breakdowns AS (
             SELECT win_id, year, value
-            FROM export_wins_breakdowns_dataset
+            FROM dit.export_wins__breakdowns_dataset
             WHERE win_id IN (select id from export_wins)
-            AND export_wins_breakdowns_dataset.type = 'Export'
+            AND export_wins__breakdowns_dataset.type = 'Export'
         ), non_export_breakdowns AS (
             SELECT win_id, year, value
-            FROM export_wins_breakdowns_dataset
+            FROM dit.export_wins__breakdowns_dataset
             WHERE win_id IN (select id from export_wins)
-            AND export_wins_breakdowns_dataset.type = 'Non-export'
+            AND export_wins__breakdowns_dataset.type = 'Non-export'
         ), odi_breakdowns AS (
             SELECT win_id, year, value
-            FROM export_wins_breakdowns_dataset
+            FROM dit.export_wins__breakdowns_dataset
             WHERE win_id IN (select id from export_wins)
-            AND export_wins_breakdowns_dataset.type = 'Outward Direct Investment'
+            AND export_wins__breakdowns_dataset.type = 'Outward Direct Investment'
         ), contributing_advisers AS (
             SELECT win_id, STRING_AGG(CONCAT('Name: ', name, ', Team: ', team_type, ' - ', hq_team, ' - ', location), ', ') as advisers
-            FROM export_wins_advisers_dataset
+            FROM dit.export_wins__advisers_dataset
             GROUP BY 1
         )
         SELECT
@@ -294,7 +294,7 @@ class ExportWinsDerivedReportTablePipeline(_DerivedReportTablePipeline):
             export_wins.goods_vs_services,
             export_wins.sector,
             COALESCE(export_wins.is_prosperity_fund_related, 'False') AS prosperity_fund_related,
-            export_wins_hvc_dataset.name AS hvc_code,
+            export_wins__hvc_dataset.name AS hvc_code,
             export_wins.hvo_programme,
             COALESCE(export_wins.has_hvo_specialist_involvement, 'False') AS has_hvo_specialist_involvement,
             COALESCE(export_wins.is_e_exported, 'False') AS is_e_exported,
@@ -495,6 +495,6 @@ class ExportWinsDerivedReportTablePipeline(_DerivedReportTablePipeline):
             AND odibd5.year = win_financial_year + 4
         )
         LEFT JOIN contributing_advisers ON contributing_advisers.win_id = export_wins.id
-        LEFT JOIN export_wins_hvc_dataset ON export_wins.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
+        LEFT JOIN dit.export_wins__hvc_dataset ON export_wins.hvc = CONCAT(export_wins__hvc_dataset.campaign_id, export_wins__hvc_dataset.financial_year)
         ORDER BY export_wins.confirmation_created NULLS FIRST
     '''

--- a/dataflow/dags/export_wins_dashboard.py
+++ b/dataflow/dags/export_wins_dashboard.py
@@ -74,7 +74,7 @@ class ExportWinsDashboardPipeline(_PipelineDAG):
     query = '''
     WITH datahub_companies AS (
       SELECT
-        DISTINCT ON (export_wins_wins_dataset.id) export_wins_wins_dataset.id AS export_win_id,
+        DISTINCT ON (export_wins__wins_dataset.id) export_wins__wins_dataset.id AS export_win_id,
         CASE
           WHEN data_hub__companies.id IS NOT NULL
             THEN CONCAT('https://datahub.trade.gov.uk/companies/',data_hub__companies.id,'/exports')
@@ -86,87 +86,87 @@ class ExportWinsDashboardPipeline(_PipelineDAG):
           ELSE ''
         END AS dh_company_name
 
-        FROM export_wins_wins_dataset
-          LEFT JOIN export_wins_wins_dataset_match_ids ON export_wins_wins_dataset_match_ids.id::uuid = export_wins_wins_dataset.id
+        FROM dit.export_wins__wins_dataset
+          LEFT JOIN export_wins_wins_dataset_match_ids ON export_wins_wins_dataset_match_ids.id::uuid = export_wins__wins_dataset.id
           LEFT JOIN companies_dataset_match_ids ON companies_dataset_match_ids.match_id = export_wins_wins_dataset_match_ids.match_id
           LEFT JOIN dit.data_hub__companies ON data_hub__companies.id = companies_dataset_match_ids.id::uuid
 
     ), win_participants AS (
       select
-        export_wins_wins_dataset.id AS win_id,
-        initcap(export_wins_wins_dataset.lead_officer_name) AS participant_name,
-        export_wins_wins_dataset.hq_team AS participant_team,
-        export_wins_wins_dataset.team_type AS team_type,
+        export_wins__wins_dataset.id AS win_id,
+        initcap(export_wins__wins_dataset.lead_officer_name) AS participant_name,
+        export_wins__wins_dataset.hq_team AS participant_team,
+        export_wins__wins_dataset.team_type AS team_type,
         'Lead' AS contribution_type
 
-      from export_wins_wins_dataset
+      from dit.export_wins__wins_dataset
         UNION ALL
           select
-            export_wins_advisers_dataset.win_id,
-            initcap(export_wins_advisers_dataset.name),
-            export_wins_advisers_dataset.hq_team,
-            export_wins_advisers_dataset.team_type,
+            export_wins__advisers_dataset.win_id,
+            initcap(export_wins__advisers_dataset.name),
+            export_wins__advisers_dataset.hq_team,
+            export_wins__advisers_dataset.team_type,
             'Contributor' AS "Contribution"
 
-          from export_wins_advisers_dataset
+          from dit.export_wins__advisers_dataset
 
     ), contributor_count AS (
       SELECT
-        export_wins_wins_dataset.id AS id,
-        count(export_wins_advisers_dataset.*) AS contributor_count
+        export_wins__wins_dataset.id AS id,
+        count(export_wins__advisers_dataset.*) AS contributor_count
 
-      from export_wins_wins_dataset
-        join export_wins_advisers_dataset on export_wins_advisers_dataset.win_id = export_wins_wins_dataset.id
+      from dit.export_wins__wins_dataset
+        join dit.export_wins__advisers_dataset on export_wins__advisers_dataset.win_id = export_wins__wins_dataset.id
 
-      group by export_wins_wins_dataset.id
+      group by export_wins__wins_dataset.id
 
     )
 
     SELECT
-      export_wins_wins_dataset.id AS "EW ID",
+      export_wins__wins_dataset.id AS "EW ID",
       CASE
         WHEN datahub_companies.dh_company_name = ''
-          THEN export_wins_wins_dataset.company_name
+          THEN export_wins__wins_dataset.company_name
         ELSE datahub_companies.dh_company_name
       END AS "Company name",
       datahub_companies.dh_company_link AS "DH company link",
-      export_wins_wins_dataset.confirmation_agree_with_win AS "EW agree with win",
+      export_wins__wins_dataset.confirmation_agree_with_win AS "EW agree with win",
       CASE
-        WHEN export_wins_wins_dataset.confirmation_agree_with_win = true
+        WHEN export_wins__wins_dataset.confirmation_agree_with_win = true
           THEN 'Verified'
         ELSE 'Unverified'
       END AS "Verified or unverified",
-      export_wins_wins_dataset.confirmation_created::text AS "EW confirmation created",
+      export_wins__wins_dataset.confirmation_created::text AS "EW confirmation created",
       CASE
-        WHEN export_wins_wins_dataset.confirmation_created IS NULL
+        WHEN export_wins__wins_dataset.confirmation_created IS NULL
           THEN NULL
-        WHEN DATE_PART('month', export_wins_wins_dataset.confirmation_created) >= 4
-          THEN CONCAT((DATE_PART('year', export_wins_wins_dataset.confirmation_created)::varchar),' / ',(DATE_PART('year', export_wins_wins_dataset.confirmation_created + interval '+1' year)::varchar))
-        ELSE CONCAT((DATE_PART('year', export_wins_wins_dataset.confirmation_created + interval '-1' year)::varchar),' / ',(DATE_PART('year', export_wins_wins_dataset.confirmation_created)::varchar))
+        WHEN DATE_PART('month', export_wins__wins_dataset.confirmation_created) >= 4
+          THEN CONCAT((DATE_PART('year', export_wins__wins_dataset.confirmation_created)::varchar),' / ',(DATE_PART('year', export_wins__wins_dataset.confirmation_created + interval '+1' year)::varchar))
+        ELSE CONCAT((DATE_PART('year', export_wins__wins_dataset.confirmation_created + interval '-1' year)::varchar),' / ',(DATE_PART('year', export_wins__wins_dataset.confirmation_created)::varchar))
       END AS "Confirmation financial year",
-      export_wins_wins_dataset.country AS "EW country",
-      export_wins_wins_dataset.created::text AS "EW created date",
-      export_wins_wins_dataset.customer_email_date::text AS "EW customer email date",
-      export_wins_wins_dataset.date::text AS "EW date business won",
-      export_wins_wins_dataset.total_expected_export_value AS "EW total expected export value",
-      export_wins_wins_dataset.total_expected_non_export_value AS "EW total expected non-export value",
-      export_wins_wins_dataset.total_expected_odi_value AS "EW total expected ODI value",
-      export_wins_wins_dataset.customer_location AS "EW Customer Location",
-      SPLIT_PART(export_wins_wins_dataset.sector, ' : ', 1) AS "EW sector",
-      DATE_PART('day', export_wins_wins_dataset.confirmation_created - export_wins_wins_dataset.customer_email_date) AS "Time to confirm",
-      LEFT(export_wins_wins_dataset.hvc,4) AS "EW HVC Code",
-      export_wins_hvc_dataset.name AS "EW HVC Name",
+      export_wins__wins_dataset.country AS "EW country",
+      export_wins__wins_dataset.created::text AS "EW created date",
+      export_wins__wins_dataset.customer_email_date::text AS "EW customer email date",
+      export_wins__wins_dataset.date::text AS "EW date business won",
+      export_wins__wins_dataset.total_expected_export_value AS "EW total expected export value",
+      export_wins__wins_dataset.total_expected_non_export_value AS "EW total expected non-export value",
+      export_wins__wins_dataset.total_expected_odi_value AS "EW total expected ODI value",
+      export_wins__wins_dataset.customer_location AS "EW Customer Location",
+      SPLIT_PART(export_wins__wins_dataset.sector, ' : ', 1) AS "EW sector",
+      DATE_PART('day', export_wins__wins_dataset.confirmation_created - export_wins__wins_dataset.customer_email_date) AS "Time to confirm",
+      LEFT(export_wins__wins_dataset.hvc,4) AS "EW HVC Code",
+      export_wins__hvc_dataset.name AS "EW HVC Name",
       win_participants.participant_name,
       win_participants.participant_team,
       win_participants.team_type,
       win_participants.contribution_type,
       CASE WHEN contributor_count IS NULL THEN 1 ELSE (contributor_count.contributor_count + 1) END AS "Number of Advisers Involved"
 
-    FROM export_wins_wins_dataset
-      JOIN datahub_companies ON datahub_companies.export_win_id = export_wins_wins_dataset.id
-      LEFT JOIN export_wins_hvc_dataset ON export_wins_wins_dataset.hvc = CONCAT(export_wins_hvc_dataset.campaign_id, export_wins_hvc_dataset.financial_year)
-      JOIN win_participants ON win_participants.win_id = export_wins_wins_dataset.id
-      LEFT JOIN contributor_count ON contributor_count.id = export_wins_wins_dataset.id
+    FROM dit.export_wins__wins_dataset
+      JOIN datahub_companies ON datahub_companies.export_win_id = export_wins__wins_dataset.id
+      LEFT JOIN dit.export_wins__hvc_dataset ON export_wins__wins_dataset.hvc = CONCAT(export_wins__hvc_dataset.campaign_id, export_wins__hvc_dataset.financial_year)
+      JOIN win_participants ON win_participants.win_id = export_wins__wins_dataset.id
+      LEFT JOIN contributor_count ON contributor_count.id = export_wins__wins_dataset.id
 
     '''
 


### PR DESCRIPTION
### Description of change
The pipeline that created the `export_wins_wins_dataset` table is now
creating our "name standard" `exports_wins__wins_dataset` table. Some of
the downstream pipelines weren't updated to use the new table name.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
