### PR TITLE
fix: allow triggering DAGs from other DAGs

### DIFF
--- a/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
+++ b/dataflow/dags/csv_pipelines/ons_csv_pipelines.py
@@ -4,22 +4,22 @@ from datetime import datetime
 
 
 from dataflow.dags import _CSVPipelineDAG
-from dataflow.dags.ons_pipelines import (
-    ONSUKSATradeInGoodsPollingPipeline,
-    ONSUKTotalTradeAllCountriesNSAPollingPipeline,
-    ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline,
-    ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline,
-)
 
 
 class ONSUKSATradeInGoodsCSV(_CSVPipelineDAG):
-    schedule_interval = ONSUKSATradeInGoodsPollingPipeline.schedule_interval
+    # We trigger this DAG manually from the related polling pipeline. We do this because the polling pipeline will often
+    # sit for 10+ hours and then skip the remaining tasks because it hasn't found new data. The way `dependencies`
+    # work is to look for a `success` state on the `swap-dataset-tables` task, which doesn't happen if the polling
+    # pipeline skips its workload. That results in this pipeline's external task sensor failing and eventually
+    # throwing an error (which gets reported by sentry) that we don't care about.
+    # Triggering this DAG manually will only work while there is a single parent pipeline. If that changes, we'll need
+    # to switch back to using `dependencies` and come up with an alternative solution to the polling timeout problem.
+    schedule_interval = None
+    # dependencies = [ONSUKSATradeInGoodsPollingPipeline]
 
     start_date = datetime(2020, 4, 1)
     catchup = False
     static = True
-
-    dependencies = [ONSUKSATradeInGoodsPollingPipeline]
 
     base_file_name = "ons_uk_sa_trade_in_goods"
     timestamp_output = False
