### PR TITLE
feat: allow running fetch and insert in paralell

### DIFF
--- a/dataflow/dags/covid19_pipelines.py
+++ b/dataflow/dags/covid19_pipelines.py
@@ -293,7 +293,7 @@ class GoogleCovid19MobilityReports(_PipelineDAG):
     source_urls = {
         'global': 'https://www.gstatic.com/covid19/mobility/Global_Mobility_Report.csv',
     }
-
+    bulk_insert_records = True
     table_config = TableConfig(
         table_name="covid19_global_mobility_report",
         schema='google',
@@ -398,6 +398,7 @@ class AppleCovid19MobilityTrendsPipeline(_PipelineDAG):
     base_url = 'https://covid19-static.cdn-apple.com'
     config_path = '/covid19-mobility-data/current/v3/index.json'
     use_utc_now_as_source_modified = True
+    bulk_insert_records = True
     table_config = TableConfig(
         schema='apple',
         table_name='covid19_mobility_data',

--- a/dataflow/dags/hmrc_pipelines.py
+++ b/dataflow/dags/hmrc_pipelines.py
@@ -16,6 +16,7 @@ class _HMRCPipeline(_PipelineDAG):
     start_date = datetime(2020, 3, 11)
     use_utc_now_as_source_modified = True
     num_csv_fields: int
+    bulk_insert_records = True
 
     def get_fetch_operator(self) -> PythonOperator:
         return PythonOperator(

--- a/dataflow/operators/db_tables.py
+++ b/dataflow/operators/db_tables.py
@@ -1,9 +1,10 @@
 import datetime
 import os
 import warnings
+from collections import defaultdict
 from hashlib import md5
 from time import sleep
-from typing import Tuple, Dict, Optional, TYPE_CHECKING, List
+from typing import Tuple, Dict, Optional, TYPE_CHECKING, List, cast
 from urllib.parse import urlparse
 
 import psycopg3
@@ -260,12 +261,15 @@ def insert_data_into_db(
 
     count = 0
     for page, records in s3.iter_keys():
-        logger.info('Processing page %s', page)
+        logger.info('Single insert: Processing page %s', page)
         count += 1
+        start = datetime.datetime.now()
 
         with engine.begin() as conn:
+            record_count = 0
             if table_config:
                 for record in records:
+                    record_count += 1
                     for transform in table_config.transforms:
                         record = transform(record, table_config, contexts)
 
@@ -280,13 +284,18 @@ def insert_data_into_db(
                         )
 
             elif table is not None and field_mapping:
+                record_count += 1
                 for record in records:
                     conn.execute(
                         temp_table.insert(),  # pylint: disable=E1120
                         **_get_data_to_insert(field_mapping, record),
                     )
 
-        logger.info('Page %s ingested successfully', page)
+        logger.info(
+            'Single record insert: %s records inserted in %s seconds',
+            record_count,
+            (datetime.datetime.now() - start).total_seconds(),
+        )
 
     if count == 0:
         raise MissingDataError("There are no pages of records in S3 to insert.")
@@ -533,14 +542,16 @@ def poll_for_new_data(
             schema=engine.dialect.identifier_preparer.quote(table_config.schema),
             table=engine.dialect.identifier_preparer.quote(table_config.table_name),
         ).fetchall()[0][0]
-        logger.info(f"last_ingest_utc from previous run: {db_data_last_modified_utc}")
+        logger.info("last_ingest_utc from previous run: %s", db_data_last_modified_utc)
 
     (
         source_last_modified_utc,
         source_next_release_utc,
     ) = pipeline_instance.__class__.date_checker()
     logger.info(
-        f"source_last_modified_utc={source_last_modified_utc}, source_next_release_utc={source_next_release_utc}"
+        "source_last_modified_utc=%s, source_next_release_utc=%s",
+        source_last_modified_utc,
+        source_next_release_utc,
     )
 
     if (
@@ -581,7 +592,7 @@ def poll_for_new_data(
             source_next_release_utc,
         ) = pipeline_instance.__class__.date_checker()
         logger.info(
-            f"source_last_modified_utc from latest data: {source_last_modified_utc}"
+            "source_last_modified_utc from latest data: %s", source_last_modified_utc
         )
 
     logger.info("Newer data is available.")
@@ -649,3 +660,96 @@ def scrape_load_and_check_data(
                     del data_frame
 
             logger.info("Copy complete.")
+
+
+def _parse_nested_record(
+    table_config: TableConfig,
+    record: dict,
+    contexts: Tuple[Dict, ...],
+    table_data: dict = None,
+):
+    """
+    For a single record, traverse all tables in a table config and prepare associated data for insert.
+    """
+    if table_data is None:
+        table_data = defaultdict(list)
+
+    for field_map in table_config.field_mapping:
+        orig_field, new_field = field_map
+        if isinstance(new_field, TableConfig):
+            sub_records = get_nested_key(record, cast(str, orig_field)) or []
+            for sub_record in sub_records:
+                table_data = _parse_nested_record(
+                    new_field, sub_record, contexts + (record,), table_data
+                )
+
+    for transform in table_config.transforms:
+        record = transform(record, table_config, contexts)
+
+    cast(Dict, table_data)[table_config.temp_table].append(
+        _get_data_to_insert(table_config.columns, record)
+    )
+    return table_data
+
+
+def bulk_insert_data_into_db(
+    target_db: str, table_config: TableConfig, contexts: Tuple = tuple(), **kwargs,
+):
+    """
+    Insert fetched response data into temporary DB tables in bulk.
+
+    If the TableConfig contains nested tables we parse each record into a
+    <SA Table> -> [<data to insert>] dict.
+
+    Once the whole page has been parsed loop through the resulting dict and bulk
+    insert the records we have to each table.
+
+    If no related tables exist skip the table traversing stage to speed things up a bit.
+    """
+    table_config.configure(**kwargs)
+    s3 = S3Data(table_config.table_name, kwargs["ts_nodash"])
+    engine = sa.create_engine(
+        'postgresql+psycopg2://',
+        creator=PostgresHook(postgres_conn_id=target_db).get_conn,
+    )
+    has_sub_tables = bool(table_config.related_table_configs)
+    total_records_processed = 0
+
+    for page, records in s3.iter_keys():
+        logger.info('Bulk insert: Processing page %s', page)
+        start = datetime.datetime.now()
+        table_insert_map = defaultdict(list)
+        for record in records:
+            # If this pipeline contains sub tables build a dict -> data mapping for
+            # each table for this page of results
+            if has_sub_tables:
+                for table, data in _parse_nested_record(
+                    table_config, record, contexts + (record,)
+                ).items():
+                    table_insert_map[table].extend(data)
+            # If it's a single table no need to traverse the field mappings so just
+            # clean the data ready for insert
+            else:
+                for transform in table_config.transforms:
+                    record = transform(record, table_config, contexts)
+                table_insert_map[table_config.temp_table].append(
+                    _get_data_to_insert(table_config.columns, record)
+                )
+        insert_count = 0
+        for table, data in table_insert_map.items():
+            engine.execute(table.insert(), data)
+            insert_count += len(data)
+
+        total_records_processed += insert_count
+
+        logger.info(
+            'Bulk insert: %s records inserted into %s tables in %s seconds',
+            insert_count,
+            len(table_insert_map),
+            (datetime.datetime.now() - start).total_seconds(),
+        )
+
+    if total_records_processed == 0:
+        raise MissingDataError("There are no pages of records in S3 to insert.")
+
+    logger.info('Bulk insert: Finished inserting %s records', total_records_processed)

--- a/tests/unit/operators/test_db_tables.py
+++ b/tests/unit/operators/test_db_tables.py
@@ -665,3 +665,172 @@ def test_poll_scrape_and_load_data(mocker, monkeypatch):
         )
     ]
     assert mock_copy_write.call_args_list == [mock.call("1\t50\n2\t999\n")]
+
+
+@mock.patch('dataflow.operators.db_tables.sa.create_engine', autospec=True)
+def test_insert_bulk_data_into_db_single_table(mock_create_engine, s3):
+    table_config = TableConfig(
+        schema='test',
+        table_name='test_table',
+        field_mapping=[
+            ('id', sqlalchemy.Column('id', sqlalchemy.Integer)),
+            ('data', sqlalchemy.Column('data', sqlalchemy.String)),
+        ],
+    )
+    mock_engine = mock.Mock()
+    mock_create_engine.return_value = mock_engine
+
+    s3.iter_keys.return_value = [
+        ('1', [{"id": 1, "data": "sometext1"}, {"id": 2, "data": "sometext2"}]),
+        (
+            '2',
+            [
+                {
+                    "id": 3,
+                    "data": "sometext3",
+                    "sub_records": [{"name": "a record"}, {"name": "another record"}],
+                },
+                {"id": 4, "data": "sometext4"},
+            ],
+        ),
+    ]
+    table_config._temp_table = mock.Mock()
+    db_tables.bulk_insert_data_into_db(
+        "test-db", table_config, ts_nodash="123",
+    )
+    mock_engine.execute.assert_has_calls(
+        [
+            mock.call(
+                table_config.temp_table.insert(),
+                [{'id': 1, 'data': 'sometext1'}, {'id': 2, 'data': 'sometext2'}],
+            ),
+            mock.call(
+                table_config.temp_table.insert(),
+                [{'id': 3, 'data': 'sometext3'}, {'id': 4, 'data': 'sometext4'}],
+            ),
+        ]
+    )
+
+    s3.iter_keys.assert_called_once_with()
+
+
+@mock.patch('dataflow.operators.db_tables.sa.create_engine', autospec=True)
+def test_insert_bulk_data_into_db_nested_tables(mock_create_engine, s3):
+    sub_table_2_config = TableConfig(
+        schema='test',
+        table_name='subtable2',
+        transforms=[
+            lambda record, table_config, contexts: {
+                **record,
+                'parent_id': contexts[-1]['id'],
+            }
+        ],
+        field_mapping=[
+            ('parent_id', sqlalchemy.Column('parent_id', sqlalchemy.Integer)),
+            ('id', sqlalchemy.Column('id', sqlalchemy.Integer)),
+            ('name', sqlalchemy.Column('name', sqlalchemy.String)),
+        ],
+    )
+    sub_table_1_config = TableConfig(
+        schema='test',
+        table_name='subtable1',
+        transforms=[
+            lambda record, table_config, contexts: {
+                **record,
+                'parent_id': contexts[0]['id'],
+            }
+        ],
+        field_mapping=[
+            ('parent_id', sqlalchemy.Column('parent_id', sqlalchemy.Integer)),
+            ('id', sqlalchemy.Column('id', sqlalchemy.Integer)),
+            ('name', sqlalchemy.Column('name', sqlalchemy.String)),
+            ('sub_records', sub_table_2_config),
+        ],
+    )
+    main_table_config = TableConfig(
+        schema='test',
+        table_name='test_table',
+        field_mapping=[
+            ('id', sqlalchemy.Column('id', sqlalchemy.Integer)),
+            ('name', sqlalchemy.Column('name', sqlalchemy.String)),
+            ('sub_records', sub_table_1_config),
+        ],
+    )
+    mock_engine = mock.Mock()
+    mock_create_engine.return_value = mock_engine
+
+    s3.iter_keys.return_value = [
+        (
+            '1',
+            [
+                {'id': 1, 'name': 'parent record 1'},
+                {'id': 2, 'name': 'parent record 2'},
+            ],
+        ),
+        (
+            '2',
+            [
+                {
+                    'id': 3,
+                    'name': 'parent record 3',
+                    'sub_records': [
+                        {
+                            'id': 4,
+                            'name': 'sub record 1',
+                            'sub_records': [
+                                {'id': 5, 'name': 'sub-sub record 1'},
+                                {'id': 6, 'name': 'sub-sub record 2'},
+                            ],
+                        },
+                        {
+                            'id': 7,
+                            'name': 'sub record 2',
+                            'sub_records': [{'id': 8, 'name': 'sub-sub record 3'}],
+                        },
+                    ],
+                },
+                {'id': 9, 'name': 'parent record 4'},
+            ],
+        ),
+    ]
+    main_table_config._temp_table = mock.Mock()
+    sub_table_1_config._temp_table = mock.Mock()
+    sub_table_2_config._temp_table = mock.Mock()
+    db_tables.bulk_insert_data_into_db(
+        "test-db", main_table_config, ts_nodash="123",
+    )
+    mock_engine.execute.assert_has_calls(
+        [
+            mock.call(
+                main_table_config.temp_table.insert(),
+                [
+                    {'id': 1, 'name': 'parent record 1'},
+                    {'id': 2, 'name': 'parent record 2'},
+                ],
+            ),
+            mock.call(
+                sub_table_2_config.temp_table.insert(),
+                [
+                    {'parent_id': 4, 'id': 5, 'name': 'sub-sub record 1'},
+                    {'parent_id': 4, 'id': 6, 'name': 'sub-sub record 2'},
+                    {'parent_id': 7, 'id': 8, 'name': 'sub-sub record 3'},
+                ],
+            ),
+            mock.call(
+                sub_table_1_config.temp_table.insert(),
+                [
+                    {'parent_id': 3, 'id': 4, 'name': 'sub record 1'},
+                    {'parent_id': 3, 'id': 7, 'name': 'sub record 2'},
+                ],
+            ),
+            mock.call(
+                main_table_config.temp_table.insert(),
+                [
+                    {'id': 3, 'name': 'parent record 3'},
+                    {'id': 9, 'name': 'parent record 4'},
+                ],
+            ),
+        ]
+    )
+
+    s3.iter_keys.assert_called_once_with()


### PR DESCRIPTION
### Description of change

Run fetch and insert tasks in parallel

- Configurable with `parallel_insert` flag on dag - off by default
- Only works in conjunction with `bulk_insert_records` currently - but can be made to work with single row inserts
- Insert task will now poll s3 waiting for files to be written by the fetch task.
  - If the fetch task fails the insert task will fail and the temp table will be dropped.
  - Insert task completes when fetch has completed successfully and there are no more unprocessed files in s3.

**Note** this is currently not enabled for any existing pipelines. I'm hesitant to change existing dags as it could mess up the graph views if we ever want to revert back (it has in my testing anyway). So for now it would be good to test this on some new datasets with a view to migrating over slowly in the future.

### Checklist

* [x ] Have tests been added to cover any changes?
* [ ] ~~Has the README been updated (if needed)?~~
