### PR TITLE
tests: refactor integration tests to avoid mocking + delete test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -20,4 +20,7 @@ AIRFLOW__API__AUTH_BACKEND=dataflow.api_auth_backend
 NOTIFY_API_KEY=test
 NOTIFY_TEMPLATE_ID__DATASET_UPDATED=get-from-notify
 
-UPDATE_EMAILS_DATA__ONSUKSATradeInGoodsPollingPipeline={"dataset_name": "My nice dataset", "dataset_url": "https://data.tr    ade.gov.uk/dataset-1", "emails": []}
+UPDATE_EMAILS_DATA__ONSUKSATradeInGoodsPollingPipeline={"dataset_name": "My nice dataset", "dataset_url": "https://data.trade.gov.uk/dataset-1", "emails": []}
+
+DATA_STORE_UPLOADER_SENDER_HAWK_ID=dataflowapi
+DATA_STORE_UPLOADER_SENDER_HAWK_KEY=some-key

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-build:
 
 .PHONY: test-integration
 test-integration: docker-build
-	docker-compose -f docker-compose-test.yml -p data-flow-test run --rm data-flow-test dockerize -wait tcp://data-flow-db-test:5432 && airflow initdb && pytest tests/integration
+	docker-compose -f docker-compose-test.yml -p data-flow-test run --rm data-flow-test
 
 .PHONY: save-requirements
 save-requirements:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -9,6 +9,16 @@ services:
     env_file: .env.test
     links:
       - "data-flow-db-test"
+    command:
+      - /bin/bash
+      - -c
+      - |
+          dockerize -wait tcp://data-flow-db-test:5432
+          airflow initdb
+          alembic upgrade head
+          airflow webserver --pid /tmp/airflow-webserver.pid -p 8080 &
+          dockerize -wait tcp://localhost:8080
+          pytest tests/integration
 
   data-flow-db-test:
     build:
@@ -20,4 +30,3 @@ services:
       POSTGRES_HOST_AUTH_METHOD: "trust"
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"
-

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,47 +1,21 @@
-import os
-
 import mohawk
 import pytest
-from airflow.www.app import create_app
-
-from dataflow import api_auth_backend
+import requests
 
 
 @pytest.mark.parametrize(
-    'auth_backend, expected_status',
-    (
-        ('airflow.api.auth.backend.default', 200),
-        ('airflow.api.auth.backend.deny_all', 403),
-        ('dataflow.api_auth_backend', 401),
-    ),
-)
-def test_no_hawk_auth(auth_backend, expected_status):
-    os.environ['AIRFLOW__API__AUTH_BACKEND'] = auth_backend
-    app = create_app(testing=True)
-    with app.test_client() as client:
-        response = client.get('/api/experimental/test')
-        assert response.status_code == expected_status
-
-
-@pytest.mark.parametrize(
-    'key, expected_status', (('validkey', 200), ('invalidkey', 401),),
+    'key, expected_status', (('some-key', 200), ('invalidkey', 401),),
 )
 def test_hawk_auth(key, expected_status, mocker):
-    os.environ['AIRFLOW__API__AUTH_BACKEND'] = 'dataflow.api_auth_backend'
-    url = 'http://0.0.0.0:8000/api/experimental/test'
-    mocker.patch.object(
-        api_auth_backend.config, 'AIRFLOW_API_HAWK_CREDENTIALS', {'hawkid': 'validkey'},
+    url = 'http://localhost:8080/api/experimental/test'
+    sender = mohawk.Sender(
+        credentials={'id': 'dataflowapi', 'key': key, 'algorithm': 'sha256'},
+        url=url,
+        method='GET',
+        content='',
+        content_type='',
     )
-    app = create_app(testing=True)
-    with app.test_client() as client:
-        sender = mohawk.Sender(
-            credentials={'id': 'hawkid', 'key': key, 'algorithm': 'sha256'},
-            url=url,
-            method='GET',
-            content='',
-            content_type='',
-        )
-        response = client.get(
-            url, headers={'Authorization': sender.request_header, 'Content-Type': ''}
-        )
-        assert response.status_code == expected_status
+    response = requests.get(
+        url, headers={'Authorization': sender.request_header, 'Content-Type': ''}
+    )
+    assert response.status_code == expected_status


### PR DESCRIPTION
### Description of change

Although it might have been me to push for the test that asserts that AIRFLOW__API__AUTH_BACKEND is respected, I think the test that gives a 401 if the credentials are wrong is enough

This is done as a precursor to integration tests for publishing the UK tariff

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the README been updated (if needed)?