@@ -134,15 +134,19 @@ FROM (
 
 
 class ONSUKTradeInServicesByPartnerCountryNSACSV(_CSVPipelineDAG):
-    schedule_interval = (
-        ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline.schedule_interval
-    )
+    # We trigger this DAG manually from the related polling pipeline. We do this because the polling pipeline will often
+    # sit for 10+ hours and then skip the remaining tasks because it hasn't found new data. The way `dependencies`
+    # work is to look for a `success` state on the `swap-dataset-tables` task, which doesn't happen if the polling
+    # pipeline skips its workload. That results in this pipeline's external task sensor failing and eventually
+    # throwing an error (which gets reported by sentry) that we don't care about.
+    # Triggering this DAG manually will only work while there is a single parent pipeline. If that changes, we'll need
+    # to switch back to using `dependencies` and come up with an alternative solution to the polling timeout problem.
+    schedule_interval = None
+    # dependencies = [ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline]
 
     start_date = datetime(2020, 4, 1)
     catchup = False
     static = True
-
-    dependencies = [ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline]
 
     base_file_name = "ons_uk_trade_in_services_by_country_nsa"
     timestamp_output = False
@@ -201,9 +205,17 @@ FROM (
 
 
 class ONSUKTotalTradeAllCountriesNSACSVPipeline(_CSVPipelineDAG):
-    dependencies = [ONSUKTotalTradeAllCountriesNSAPollingPipeline]
-    start_date = ONSUKTotalTradeAllCountriesNSAPollingPipeline.start_date
-    schedule_interval = ONSUKTotalTradeAllCountriesNSAPollingPipeline.schedule_interval
+    # We trigger this DAG manually from the related polling pipeline. We do this because the polling pipeline will often
+    # sit for 10+ hours and then skip the remaining tasks because it hasn't found new data. The way `dependencies`
+    # work is to look for a `success` state on the `swap-dataset-tables` task, which doesn't happen if the polling
+    # pipeline skips its workload. That results in this pipeline's external task sensor failing and eventually
+    # throwing an error (which gets reported by sentry) that we don't care about.
+    # Triggering this DAG manually will only work while there is a single parent pipeline. If that changes, we'll need
+    # to switch back to using `dependencies` and come up with an alternative solution to the polling timeout problem.
+    schedule_interval = None
+    # dependencies = [ONSUKTotalTradeAllCountriesNSAPollingPipeline]
+
+    start_date = datetime(2020, 4, 1)
 
     catchup = False
     static = True
@@ -326,11 +338,17 @@ FROM (
 
 
 class ONSUKTradeInGoodsByCountryAndCommodityCSVPipeline(_CSVPipelineDAG):
-    dependencies = [ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline]
-    start_date = ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline.start_date
-    schedule_interval = (
-        ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline.schedule_interval
-    )
+    # We trigger this DAG manually from the related polling pipeline. We do this because the polling pipeline will often
+    # sit for 10+ hours and then skip the remaining tasks because it hasn't found new data. The way `dependencies`
+    # work is to look for a `success` state on the `swap-dataset-tables` task, which doesn't happen if the polling
+    # pipeline skips its workload. That results in this pipeline's external task sensor failing and eventually
+    # throwing an error (which gets reported by sentry) that we don't care about.
+    # Triggering this DAG manually will only work while there is a single parent pipeline. If that changes, we'll need
+    # to switch back to using `dependencies` and come up with an alternative solution to the polling timeout problem.
+    schedule_interval = None
+    # dependencies = [ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline]
+
+    start_date = datetime(2020, 4, 1)
 
     catchup = False
     static = True

--- a/dataflow/dags/ons_pipelines.py
+++ b/dataflow/dags/ons_pipelines.py
@@ -5,6 +5,12 @@ import sqlalchemy as sa
 
 from dataflow.dags import _PipelineDAG
 from dataflow.dags.base import _PandasPipelineWithPollingSupport
+from dataflow.dags.csv_pipelines.ons_csv_pipelines import (
+    ONSUKTradeInGoodsByCountryAndCommodityCSVPipeline,
+    ONSUKSATradeInGoodsCSV,
+    ONSUKTradeInServicesByPartnerCountryNSACSV,
+    ONSUKTotalTradeAllCountriesNSACSVPipeline,
+)
 from dataflow.operators.ons import fetch_from_ons_sparql
 from dataflow.utils import SingleTableConfig
 
@@ -28,6 +34,8 @@ class ONSUKSATradeInGoodsPollingPipeline(_PandasPipelineWithPollingSupport):
         get_current_and_next_release_date,
         get_data,
     )
+
+    trigger_dags_on_success = [ONSUKSATradeInGoodsCSV]
 
     date_checker = get_current_and_next_release_date
     data_getter = get_data
@@ -59,6 +67,8 @@ class ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline(
         get_current_and_next_release_date,
         get_data,
     )
+
+    trigger_dags_on_success = [ONSUKTradeInGoodsByCountryAndCommodityCSVPipeline]
 
     date_checker = get_current_and_next_release_date
     data_getter = get_data
@@ -95,6 +105,8 @@ class ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline(
         get_data,
     )
 
+    trigger_dags_on_success = [ONSUKTradeInServicesByPartnerCountryNSACSV]
+
     schedule_interval = "0 6 20-31 1,4,7,10 *"
 
     date_checker = get_current_and_next_release_date
@@ -128,6 +140,8 @@ class ONSUKTotalTradeAllCountriesNSAPollingPipeline(_PandasPipelineWithPollingSu
         get_current_and_next_release_date,
         get_data,
     )
+
+    trigger_dags_on_success = [ONSUKTotalTradeAllCountriesNSACSVPipeline]
 
     schedule_interval = "0 6 20-31 1,4,7,10 *"
 

--- a/tests/unit/dags/test_ons_pipelines.py
+++ b/tests/unit/dags/test_ons_pipelines.py
@@ -11,25 +11,36 @@ class TestONSUKSATradeInGoodsPollingPipeline:
     def test_tasks_in_dag(self):
         dag = ONSUKSATradeInGoodsPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
+            with_emails=True, with_triggered_dags=["ONSUKSATradeInGoodsCSV"]
+        )
 
 
 class TestONSUKTradeInGoodsByCountryAndCommodity:
     def test_tasks_in_dag(self):
         dag = ONSUKTradeInGoodsByCountryAndCommodityPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
+            with_emails=True,
+            with_triggered_dags=["ONSUKTradeInGoodsByCountryAndCommodityCSVPipeline"],
+        )
 
 
 class TestONSUKTradeInServicesByPartnerCountryNSAPollingPipeline:
     def test_tasks_in_dag(self):
         dag = ONSUKTradeInServicesByPartnerCountryNSAPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
+            with_emails=True,
+            with_triggered_dags=["ONSUKTradeInServicesByPartnerCountryNSACSV"],
+        )
 
 
 class TestONSUKTotalTradeAllCountriesNSAPollingPipeline:
     def test_tasks_in_dag(self):
         dag = ONSUKTotalTradeAllCountriesNSAPollingPipeline().get_dag()
 
-        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(with_emails=True)
+        assert {t.task_id for t in dag.tasks} == get_polling_dag_tasks(
+            with_emails=True,
+            with_triggered_dags=["ONSUKTotalTradeAllCountriesNSACSVPipeline"],
+        )

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -25,7 +25,7 @@ def get_base_dag_tasks(with_modified_date_check=False, fetch_name="fetch-data"):
     return tasks
 
 
-def get_polling_dag_tasks(with_emails=False):
+def get_polling_dag_tasks(with_emails=False, with_triggered_dags=None):
     tasks = {
         "poll-for-new-data",
         "scrape-and-load-data",
@@ -37,6 +37,10 @@ def get_polling_dag_tasks(with_emails=False):
 
     if with_emails:
         tasks.add("send-dataset-updated-emails")
+
+    if with_triggered_dags:
+        for triggered_dag in with_triggered_dags:
+            tasks.add(f"trigger-{triggered_dag}")
 
     return tasks
 


### PR DESCRIPTION
### Description of change
Our ONS pipelines come in two parts - polling pipelines that update
master dataset tables, and CSV generators that use the master datasets
to write out the latest data to CSV. The CSV pipelines use the
`dependencies` attribute to set up external task sensors on the polling
pipelines checking for a successful run of the `swap-dataset-tables`
task. This task only runs when the polling pipeline detects new data is
available, otherwise after a period of polling that task (and all
others) are skipped for the day. The `dependencies` framework ignores
skipped tasks.

The problem with this is that the external task sensor, on days where
new data isn't available, ends up timing out because it doesn't find a
successful run of the `swap-dataset-tables` task. This throws errors,
which get reported in sentry. We don't want these errors, because this
is OK behaviour in this instance.

What we need is to have the CSV pipelines run when the polling pipeline
has pulled in new data, and not run/error if it doesn't.

I considered a few solutions:

1) Turn off scheduled runs of the CSV pipeline and trigger it manually
   when the polling pipeline has pulled in new data. This is sort of the
   opposite of the `dependencies` process. It also only works when there
   is a single parent pipeline, which in our current ONS example is
   true. If there were multiple parents, triggering the CSV pipeline
   manually would not be feasible.
2) Change the external task sensor to accept skipped
   `swap-dataset-tables` tasks, perhaps only for specific pipelines.
   This would then result in the CSV being generated again, redundantly,
   every day. This would also mean that the sensors are running
   throughout the day taking up a slot for limited reason.
3) Sub-class the ExternalTaskSensor in some way, for specific pipelines,
   to suppress the error that gets thrown. This would again mean the
   sensor still runs a lot, taking up a slot, but then when it dies we
   don't get noisy errors where we don't want them.

This patch goes for option 1 as a relatively simple implementation that
reduces the number of sensors running when they aren't likely to trigger.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
